### PR TITLE
undo space encoding before reencoding for image service

### DIFF
--- a/server/transforms/external-img.js
+++ b/server/transforms/external-img.js
@@ -17,7 +17,7 @@ module.exports = function($, flags) {
 		}
 		$el.removeAttr('height');
 		$el.removeAttr('width');
-		$el.attr('src', resize($el.attr('src'), { width: 710 }));
+		$el.attr('src', resize(decodeURIComponent($el.attr('src')), { width: 710 }));
 
 		var classes = 'article__image-wrapper ng-figure-reset ';
 		if (isMain) {

--- a/test/server/transforms/external-img.test.js
+++ b/test/server/transforms/external-img.test.js
@@ -18,4 +18,10 @@ describe('External Img', function () {
 		expect($.html()).to.equal('<body><a><figure class="article__image-wrapper ng-figure-reset article__main-image"><img src="https://next-geebee.ft.com/image/v1/images/raw/http%3A%2F%2Fmy-image%2Fimage.jpg?source=next&amp;fit=scale-down&amp;width=710\" class="article__image"></figure></a><p>Mr Dougan has been blamed by some leading shareholders for failing to grasp the extent of the change in the aftermath of the financial crisis.</p></body>');
 	});
 
+	it('should correctly encode images with spaces in file names', function() {
+		var $ = cheerio.load('<body><p>James Bond Watch</p><img alt="james bond omega.JPG" src="http://clamo.ftdata.co.uk/files/2015-07/16/james%20bond%20omega.JPG"/></body>');
+		$ = externalImgTransform($, { fullWidthMainImages: true });
+		expect($.html()).to.equal('<body><p>James Bond Watch</p><figure class="article__image-wrapper ng-figure-reset article__inline-image ng-inline-element ng-pull-out"><img alt="james bond omega.JPG" src="https://next-geebee.ft.com/image/v1/images/raw/http%3A%2F%2Fclamo.ftdata.co.uk%2Ffiles%2F2015-07%2F16%2Fjames%20bond%20omega.JPG?source=next&amp;fit=scale-down&amp;width=710\" class="article__image"></figure></body>');
+	});
+
 });


### PR DESCRIPTION
Many images from Clamo (fastFT CMS) have spaces in file names. XSLT is encoding these spaces to %20 and then our resize service is encoding the whole url of the file so the %20 becomes %2520 which fails when processed by the responsive image webservice.

This 'decodes' the XSLT partial encoding of the url, before the whole of it is re-encoded.