### PR TITLE
No border on inline story package links

### DIFF
--- a/client/components/_story-package.scss
+++ b/client/components/_story-package.scss
@@ -65,6 +65,7 @@
 	.story-package__article__link {
 		display: block;
 		color: inherit;
+		border: 0;
 	}
 }
 


### PR DESCRIPTION
e.g.

![screen shot 2015-06-22 at 15 19 20](https://cloud.githubusercontent.com/assets/74132/8283941/13ec509a-18f2-11e5-8437-055875799fc0.jpeg)
