### PR TITLE
Fix combo components

### DIFF
--- a/server/transforms/big-number-follows-image.js
+++ b/server/transforms/big-number-follows-image.js
@@ -19,13 +19,12 @@ module.exports = function($, flags) {
 			if (!$p.get(0) || $p.get(0).tagName !== 'p' || $pChildren.length !== 1 || $image.length !==1) {
 				return;
 			}
-			var imageHtml = $.html($image);
 			$image.remove();
 			var title = $el.find('big-number-headline').html();
 			var content = $el.find('big-number-intro').html();
 			$el.replaceWith(
 				'<div class="article__combo article__combo--big-number">' +
-					imageHtml +
+					'<ft-content type="' + $image.attr('type') + '" url="' + $image.attr('url') + '"></ft-content>' +
 					'<span class="article__combo__big-number">' +
 						'<span class="o-big-number__title">' +
 							title +

--- a/server/transforms/double-images.js
+++ b/server/transforms/double-images.js
@@ -17,12 +17,11 @@ module.exports = function($, flags) {
 			if (!$elPrev.is('ft-content[type$="ImageSet"]')) {
 				return;
 			}
-			var elPrevHtml = $.html($elPrev);
 			$elPrev.remove();
 			$image.replaceWith(
 				'<div class="article__combo article__combo--double-image">' +
-					elPrevHtml +
-					$.html(image) +
+					'<ft-content type="' + $elPrev.attr('type') + '" url="' + $elPrev.attr('url') + '"></ft-content>' +
+					'<ft-content type="' + $image.attr('type') + '" url="' + $image.attr('url') + '"></ft-content>' +
 				'</div>'
 			);
 		});

--- a/server/transforms/pull-quotes-follows-image.js
+++ b/server/transforms/pull-quotes-follows-image.js
@@ -19,13 +19,12 @@ module.exports = function($, flags) {
 			if (!$p.get(0) || $p.get(0).tagName !== 'p' || $pChildren.length !== 1 || $image.length !==1) {
 				return;
 			}
-			var imageHtml = $.html($image);
 			$image.remove();
 			var text = $el.find('pull-quote-text').text();
 			var cite = $el.find('pull-quote-source').text();
 			$el.replaceWith(
 				'<div class="article__combo article__combo--pull-quote">' +
-					imageHtml +
+					'<ft-content type="' + $image.attr('type') + '" url="' + $image.attr('url') + '"></ft-content>' +
 					'<blockquote class="article__combo__pull-quote">' +
 						'<p>' + text + '</p>' +
 						(cite ? '<cite>' + cite + '</cite>' : '') +


### PR DESCRIPTION
We are now ingesting capi's `bodyXML` into `cheerio` as xml, which means weird things can happen, e.g. if you try and get an element's html (which will be returned as xml) and then re-inject it (as html), things might explode
