### PR TITLE
Generate open graph data for each article

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,3 @@ make run
 ## CAPI V1 vs. V2
 
 We aim to remove our dependency on the old Content API (v1) by the end of June.  Please don't create features that depend on features in V1 that have not been scheduled for V2.  [Please see the Content Programme roadmap for more details](https://docs.google.com/a/ft.com/presentation/d/1e711m8jZaBQ_CzLxhS7_1B3o015yVEmCiAni95zAPOg/edit#slide=id.p).  When using any feature from V1 please add a `TODO` for its replacement.
-

--- a/server/controllers/article.js
+++ b/server/controllers/article.js
@@ -41,15 +41,11 @@ module.exports = function(req, res, next) {
 		useElasticSearch: res.locals.flags.elasticSearchItemGet
 	});
 
-	var mainImage = function (articleV2) {
+	var openGraphImage = function (articleV2) {
 		
-		if (!articleV2.mainImage) {
+		if (!articleV2.mainImage || !res.locals.flags.openGraph) {
 			return Promise.resolve();
 		}
-		
-		if (!res.locals.flags.openGraph) {
-			return Promise.resolve();
-		} 
 
 		return api.content({ uuid: extractUuid(articleV2.mainImage.id), type: 'ImageSet' })
 			.then(function (images) {
@@ -72,7 +68,7 @@ module.exports = function(req, res, next) {
 						useBrightcovePlayer: res.locals.flags.brightcovePlayer ? 1 : 0
 					}
 				}),
-				mainImage(article[1])
+				openGraphImage(article[1])
 			]);
 		})
 		.then(function(results) {

--- a/server/controllers/article.js
+++ b/server/controllers/article.js
@@ -13,7 +13,7 @@ var bodyTransform = require('../transforms/body');
 var getVisualCategorisation = require('ft-next-article-genre');
 var articleXSLT = require('../transforms/article-xslt');
 var htmlifyXML = require('../transforms/htmlify-xml');
-var extractOpenGraph = require('../utils/open-graph');
+var openGraph = require('../utils/open-graph');
 
 module.exports = function(req, res, next) {
 	var articleV1Promise;
@@ -130,7 +130,7 @@ module.exports = function(req, res, next) {
 					};
 
 					if (mainImage) {
-						viewModel.og = extractOpenGraph(article, articleV1.item, mainImage);
+						viewModel.og = openGraph(article, articleV1.item, mainImage);
 					}
 
 					if (res.locals.barrier) {

--- a/server/utils/open-graph.js
+++ b/server/utils/open-graph.js
@@ -1,12 +1,19 @@
 
+'use strict';
+
 var extractUuid = require('./extract-uuid');
 
 module.exports = function (article, articleV1, mainImage) {
-	return {
+
+	var og = {
 		title: article.title,
 		description: articleV1.editorial.standFirst,
-		url: 'https://next.ft.com/' + extractUuid(article.id),
-		id: article.id,
-		image: mainImage.binaryUrl
+		url: 'https://next.ft.com/' + extractUuid(article.id)
+	};
+
+	if (mainImage) {
+		og.image = mainImage.binaryUrl;
 	}
-}
+
+	return og;
+};

--- a/server/utils/open-graph.js
+++ b/server/utils/open-graph.js
@@ -1,0 +1,12 @@
+
+var extractUuid = require('./extract-uuid');
+
+module.exports = function (article, articleV1, mainImage) {
+	return {
+		title: article.title,
+		description: articleV1.editorial.standFirst,
+		url: 'https://next.ft.com/' + extractUuid(article.id),
+		id: article.id,
+		image: mainImage.binaryUrl
+	}
+}

--- a/server/utils/twitter-card.js
+++ b/server/utils/twitter-card.js
@@ -1,0 +1,19 @@
+
+'use strict';
+
+module.exports.summary = function (article, articleV1, mainImage) {
+
+	var card = {
+		title: article.title,
+		description: articleV1.editorial.standFirst,
+	};
+
+	if (mainImage) {
+		card.card = "summary_large_image";
+		card.image = mainImage.binaryUrl;
+	} else {
+		card.card = "summary";
+	}
+
+	return card;
+};

--- a/test/server/utils/open-graph.test.js
+++ b/test/server/utils/open-graph.test.js
@@ -1,0 +1,35 @@
+/*global describe, it*/
+'use strict';
+
+require('chai').should();
+var openGraph = require('../../../server/utils/open-graph');
+
+describe('Open graph', function () {
+
+	var image = {
+		binaryUrl: 'http://foo.png'
+	};
+
+	var v1 = {
+		editorial: {
+			standFirst: 'vertical but yet are broadly'
+		}
+	};
+
+	var v2 = {
+		title: 'Monitise issues fresh',
+		id: 'http://www.ft.com/thing/0786d5a8-23b2-11e5-bd83-71cb60e8f08c'
+	};
+
+	it('should return an Open Graph object', function () {
+		openGraph(v2, v1, image).should.deep.equal(
+		    {
+				"description": "vertical but yet are broadly",
+				"image": "http://foo.png",
+				"title": "Monitise issues fresh",
+				"url": "https://next.ft.com/0786d5a8-23b2-11e5-bd83-71cb60e8f08c"
+			}	
+		);
+	});
+
+});

--- a/test/server/utils/twitter-card.test.js
+++ b/test/server/utils/twitter-card.test.js
@@ -1,0 +1,35 @@
+/*global describe, it*/
+'use strict';
+
+require('chai').should();
+var twitterCard = require('../../../server/utils/twitter-card').summary;
+
+describe('Twitter card', function () {
+
+	var image = {
+		binaryUrl: 'http://foo.png'
+	};
+
+	var v1 = {
+		editorial: {
+			standFirst: 'vertical but yet are broadly'
+		}
+	};
+
+	var v2 = {
+		title: 'Monitise issues fresh',
+		id: 'http://www.ft.com/thing/0786d5a8-23b2-11e5-bd83-71cb60e8f08c'
+	};
+
+	it('should return an Open Graph object', function () {
+		twitterCard(v2, v1, image).should.deep.equal(
+		    {
+				"description": "vertical but yet are broadly",
+				"image": "http://foo.png",
+				"title": "Monitise issues fresh",
+				"card": "summary_large_image"
+			}	
+		);
+	});
+
+});


### PR DESCRIPTION
Generates basic open graph data.

See also - https://github.com/Financial-Times/next-express/pull/191

```
<meta property="og:title" content="Monitise issues fresh revenue warning as model evolves"/>
<meta property="og:url" content="https://next.ft.com/0786d5a8-23b2-11e5-bd83-71cb60e8f08c"/>
<meta property="og:description" content="Mobile money group predicts return to profit by 2016"/>
<meta property="og:image" content="http://com.ft.imagepublish.prod.s3.amazonaws.com/39278302-23ba-11e5-bd83-71cb60e8f08c"/>
<meta property="og:type" content="article"/>
<meta property="og:site_name" content="Financial Times"/>
```