### PR TITLE
Only run article scroll depth if there's an article body

### DIFF
--- a/client/components/article/_listicle.scss
+++ b/client/components/article/_listicle.scss
@@ -11,7 +11,7 @@
 	position: relative;
 	display: inline-block;
 	margin: -30px 0 10px;
-	background: #F57323;
+	background: #f57323;
 	padding: 5px;
 	color: white;
 }

--- a/client/components/article/_main.scss
+++ b/client/components/article/_main.scss
@@ -28,10 +28,11 @@ $header-offset: 30px;
 	}
 }
 .article__header-inner {
+	padding: 12px 20px 0;
+
 	@include oGridRespondTo(L) {
 		display: flex;
 	}
-	padding: 12px 20px 0;
 }
 .article__header--overlap {
 	padding-bottom: $header-offset + 20;
@@ -59,17 +60,17 @@ $header-offset: 30px;
 }
 .article__title {
 	@include nTypeAlpha(2);
+	margin: 0;
 	@include oGridRespondTo(L) {
 		@include nTypeAlphaSize(1);
 	}
-	margin: 0;
 }
 .article__stand-first {
 	@include nTypeDelta(3);
+	margin: 0 0 $spacing-unit / 4;
 	@include oGridRespondTo(L) {
 		@include nTypeDeltaSize(2);
 	}
-	margin: 0 0 $spacing-unit / 4;
 }
 .article__meta {
 	margin: 20px 0 0;
@@ -85,6 +86,9 @@ $header-offset: 30px;
 	font-style: normal;
 }
 .article__timestamp {
+	@include nTypeAlpha(5);
+	display: inline-block;
+	text-transform: uppercase;
 	@include print {
 		text-indent: -9999px;
 
@@ -96,25 +100,22 @@ $header-offset: 30px;
 			text-indent: 0;
 		}
 	}
-	@include nTypeAlpha(5);
-	display: inline-block;
-	text-transform: uppercase;
 }
 .article__primary-theme {
+	@include nTypeBeta(4);
+	margin: 0;
 	@include print {
 		display: none;
 	}
-	@include nTypeBeta(4);
-	margin: 0;
 }
 .article__actions {
+	margin-top: 10px;
 	@include oGridRespondTo(L) {
 		text-align: right;
 	}
 	@include print {
 		display: none;
 	}
-	margin-top: 10px;
 }
 .article__actions__action {
 	@include nTypeAlpha(5);
@@ -129,14 +130,14 @@ $header-offset: 30px;
 }
 
 .article__tags {
+	margin-top: 10px;
+	padding: 0;
 	@include print {
 		display: none;
 	}
 	@include oGridRespondTo(L) {
 		align-self: flex-end;
 	}
-	margin-top: 10px;
-	padding: 0;
 }
 .article__tags__title {
 	@include nTypeAlpha(5);
@@ -145,10 +146,10 @@ $header-offset: 30px;
 }
 .article__tags-list {
 	@include nLists();
+	margin: ($spacing-unit/2) 0 0;
 	@include oGridRespondTo($until: S) {
 		width: 100%;
 	}
-	margin: ($spacing-unit/2) 0 0;
 }
 .article__tag {
 	@include nListsItem($use-case: n-lists-inversed);

--- a/client/components/article/_promo-box-new.scss
+++ b/client/components/article/_promo-box-new.scss
@@ -85,8 +85,8 @@
 	display: inline;
 }
 .promo-box__content p {
-	margin: 5px 0 0;
 	@include nTypeAlpha(3);
+	margin: 5px 0 0;
 	strong a {
 		@include nLinksHeadline();
 		border-bottom: 0;

--- a/client/components/article/_promo-box.scss
+++ b/client/components/article/_promo-box.scss
@@ -39,6 +39,6 @@
 	width: 100%;
 }
 .article__promo-box__content p {
-	margin: 5px 0 0;
 	@include nTypeAlpha(3);
+	margin: 5px 0 0;
 }

--- a/client/components/article/scroll-depth.js
+++ b/client/components/article/scroll-depth.js
@@ -6,9 +6,9 @@ var throttle = require('../../libs/throttle');
 var mockedWindowHeight;
 // these are what scroll depth are bucketed into
 var percentageBuckets = [25, 50, 75, 100];
+var article = document.querySelector('.article__body');
 
 function getPercentageViewable() {
-	var article = document.querySelector('.article__body');
 	var windowHeight = mockedWindowHeight || window.innerHeight;
 	return (100 / article.getBoundingClientRect().height) * (windowHeight - article.getBoundingClientRect().top);
 }
@@ -33,7 +33,7 @@ var scrollDepth = {
 		opts = opts || {};
 		// allow mocking of window height
 		mockedWindowHeight = opts.windowHeight;
-		if (flags.get('articleScrollDepthTracking') || true) {
+		if (flags.get('articleScrollDepthTracking') && article) {
 			// how much of the article can we initially see
 			fireBeacon(getPercentageViewable());
 			// throttle scrolling

--- a/client/components/article/scroll-depth.js
+++ b/client/components/article/scroll-depth.js
@@ -6,9 +6,9 @@ var throttle = require('../../libs/throttle');
 var mockedWindowHeight;
 // these are what scroll depth are bucketed into
 var percentageBuckets = [25, 50, 75, 100];
-var article = document.querySelector('.article__body');
 
 function getPercentageViewable() {
+	var article = document.querySelector('.article__body');
 	var windowHeight = mockedWindowHeight || window.innerHeight;
 	return (100 / article.getBoundingClientRect().height) * (windowHeight - article.getBoundingClientRect().top);
 }
@@ -33,7 +33,7 @@ var scrollDepth = {
 		opts = opts || {};
 		// allow mocking of window height
 		mockedWindowHeight = opts.windowHeight;
-		if (flags.get('articleScrollDepthTracking') && article) {
+		if (flags.get('articleScrollDepthTracking') && document.querySelector('.article__body')) {
 			// how much of the article can we initially see
 			fireBeacon(getPercentageViewable());
 			// throttle scrolling

--- a/client/components/barriers/_premium-simple.scss
+++ b/client/components/barriers/_premium-simple.scss
@@ -29,9 +29,9 @@
 	background-color: oColorsGetPaletteColor('warm-2');
 
 	h2 {
-		margin: 0;
 		@include nTypeBeta(3);
 		@include oGridColumn((default: full-width, L: three-quarters));
+		margin: 0;
 	}
 
 	h2 {


### PR DESCRIPTION
i.e. not a barrier - fixes https://github.com/Financial-Times/next-article/issues/681

Also fix some sass lint warnings