### PR TITLE
Bug/fix promobox images

### DIFF
--- a/server/transforms/images.js
+++ b/server/transforms/images.js
@@ -29,7 +29,7 @@ module.exports = function($body, opts) {
 				var $img = $body('img[data-image-set-id="' + imageSet.id.replace('http://www.ft.com/thing/', '') + '"]')
 					.attr('src', imgSrc);
 
-				if (imageSet.title) {
+				if ($img.parent().filter('figure').length > 0 && imageSet.title) {
 					var $figcaption = $('<figcaption></figcaption>')
 						.addClass('article__image-caption ng-meta')
 						.text(imageSet.title);

--- a/server/transforms/promo-box-new.js
+++ b/server/transforms/promo-box-new.js
@@ -86,6 +86,8 @@ module.exports = function ($) {
 			$promoBox.append(
 				$promoBoxImage.html()
 			);
+			var imageClass = "promo-box__image " + promoBoxLong ? "promo-box--long__image" : "";
+			$promoBox.find('img').addClass(imageClass).removeClass('ng-pull-out');
 		}
 
 		if ($promoBoxIntro.length) {

--- a/server/transforms/promo-box-new.js
+++ b/server/transforms/promo-box-new.js
@@ -86,7 +86,10 @@ module.exports = function ($) {
 			$promoBox.append(
 				$promoBoxImage.html()
 			);
-			var imageClass = "promo-box__image " + promoBoxLong ? "promo-box--long__image" : "";
+			var imageClass = "promo-box__image";
+			if (promoBoxLong) {
+				imageClass += " promo-box--long__image";
+			}
 			$promoBox.find('img').addClass(imageClass).removeClass('ng-pull-out');
 		}
 

--- a/test/server/transforms/images.test.js
+++ b/test/server/transforms/images.test.js
@@ -34,14 +34,16 @@ describe('Images', function() {
 	it('should get the image\'s src and caption', function() {
 		var $content = $.load('');
 		$content.root().append(
-			'<img data-image-set-id="f14a7e9e-cc08-11e4-30d3-978e959e1c97">'
+			'<figure><img data-image-set-id="f14a7e9e-cc08-11e4-30d3-978e959e1c97"></figure>'
 		);
 
 		return images($content, flags)
 			.then(function($content) {
 				$content.html().should.equal(
+					'<figure>' +
 					'<img data-image-set-id="f14a7e9e-cc08-11e4-30d3-978e959e1c97" src="https://next-geebee.ft.com/image/v1/images/raw/ftcms%3Af14a7e9e-cc08-11e4-aeb5-00144feab7de?source=next&amp;fit=scale-down&amp;width=710">' +
-					'<figcaption class="article__image-caption ng-meta">American staples old and new: from top, Campbell&#x2019;s Soup, hot dogs and kale. Below, Annie&#x2019;s Homegrown co-founder Annie Withey</figcaption>'
+					'<figcaption class="article__image-caption ng-meta">American staples old and new: from top, Campbell&#x2019;s Soup, hot dogs and kale. Below, Annie&#x2019;s Homegrown co-founder Annie Withey</figcaption>' +
+					'</figure>'
 				);
 			});
 	});
@@ -49,18 +51,22 @@ describe('Images', function() {
 	it('should get the source and caption for multiple images', function() {
 		var $content = $.load('');
 		$content.root().append([
-				'<img data-image-set-id="f14a7e9e-cc08-11e4-30d3-978e959e1c97">',
-				'<img data-image-set-id="2ad940b2-cc01-11e4-30d3-978e959e1c97">'
+				'<figure><img data-image-set-id="f14a7e9e-cc08-11e4-30d3-978e959e1c97"></figure>',
+				'<figure><img data-image-set-id="2ad940b2-cc01-11e4-30d3-978e959e1c97"></figure>'
 			].join(''));
 
 		return images($content, flags)
 			.then(function($content) {
 				$content.html().should.equal([
+					'<figure>' +
 					'<img data-image-set-id="f14a7e9e-cc08-11e4-30d3-978e959e1c97" src="https://next-geebee.ft.com/image/v1/images/raw/ftcms%3Af14a7e9e-cc08-11e4-aeb5-00144feab7de?source=next&amp;fit=scale-down&amp;width=710">',
 					'<figcaption class="article__image-caption ng-meta">',
 						'American staples old and new: from top, Campbell&#x2019;s Soup, hot dogs and kale. Below, Annie&#x2019;s Homegrown co-founder Annie Withey',
-					'</figcaption>',
-					'<img data-image-set-id="2ad940b2-cc01-11e4-30d3-978e959e1c97" src="https://next-geebee.ft.com/image/v1/images/raw/ftcms%3A2ad940b2-cc01-11e4-aeb5-00144feab7de?source=next&amp;fit=scale-down&amp;width=710">',
+					'</figcaption>' +
+					'</figure>',
+					'<figure>' +
+					'<img data-image-set-id="2ad940b2-cc01-11e4-30d3-978e959e1c97" src="https://next-geebee.ft.com/image/v1/images/raw/ftcms%3A2ad940b2-cc01-11e4-aeb5-00144feab7de?source=next&amp;fit=scale-down&amp;width=710">' +
+					'</figure>'
 				].join(''));
 			});
 	});

--- a/test/server/transforms/promo-box-new.test.js
+++ b/test/server/transforms/promo-box-new.test.js
@@ -12,7 +12,7 @@ describe('Promo Box New', function () {
 			'<promo-box>' +
 				'<promo-title><p>Tatomer Riesling 2012</p></promo-title>' +
 				'<promo-headline><p>Greece debt crisis</p></promo-headline>' +
-				'<promo-image><ft-content data-embedded="true" type="http://www.ft.com/ontology/content/ImageSet" url="http://api.ft.com/content/9ccaf9da-cde2-11e4-0f22-978e959e1c97"></ft-content></promo-image>' +
+				'<promo-image><img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image ng-inline-element ng-pull-out" alt=""></promo-image>' +
 				'<promo-intro><p>Graham Tatomer worked at Austrian Riesling producer Emmerich Knoll and now fashions this example from the old vines of the Kick-on Ranch in Santa Barbara (£26.95, Roberson)</p></promo-intro>' +
 			'</promo-box>'
 		);
@@ -22,19 +22,42 @@ describe('Promo Box New', function () {
 			'<aside data-trackable=\"promobox\" role="complementary" class="promo-box ng-pull-out ng-inline-element">' +
 				'<div class="promo-box__title__wrapper"><h3 class="promo-box__title">Tatomer Riesling 2012</h3></div>' +
 				'<h4 class="promo-box__headline">Greece debt crisis</h4>' +
-				'<ft-content data-embedded="true" type="http://www.ft.com/ontology/content/ImageSet" url="http://api.ft.com/content/9ccaf9da-cde2-11e4-0f22-978e959e1c97"></ft-content>' +
+				'<img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image ng-inline-element promo-box__image" alt="">' +
 				'<div class="promo-box__content">' +
 				'<div class="promo-box__content__initial"><p>Graham Tatomer worked at Austrian Riesling producer Emmerich Knoll and now fashions this example from the old vines of the Kick-on Ranch in Santa Barbara (&#xA3;26.95, Roberson)</p></div></div>' +
 			'</aside>'
 		);
 	});
 
-	it('should transform to promo box HTML - long version', function () {
+	it('should transform to promo box HTML - long version - no expander', function () {
 		var $ = cheerio.load(
 			'<promo-box>' +
 				'<promo-title><p>Tatomer Riesling 2012</p></promo-title>' +
 				'<promo-headline><p>Greece debt crisis</p></promo-headline>' +
-				'<promo-image><ft-content data-embedded="true" type="http://www.ft.com/ontology/content/ImageSet" url="http://api.ft.com/content/9ccaf9da-cde2-11e4-0f22-978e959e1c97"></ft-content></promo-image>' +
+				'<promo-image><img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image ng-inline-element ng-pull-out" alt=""></promo-image>' +
+				'<promo-intro><p><strong>Breakthrough:</strong> “Closing our first seed round in 10 days three times oversubscribed gave us momentum [to carry through] to the execution of our strategy and into the IPO.”</p>' +
+				'<p><strong>Best mentor:</strong> “Chris Baohm, my boss at Gresham Partners in Australia . . . made me understand the importance of breaking down complex situations into the core commercial objectives.”</p></promo-intro' +
+			'</promo-box>'
+		);
+
+		$ = promoBoxTransform($);
+		$.html().should.equal(
+			'<aside data-trackable=\"promobox\" role="complementary" class="promo-box ng-pull-out ng-inline-element promo-box--long">' +
+				'<div class="promo-box__title__wrapper"><h3 class="promo-box__title">Tatomer Riesling 2012</h3></div>' +
+				'<h4 class="promo-box__headline">Greece debt crisis</h4>' +
+				'<img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image ng-inline-element promo-box__image promo-box--long__image" alt="">' +
+				'<div class="promo-box__content">' +
+				'<div class="promo-box__content__initial"><p><strong>Breakthrough:</strong> &#x201C;Closing our first seed round in 10 days three times oversubscribed gave us momentum [to carry through] to the execution of our strategy and into the IPO.&#x201D;</p>' +
+				'<p><strong>Best mentor:</strong> &#x201C;Chris Baohm, my boss at Gresham Partners in Australia&#x2009;.&#x2009;.&#x2009;.&#x2009;made me understand the importance of breaking down complex situations into the core commercial objectives.&#x201D;</p></div></div>' +
+			'</aside>'
+		);
+	});
+	it('should transform to promo box HTML - long version - with expander', function () {
+		var $ = cheerio.load(
+			'<promo-box>' +
+				'<promo-title><p>Tatomer Riesling 2012</p></promo-title>' +
+				'<promo-headline><p>Greece debt crisis</p></promo-headline>' +
+				'<promo-image><img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image ng-inline-element ng-pull-out" alt=""></promo-image>' +
 				'<promo-intro><p><strong>Breakthrough:</strong> “Closing our first seed round in 10 days three times oversubscribed gave us momentum [to carry through] to the execution of our strategy and into the IPO.”</p>' +
 				'<p><strong>Best mentor:</strong> “Chris Baohm, my boss at Gresham Partners in Australia . . . made me understand the importance of breaking down complex situations into the core commercial objectives.”</p>' +
 				'<p><strong>Biggest mistake:</strong> “It became very clear that we needed a strong team with us who we could trust to navigate the huge due diligence tasks we had in several countries, in a different language.”</p>' +
@@ -47,7 +70,7 @@ describe('Promo Box New', function () {
 			'<aside data-trackable=\"promobox\" role="complementary" class="promo-box ng-pull-out ng-inline-element o-expander promo-box--long" data-o-component="o-expander" data-o-expander-shrink-to="0" data-o-expander-count-selector=".promo-box__content__extension">' +
 				'<div class="promo-box__title__wrapper"><h3 class="promo-box__title">Tatomer Riesling 2012</h3></div>' +
 				'<h4 class="promo-box__headline">Greece debt crisis</h4>' +
-				'<ft-content data-embedded="true" type="http://www.ft.com/ontology/content/ImageSet" url="http://api.ft.com/content/9ccaf9da-cde2-11e4-0f22-978e959e1c97"></ft-content>' +
+				'<img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image ng-inline-element promo-box__image promo-box--long__image" alt="">' +
 				'<div class="promo-box__content o-expander__content">' +
 				'<div class="promo-box__content__initial"><p><strong>Breakthrough:</strong> &#x201C;Closing our first seed round in 10 days three times oversubscribed gave us momentum [to carry through] to the execution of our strategy and into the IPO.&#x201D;</p>' +
 				'<p><strong>Best mentor:</strong> &#x201C;Chris Baohm, my boss at Gresham Partners in Australia&#x2009;.&#x2009;.&#x2009;.&#x2009;made me understand the importance of breaking down complex situations into the core commercial objectives.&#x201D;</p></div>' +
@@ -62,7 +85,7 @@ describe('Promo Box New', function () {
 		var $ = cheerio.load(
 			'<promo-box>' +
 				'<promo-headline><p>Greece debt crisis</p></promo-headline>' +
-				'<promo-image><ft-content data-embedded="true" type="http://www.ft.com/ontology/content/ImageSet" url="http://api.ft.com/content/9ccaf9da-cde2-11e4-0f22-978e959e1c97"></ft-content></promo-image>' +
+				'<promo-image><img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image ng-inline-element ng-pull-out" alt=""></promo-image>' +
 				'<promo-intro><p>Graham Tatomer worked at Austrian Riesling producer Emmerich Knoll and now fashions this example from the old vines of the Kick-on Ranch in Santa Barbara (£26.95, Roberson)</p></promo-intro>' +
 			'</promo-box>'
 		);
@@ -72,7 +95,7 @@ describe('Promo Box New', function () {
 			'<aside data-trackable=\"promobox\" role="complementary" class="promo-box ng-pull-out ng-inline-element">' +
 				'<div class="promo-box__title__wrapper"><h3 class="promo-box__title">Related Content</h3></div>' +
 				'<h4 class="promo-box__headline">Greece debt crisis</h4>' +
-				'<ft-content data-embedded="true" type="http://www.ft.com/ontology/content/ImageSet" url="http://api.ft.com/content/9ccaf9da-cde2-11e4-0f22-978e959e1c97"></ft-content>' +
+				'<img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image ng-inline-element promo-box__image" alt="">' +
 				'<div class="promo-box__content">' +
 				'<div class="promo-box__content__initial"><p>Graham Tatomer worked at Austrian Riesling producer Emmerich Knoll and now fashions this example from the old vines of the Kick-on Ranch in Santa Barbara (&#xA3;26.95, Roberson)</p></div></div>' +
 			'</aside>'
@@ -83,7 +106,7 @@ describe('Promo Box New', function () {
 		var $ = cheerio.load(
 			'<promo-box>' +
 				'<promo-title><p>Tatomer Riesling 2012</p></promo-title>' +
-				'<promo-image><ft-content data-embedded="true" type="http://www.ft.com/ontology/content/ImageSet" url="http://api.ft.com/content/9ccaf9da-cde2-11e4-0f22-978e959e1c97"></ft-content></promo-image>' +
+				'<promo-image><img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image ng-inline-element ng-pull-out" alt=""></promo-image>' +
 				'<promo-intro><p>Graham Tatomer worked at Austrian Riesling producer Emmerich Knoll and now fashions this example from the old vines of the Kick-on Ranch in Santa Barbara (£26.95, Roberson)</p></promo-intro>' +
 			'</promo-box>'
 		);
@@ -92,7 +115,7 @@ describe('Promo Box New', function () {
 		$.html().should.equal(
 			'<aside data-trackable=\"promobox\" role="complementary" class="promo-box ng-pull-out ng-inline-element">' +
 				'<div class="promo-box__title__wrapper"><h3 class="promo-box__title">Tatomer Riesling 2012</h3></div>' +
-				'<ft-content data-embedded="true" type="http://www.ft.com/ontology/content/ImageSet" url="http://api.ft.com/content/9ccaf9da-cde2-11e4-0f22-978e959e1c97"></ft-content>' +
+				'<img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image ng-inline-element promo-box__image" alt="">' +
 				'<div class="promo-box__content">' +
 				'<div class="promo-box__content__initial"><p>Graham Tatomer worked at Austrian Riesling producer Emmerich Knoll and now fashions this example from the old vines of the Kick-on Ranch in Santa Barbara (&#xA3;26.95, Roberson)</p></div></div>' +
 			'</aside>'
@@ -124,7 +147,7 @@ describe('Promo Box New', function () {
 			'<promo-box>' +
 				'<promo-title><p>Tatomer Riesling 2012</p></promo-title>' +
 				'<promo-headline><p>Greece debt crisis</p></promo-headline>' +
-				'<promo-image><ft-content data-embedded="true" type="http://www.ft.com/ontology/content/ImageSet" url="http://api.ft.com/content/9ccaf9da-cde2-11e4-0f22-978e959e1c97"></ft-content></promo-image>' +
+				'<promo-image><img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image ng-inline-element ng-pull-out" alt=""></promo-image>' +
 			'</promo-box>'
 		);
 
@@ -133,7 +156,7 @@ describe('Promo Box New', function () {
 			'<aside data-trackable=\"promobox\" role="complementary" class="promo-box ng-pull-out ng-inline-element">' +
 				'<div class="promo-box__title__wrapper"><h3 class="promo-box__title">Tatomer Riesling 2012</h3></div>' +
 				'<h4 class="promo-box__headline">Greece debt crisis</h4>' +
-				'<ft-content data-embedded="true" type="http://www.ft.com/ontology/content/ImageSet" url="http://api.ft.com/content/9ccaf9da-cde2-11e4-0f22-978e959e1c97"></ft-content>' +
+				'<img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image ng-inline-element promo-box__image" alt="">' +
 			'</aside>'
 		);
 	});


### PR DESCRIPTION
Transfer of images transform to xslt meant that promo-box image classes were not being appended. This solves that issue for the new promo-box style (currently switched on behind flag). Will need to make happen on old promo-box style as well.