### PR TITLE
fix issue where text in same p as slideshow got removed

### DIFF
--- a/server/stylesheets/slideshow.xsl
+++ b/server/stylesheets/slideshow.xsl
@@ -3,6 +3,11 @@
 
     <xsl:template match="/body/p[a[substring(@href, string-length(@href) - 6) = '#slide0' and string-length(text()) = 0] and count(*) = 1]">
         <xsl:apply-templates select="a" />
+        <xsl:if test="string-length(text()) > 0">
+          <p>
+            <xsl:value-of select="text()"/>
+          </p>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template match="a[substring(@href, string-length(@href) - 6) = '#slide0' and string-length(text()) = 0]">

--- a/test/server/stylesheets/slideshow.test.js
+++ b/test/server/stylesheets/slideshow.test.js
@@ -62,4 +62,23 @@ describe('Slideshow', function () {
 			});
 	});
 
+	it('should retain any text in the same <p> tag as the slideshow in a separate <p>', function() {
+		return transform(
+				'<body>' +
+					'<p>' +
+						'<a href="http://www.ft.com/cms/s/0/f3970f88-0475-11df-8603-00144feabdc0.html#slide0"></a>' +
+						'Some text in the same p tag as the slideshow' +
+					'</p>' +
+				'</body>'
+			)
+			.then(function (transformedXml) {
+				transformedXml.should.equal(
+					'<body>' +
+						'<ft-slideshow data-uuid="f3970f88-0475-11df-8603-00144feabdc0"/>' +
+						'<p>Some text in the same p tag as the slideshow</p>' +
+					'</body>'
+				);
+			});
+	});
+
 });


### PR DESCRIPTION
Fix issue raised where text in same p tag as a slideshow got removed by the xsl process.
Unit test also written to cover this scenario.