### PR TITLE
story package timestamp para spacing fix

### DIFF
--- a/client/components/_story-package.scss
+++ b/client/components/_story-package.scss
@@ -37,9 +37,6 @@
 	}
 	&:first-child {
 		margin-top: 0;
-		.story-package__article__timestamp {
-			float: left;
-		}
 		.story-package__article__link {
 			clear: left;
 		}
@@ -81,6 +78,6 @@
 	margin-top: 5px;
 	color: oColorsGetPaletteColor('cold-1');
 	display: block;
-	margin: 10px 0;
+	margin: 8px 0;
 	text-transform: uppercase;
 }


### PR DESCRIPTION
Fixed issue documented here https://github.com/Financial-Times/next-article/issues/510

@matthew-andrews - this is a fix to an issue you raised - played around with squashing previous branch commit history, but was still messy, so started from scratch as it was a 2 line fix. Will close previous pr on this.

Fixed in CSS;
- removing float: left from timestamp to get timestamp within overall container
- reducing timestamp top/bottom margins from 10px to 8px to ensure box is same height as image (56px) when story headline on single line

Before
![screen shot 2015-06-26 at 11 45 44](https://cloud.githubusercontent.com/assets/8938227/8379735/dc8416f8-1c19-11e5-8d17-3bdc211640f2.png)

After
![screen shot 2015-06-26 at 11 46 07](https://cloud.githubusercontent.com/assets/8938227/8379744/e512d246-1c19-11e5-972a-92da99be6052.png)
