### PR TITLE
Back to non-ssl

### DIFF
--- a/client/components/more-on/market-data.js
+++ b/client/components/more-on/market-data.js
@@ -10,7 +10,7 @@ module.exports = function () {
 	var stockPromises = $('.js-markets-data').map(function (el) {
 		var tickerSymbol = el.getAttribute('data-ticker-symbol');
 
-		return fetch('https://ft-next-markets-proxy.global.ssl.fastly.net/securities/v1/quotes?symbols=' + tickerSymbol)
+		return fetch('http://next-markets-proxy.ft.com.global.prod.fastly.net/securities/v1/quotes?symbols=' + tickerSymbol)
 			.then(fetchres.json)
 			.then(function (response) {
 				var data = response.data.items[0];

--- a/client/components/video/brightcove.js
+++ b/client/components/video/brightcove.js
@@ -43,7 +43,7 @@ function brightcove(url) {
 	}
 	var videoId = videoIdMatch[1];
 
-	return fetch('https://ft-next-brightcove-proxy.global.ssl.fastly.net/' + videoId)
+	return fetch('http://next-brightcove-proxy.ft.com.global.prod.fastly.net/' + videoId)
 		.then(function(response) {
 			if (response.status === 404) {
 				throw new Error('Video ' + videoId + ' not found or not available in compatible format');


### PR DESCRIPTION
IE9 can't handle x-domain requests to a different protocol, e.g. http->https

As we are still serving the site non-securely, doesn't add any extra risk to point these back to http

@richard-still-ft 