### PR TITLE
Differentiate between standard subheaders and crossheads

### DIFF
--- a/client/components/article/_main.scss
+++ b/client/components/article/_main.scss
@@ -333,10 +333,16 @@ $header-offset: 30px;
 	}
 }
 .article__subhead {
-	padding-right: 40px;
-	position: relative;
-	border-bottom: 1px solid black;
+	@include nTypeBeta(2);
 	clear: left;
+	margin-top: 50px;
+	margin-bottom: 20px;
+}
+.article__subhead--crosshead {
+	border-bottom: 1px solid black;
+}
+.article__subhead--standard {
+	@include nTypeBeta(3);
 }
 .article__pull-quote,
 .article__block-quote,

--- a/server/controllers/article.js
+++ b/server/controllers/article.js
@@ -46,7 +46,7 @@ module.exports = function(req, res, next) {
 			var article = articles[1];
 
 			var $ = bodyTransform(article.bodyXML, res.locals.flags);
-			var $subheaders = $('.article__subhead');
+			var $crossheads = $('.article__subhead--crosshead');
 			var primaryTag = articleV1 && articleV1.item && articleV1.item.metadata ? articlePrimaryTag(articleV1.item.metadata) : undefined;
 			if (primaryTag) {
 				primaryTag.conceptId = res.locals.flags.userPrefsUseConceptId ? primaryTag.id : (primaryTag.taxonomy + ':"' + encodeURIComponent(primaryTag.name) + '"');
@@ -71,14 +71,14 @@ module.exports = function(req, res, next) {
 						byline: bylineTransform(article.byline, articleV1),
 						tags: extractTags(article, articleV1, res.locals.flags),
 						body: $.html(),
-						subheaders: $subheaders.map(function() {
-							var $subhead = $(this);
+						crossheads: $crossheads.map(function() {
+							var $crosshead = $(this);
 							return {
-								text: $subhead.find('.article__subhead__title').text(),
-								id: $subhead.attr('id')
+								text: $crosshead.text(),
+								id: $crosshead.attr('id')
 							};
 						}).get(),
-						tableOfContents: res.locals.flags.articleTOC && $subheaders.length > 2,
+						tableOfContents: res.locals.flags.articleTOC && $crossheads.length > 2,
 						isColumnist: isColumnist,
 						// if there's a main image, or slideshow or video, we overlap them on the header
 						headerOverlap:

--- a/server/transforms/subheaders.js
+++ b/server/transforms/subheaders.js
@@ -18,11 +18,8 @@ module.exports = function ($, flags) {
 		});
 	} else {
 		$('.ft-subhead')
-			.attr('id', function(index) {
-				return 'crosshead-' + (index + 1);
-			})
 			.replaceWith(function(index, subhead) {
-				return '<h2 class="article__subhead article__subhead--crosshead ng-pull-out ">' +
+				return '<h2 class="article__subhead article__subhead--crosshead ng-pull-out" id="crosshead-' + (index + 1) + '">' +
 					cheerio(subhead).text() +
 				'</h2>';
 			});

--- a/server/transforms/subheaders.js
+++ b/server/transforms/subheaders.js
@@ -2,19 +2,31 @@
 
 var cheerio = require('cheerio');
 
-module.exports = function ($) {
-	$('.ft-subhead')
-		.attr('id', function(index) {
-			return 'subhead-' + (index + 1);
-		})
-		.replaceWith(function(index, el) {
-			var $el = cheerio(el);
-
-			$el.addClass('article__subhead ng-pull-out')
-				.html('<span class="article__subhead__title">' + $el.text() + '</span>');
-
-			return $el.clone();
+module.exports = function ($, flags) {
+	if (flags.articleCrossheads) {
+		$('.ft-subhead').each(function (index, subhead) {
+			var $subhead = cheerio(subhead);
+			var $newSubhead = cheerio('<h2 class="article__subhead">' + $subhead.text() + '</h2');
+			var childEl = $subhead.children().get(0);
+			if (childEl && childEl.tagName === 'strong') {
+				$newSubhead.attr('id', 'crosshead-' + (index + 1));
+				$newSubhead.addClass('article__subhead--crosshead ng-pull-out');
+			} else {
+				$newSubhead.addClass('article__subhead--standard');
+			}
+			$subhead.replaceWith($newSubhead);
 		});
+	} else {
+		$('.ft-subhead')
+			.attr('id', function(index) {
+				return 'crosshead-' + (index + 1);
+			})
+			.replaceWith(function(index, subhead) {
+				return '<h2 class="article__subhead article__subhead--crosshead ng-pull-out ">' +
+					cheerio(subhead).text() +
+				'</h2>';
+			});
+	}
 
 	return $;
 };

--- a/test/server/transforms/subheaders.test.js
+++ b/test/server/transforms/subheaders.test.js
@@ -9,12 +9,34 @@ describe('Subheaders', function () {
 
 	it('should update subheaders', function() {
 		var $ = cheerio.load('<h3 class="ft-subhead">The new big earners</h3>');
-		$ - subheadersTransform($);
+		$ - subheadersTransform($, {});
 
 		expect($.html()).to.equal(
-			'<h3 class="ft-subhead article__subhead ng-pull-out" id="subhead-1">' +
-				'<span class="article__subhead__title">The new big earners</span>' +
-			'</h3>'
+			'<h2 class="article__subhead article__subhead--crosshead ng-pull-out" id="crosshead-1">' +
+				'The new big earners' +
+			'</h2>'
+		);
+	});
+
+	it('should create subheaders (if flag is on)', function() {
+		var $ = cheerio.load('<h3 class="ft-subhead">The new big earners</h3>');
+		$ - subheadersTransform($, { articleCrossheads: true });
+
+		expect($.html()).to.equal(
+			'<h2 class="article__subhead article__subhead--standard">' +
+				'The new big earners' +
+			'</h2>'
+		);
+	});
+
+	it('should create crossheads (if flag is on)', function() {
+		var $ = cheerio.load('<h3 class="ft-subhead"><strong>The new big earners</strong></h3>');
+		$ - subheadersTransform($, { articleCrossheads: true });
+
+		expect($.html()).to.equal(
+			'<h2 class="article__subhead article__subhead--crosshead ng-pull-out" id="crosshead-1">' +
+				'The new big earners' +
+			'</h2>'
 		);
 	});
 

--- a/views/article-v2.html
+++ b/views/article-v2.html
@@ -18,7 +18,7 @@
 						<div class="toc">
 							<div class="toc__title">Article quick links:</div>
 							<ul class="toc__list">
-							{{#each subheaders}}
+							{{#each crossheads}}
 								<li class="toc__item"><a class="toc__link" data-trackable="toc" href="#{{id}}">{{text}}</a></li>
 							{{/each}}
 							</ul>


### PR DESCRIPTION
If a `ft-subhead` has a nested `strong`, assumes it's a crosshead, otherwise standard subheader. Only crossheads are used for the TOC

Currently behind a (off) switch

### Crosshead

![screen shot 2015-06-25 at 14 12 36](https://cloud.githubusercontent.com/assets/74132/8354995/608ac9e6-1b44-11e5-8f38-223101eb3c30.jpeg)

### Subheader

![screen shot 2015-06-25 at 14 13 32](https://cloud.githubusercontent.com/assets/74132/8354998/65168c20-1b44-11e5-8b3f-94eecb7a858b.jpeg)
