### PR TITLE
avoid faux-bold in body text

### DIFF
--- a/client/components/article/_main.scss
+++ b/client/components/article/_main.scss
@@ -207,14 +207,12 @@ $header-offset: 30px;
 
 //ARTICLE BODY ELEMENTS
 .article__body {
-	font-weight: normal;
-	font-size: 18px;
+	@include nTypeAlpha(4);
 	color: $next-grey-dark;
 	margin-bottom: 20px;
 
 	@include oGridRespondTo(S) {
-		font-size: 20px;
-		font-weight: 200;
+		@include nTypeAlpha(3);
 	}
 	> p {
 		margin: 0.3em 0 0.8em;
@@ -228,6 +226,14 @@ $header-offset: 30px;
 	> *:first-child {
 		margin-top: 0;
 	}
+
+	strong {
+		@include nTypeBeta(4);
+		@include oGridRespondTo(S) {
+			@include nTypeBeta(3);
+		}
+	}
+
 	a {
 		color: $next-grey-dark;
 


### PR DESCRIPTION
# old

bold text was looking all muddy-teal-rahnd-the-edges

![image](https://cloud.githubusercontent.com/assets/447559/7983566/942a27f6-0ab9-11e5-985b-ca6b18e25785.png)

![image](https://cloud.githubusercontent.com/assets/447559/7983663/853d5e7e-0aba-11e5-93d8-a0e4dffce4ec.png)

# new

cleaner, but does next-type need an intermediate size between 3 and 4? Looks too small on mobile?

![image](https://cloud.githubusercontent.com/assets/447559/7983633/469866fa-0aba-11e5-9240-0b2b49f4ff67.png)

![image](https://cloud.githubusercontent.com/assets/447559/7983655/74d6da38-0aba-11e5-8941-56df9e1d0baf.png)

@keirog @tom-parker @simonwilliamsFT 