### PR TITLE
Add mechanism to test typography variants with customers

### DIFF
--- a/client/components/typography-switcher/main.js
+++ b/client/components/typography-switcher/main.js
@@ -1,0 +1,50 @@
+'use strict';
+
+var Superstore = require('superstore');
+var store = new Superstore('ft');
+var storeKey = 'typog-switcher';
+var variantPattern = new RegExp(storeKey + ':(variant-[0-9])');
+
+function isValidVariant(variant) {
+	return variantPattern.test(storeKey + ':' + variant);
+}
+
+function addVariantClassName(variant) {
+	document.body.classList.add('typog-variant', 'typog-variant--' + variant);
+}
+
+function removeVariantClassNames() {
+	document.body.className = document.body.className.replace(/typog-variant--variant-[0-9]/g, '');
+}
+
+function bindEvents() {
+	window.addEventListener('hashchange', updateVariantState, false);
+}
+
+function updateVariantState() {
+	var hashMatch = document.location.hash.match(variantPattern);
+	var requestedVariant = hashMatch && hashMatch[1];
+
+	if (requestedVariant) {
+	// Variant requested via URL
+		removeVariantClassNames();
+		addVariantClassName(requestedVariant);
+		store.set(storeKey, requestedVariant);
+	} else {
+	// Check for saved variant
+		store.get(storeKey, function (err, savedVariant) {
+			// So we don't blindly append to body's className
+			if (isValidVariant(savedVariant)) {
+				addVariantClassName(savedVariant);
+			}
+		});
+	}
+}
+
+module.exports.init = function(flags) {
+	if (!flags.get('typographySwitcher')) {
+		return;
+	}
+	updateVariantState();
+	bindEvents();
+};

--- a/client/components/typography-switcher/main.scss
+++ b/client/components/typography-switcher/main.scss
@@ -1,0 +1,11 @@
+.typog-variant {
+	&--variant-1 {
+		background: red !important;
+	}
+	&--variant-2 {
+		background: green !important;
+	}
+	&--variant-3 {
+		background: blue !important;
+	}
+}

--- a/client/main.js
+++ b/client/main.js
@@ -15,6 +15,7 @@ var toc = require('./components/toc/main');
 var comments = require('./components/comments/main');
 var readingList = require('./components/reading-list/main');
 var scrollDepth = require('./components/article/scroll-depth');
+var typogSwitcher = require('./components/typography-switcher/main');
 
 oViewport.listenTo('resize');
 
@@ -56,4 +57,5 @@ setup.bootstrap(function(result) {
 	oDate.init(document.querySelector('.article'));
 	scrollDepth.init(flags);
 	nAds.init(flags);
+	typogSwitcher.init(flags);
 });

--- a/client/main.scss
+++ b/client/main.scss
@@ -44,3 +44,4 @@ $o-comments-is-silent: false;
 @import "components/comments/main";
 @import "components/first-click-free/main";
 @import "components/reading-list/main";
+@import "components/typography-switcher/main";

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "ft-poller": "0.0.4",
     "lodash": "^3.6.0",
     "merge": "^1.2.0",
-    "next-ft-api-client": "^3.0.0"
+    "next-ft-api-client": "^3.0.0",
+    "superstore": "^1.0.0"
   },
   "devDependencies": {
     "chai": "^2.0.0",


### PR DESCRIPTION
Provides a way for us to show different typography variants to customers.

The (hacky and inelegant) mechanism works via hash in the URL:
http://next.ft.com/[article-id]#typog-switcher:variant-[0-9]
This'll add a class to the body, to give a hook for varying CSS styles.
The variant is saved in localStorage to persist the styling for the customer.

Note: Only runs if the typographySwitcher flag is switched on, and obviously only works for enhanced-experience users.