### PR TITLE
Use unique syncids per slideshow in an article to support multiple slideshows

### DIFF
--- a/client/components/slideshow/main.js
+++ b/client/components/slideshow/main.js
@@ -7,8 +7,9 @@ var beacon = require('next-beacon-component');
 module.exports = function(els) {
 	[].slice.call(els).forEach(function(el) {
 		var uuid = el.getAttribute('data-uuid');
+		var syncid = el.getAttribute('data-syncid');
 		if (uuid) {
-			fetch('/embedded-components/slideshow/' + uuid, { credentials: 'same-origin' })
+			fetch('/embedded-components/slideshow/' + uuid + '?syncid=' + syncid, { credentials: 'same-origin' })
 				.then(fetchres.text)
 				.then(function(data) {
 					var container = document.createElement('div');

--- a/server/controllers/slideshow.js
+++ b/server/controllers/slideshow.js
@@ -12,15 +12,11 @@ module.exports = function(req, res, next) {
 	})
 		.then(function(data) {
 			if (data.item && data.item && data.item.assets && data.item.assets[0] && data.item.assets[0].type === 'slideshow') {
-
-				// When in INT the URLs to images don't work.  Hack for now.
-				data.item.assets[0].fields.slides = data.item.assets[0].fields.slides.map(function(slide) {
-					return slide;
+				res.render('slideshow', {
+					title: data.item.assets[0].fields.title,
+					syncid: req.query.syncid,
+					slides: data.item.assets[0].fields.slides
 				});
-
-				// HACK - Disable the layout on slideshows
-				data.item.assets[0].fields.layout = false;
-				res.render('slideshow', data.item.assets[0].fields);
 			} else {
 				res.status(404).end();
 			}

--- a/server/transforms/slideshow.js
+++ b/server/transforms/slideshow.js
@@ -10,7 +10,7 @@ module.exports = function(index, el) {
 	}
 
 	var uuid = $el.attr('href').replace(/.*([a-zA-Z0-9-]{36}).*/, '$1');
-	var slideshow = '<ft-slideshow data-uuid="' + uuid + '"></ft-slideshow>';
+	var slideshow = '<ft-slideshow data-uuid="' + uuid + '" data-syncid="' + (index + 1) + '"></ft-slideshow>';
 
 	// NOTE - can be removed once the slideshow is moved out of p's upstream
 	if ($el.parent('p').length) {

--- a/tests/server/transforms/slideshow.test.js
+++ b/tests/server/transforms/slideshow.test.js
@@ -9,13 +9,13 @@ describe('Slideshow', function () {
 	it('should understand slideshows', function() {
 		var $ = cheerio.load('<a href="http://www.ft.com/cms/s/0/f3970f88-0475-11df-8603-00144feabdc0.html#slide0"></a>');
 		$('a[href$="#slide0"]').replaceWith(slideshowTransform);
-		expect($.html()).to.equal('<ft-slideshow data-uuid="f3970f88-0475-11df-8603-00144feabdc0"></ft-slideshow>');
+		expect($.html()).to.equal('<ft-slideshow data-uuid="f3970f88-0475-11df-8603-00144feabdc0" data-syncid="1"></ft-slideshow>');
 	});
 
 	it('should move the slideshow before the parent `p`', function () {
 		var $ = cheerio.load('<p><a href="http://www.ft.com/cms/s/0/f3970f88-0475-11df-8603-00144feabdc0.html#slide0"></a>A gallery</p>');
 		$('a[href$="#slide0"]').replaceWith(slideshowTransform);
-		expect($.html()).to.equal('<ft-slideshow data-uuid="f3970f88-0475-11df-8603-00144feabdc0"></ft-slideshow><p>A gallery</p>');
+		expect($.html()).to.equal('<ft-slideshow data-uuid="f3970f88-0475-11df-8603-00144feabdc0" data-syncid="1"></ft-slideshow><p>A gallery</p>');
 	});
 
 	it('should only promote links to slideshows to embeds if <a> inner text not empty', function() {

--- a/views/slideshow.html
+++ b/views/slideshow.html
@@ -1,5 +1,7 @@
-<div class="o-gallery o-gallery--slideshow" data-o-component="o-gallery" data-o-gallery-syncid="declarative-slideshow-with-thumbnails" data-o-gallery-captionminheight="30" data-o-gallery-captionmaxheight="50">
+<div class="o-gallery o-gallery--slideshow" data-o-component="o-gallery" data-o-gallery-syncid="{{syncid}}" data-o-gallery-captionminheight="30" data-o-gallery-captionmaxheight="50">
+	{{#if title}}
 	<h1 class="o-gallery__title">{{title}}</h1>
+	{{/if}}
 	<ol class="o-gallery__items">
 		{{#each slides}}
 		<li class="o-gallery__item"{{#if @first}} aria-selected="true"{{/if}}>
@@ -9,7 +11,7 @@
 		{{/each}}
 	</ol>
 </div>
-<div class="o-gallery o-gallery--thumbnails" data-o-component="o-gallery" data-o-gallery-syncid="declarative-slideshow-with-thumbnails" data-o-gallery-multipleitemsperpage="true">
+<div class="o-gallery o-gallery--thumbnails" data-o-component="o-gallery" data-o-gallery-syncid="{{syncid}}" data-o-gallery-multipleitemsperpage="true">
 	<ol class="o-gallery__items">
 		{{#each slides}}
 		<li class="o-gallery__item"{{#if @first}} aria-selected="true"{{/if}}>


### PR DESCRIPTION
should make @musthemag happy

http://next.ft.com/7316cacc-07d2-11e5-a58f-00144feabdc0

{right now when you go forward on one slideshow all others on the same page progress}