### PR TITLE
Use next-type's default line-height

### DIFF
--- a/client/components/article/_main.scss
+++ b/client/components/article/_main.scss
@@ -223,10 +223,6 @@ $header-offset: 30px;
 	> p {
 		margin: 0.3em 0 0.8em;
 		display: block;
-
-		@include oGridRespondTo(S) {
-			line-height: 26px;
-		}
 	}
 	> *:first-child {
 		margin-top: 0;


### PR DESCRIPTION
([next-type](https://github.com/Financial-Times/next-type)'s alpha 3 line-height was recently bumped up to 24px)