### PR TITLE
preventing access middleware from forwarding errors to article controller

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,7 @@
     "o-ft-icons": "next",
     "o-fonts": "^2.0.0",
     "next-sass-setup": "^6.0.0",
-    "o-colors": "^3.0.0"
+    "o-colors": "^3.0.0",
+    "next-buttons": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "array.prototype.find": "^1.0.0",
     "cheerio": "^0.18.0",
     "denodeify": "^1.2.1",
+    "express-errors-handler": "^1.2.5",
     "fetchres": "^1.0.4",
     "forever": "^0.11.1",
     "ft-next-article-primary-tag": "^1.0.0",

--- a/server/app.js
+++ b/server/app.js
@@ -2,7 +2,7 @@
 
 var express = require('ft-next-express');
 var app = module.exports = express();
-var access = require('./controllers/access');
+var access = require('./utils/access');
 var logger = require('ft-next-logger');
 
 var articleUuidRegex = '[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}';

--- a/server/utils/access.js
+++ b/server/utils/access.js
@@ -2,6 +2,7 @@
 
 var api = require('next-ft-api-client');
 var fetchres = require('fetchres');
+var errorsHandler = require('express-errors-handler');
 
 module.exports = function(req, res, next) {
 	if (req.get('X-FT-Access-Metadata') === 'remote_headers') {
@@ -13,7 +14,7 @@ module.exports = function(req, res, next) {
 				if (err instanceof fetchres.BadServerResponseError) {
 					return;
 				} else {
-					next(err);
+					errorsHandler.middleware(err);
 				}
 			})
 			.then(function(article) {
@@ -23,7 +24,6 @@ module.exports = function(req, res, next) {
 				if (article) {
 					results = /cms\/s\/([0-3])\//i.exec(article.item.location.uri);
 				}
-
 				// “if the match fails, the exec() method returns null” — MDN
 				// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec
 				// We often don't get matches for, say, blog articles.
@@ -46,7 +46,8 @@ module.exports = function(req, res, next) {
 				res.set('X-FT-UID', req.params.id);
 				res.set('X-FT-Content-Classification', classification);
 				res.status(200).end();
-			}).catch(next);
+			})
+			.catch(errorsHandler.middleware);
 	} else {
 		next();
 	}


### PR DESCRIPTION
@aintgoin2goa @adamsilver @matthew-andrews 

I'm not 100% sure this is right and would ideally like some insight on how to recreate the bug, but I think the reason headers are being set twice is because 'next' in this context is cache control 

see bug https://app.getsentry.com/nextftcom/ft-next-article/group/66204307/