### PR TITLE
Fix images within promoboxes and tables

### DIFF
--- a/server/stylesheets/images.xsl
+++ b/server/stylesheets/images.xsl
@@ -73,7 +73,8 @@
             <xsl:attribute name="class">
                 <xsl:choose>
                     <xsl:when test="$isMain and $fullWidthMainImages">article__image ng-media</xsl:when>
-                    <xsl:when test="$isInline">article__image ng-inline-element ng-pull-out</xsl:when>
+                    <xsl:when test="$isInline and current()[name(parent::*) = 'p']">article__image ng-inline-element ng-pull-out</xsl:when>
+                    <xsl:when test="$isInline and current()[name(parent::*) != 'p']">article__image</xsl:when>
                     <xsl:otherwise>article__image</xsl:otherwise>
                 </xsl:choose>
             </xsl:attribute>

--- a/server/transforms/promo-box-new.js
+++ b/server/transforms/promo-box-new.js
@@ -90,7 +90,7 @@ module.exports = function ($) {
 			if (promoBoxLong) {
 				imageClass += " promo-box--long__image";
 			}
-			$promoBox.find('img').addClass(imageClass).removeClass('ng-pull-out');
+			$promoBox.find('img').addClass(imageClass);
 		}
 
 		if ($promoBoxIntro.length) {

--- a/test/server/stylesheets/image.test.js
+++ b/test/server/stylesheets/image.test.js
@@ -176,4 +176,32 @@ describe('Images', function () {
 		});
 	});
 
+	it('should not add ng-inline-element or ng-pull-out to an image who\'s immediate parent is not a p tag, eg. promo-box or table', function() {
+		return transform(
+			'<html>' +
+				'<body>' +
+					'<promo-box>' +
+						'<promo-image>' +
+							'<ft-content type="http://www.ft.com/ontology/content/ImageSet" url="http://api.ft.com/content/ab3c20e8-15fe-11e5-2032-978e959e1689" data-embedded="true"></ft-content>' +
+						'</promo-image>' +
+					'</promo-box>' +
+				'</body>' +
+			'</html>',
+			{
+				fullWidthMainImages: 0
+			}
+		)
+		.then(function (transformedXml) {
+			transformedXml.should.equal(
+				'<body>' +
+					'<promo-box>' +
+						'<promo-image>' +
+							'<img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image" alt="">' +
+						'</promo-image>' +
+					'</promo-box>' +
+				'</body>\n'
+			);
+		});
+	});
+
 });

--- a/test/server/transforms/promo-box-new.test.js
+++ b/test/server/transforms/promo-box-new.test.js
@@ -12,7 +12,7 @@ describe('Promo Box New', function () {
 			'<promo-box>' +
 				'<promo-title><p>Tatomer Riesling 2012</p></promo-title>' +
 				'<promo-headline><p>Greece debt crisis</p></promo-headline>' +
-				'<promo-image><img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image ng-inline-element ng-pull-out" alt=""></promo-image>' +
+				'<promo-image><img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image" alt=""></promo-image>' +
 				'<promo-intro><p>Graham Tatomer worked at Austrian Riesling producer Emmerich Knoll and now fashions this example from the old vines of the Kick-on Ranch in Santa Barbara (£26.95, Roberson)</p></promo-intro>' +
 			'</promo-box>'
 		);
@@ -22,7 +22,7 @@ describe('Promo Box New', function () {
 			'<aside data-trackable=\"promobox\" role="complementary" class="promo-box ng-pull-out ng-inline-element">' +
 				'<div class="promo-box__title__wrapper"><h3 class="promo-box__title">Tatomer Riesling 2012</h3></div>' +
 				'<h4 class="promo-box__headline">Greece debt crisis</h4>' +
-				'<img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image ng-inline-element promo-box__image" alt="">' +
+				'<img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image promo-box__image" alt="">' +
 				'<div class="promo-box__content">' +
 				'<div class="promo-box__content__initial"><p>Graham Tatomer worked at Austrian Riesling producer Emmerich Knoll and now fashions this example from the old vines of the Kick-on Ranch in Santa Barbara (&#xA3;26.95, Roberson)</p></div></div>' +
 			'</aside>'
@@ -34,7 +34,7 @@ describe('Promo Box New', function () {
 			'<promo-box>' +
 				'<promo-title><p>Tatomer Riesling 2012</p></promo-title>' +
 				'<promo-headline><p>Greece debt crisis</p></promo-headline>' +
-				'<promo-image><img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image ng-inline-element ng-pull-out" alt=""></promo-image>' +
+				'<promo-image><img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image" alt=""></promo-image>' +
 				'<promo-intro><p><strong>Breakthrough:</strong> “Closing our first seed round in 10 days three times oversubscribed gave us momentum [to carry through] to the execution of our strategy and into the IPO.”</p>' +
 				'<p><strong>Best mentor:</strong> “Chris Baohm, my boss at Gresham Partners in Australia . . . made me understand the importance of breaking down complex situations into the core commercial objectives.”</p></promo-intro' +
 			'</promo-box>'
@@ -45,7 +45,7 @@ describe('Promo Box New', function () {
 			'<aside data-trackable=\"promobox\" role="complementary" class="promo-box ng-pull-out ng-inline-element promo-box--long">' +
 				'<div class="promo-box__title__wrapper"><h3 class="promo-box__title">Tatomer Riesling 2012</h3></div>' +
 				'<h4 class="promo-box__headline">Greece debt crisis</h4>' +
-				'<img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image ng-inline-element promo-box__image promo-box--long__image" alt="">' +
+				'<img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image promo-box__image promo-box--long__image" alt="">' +
 				'<div class="promo-box__content">' +
 				'<div class="promo-box__content__initial"><p><strong>Breakthrough:</strong> &#x201C;Closing our first seed round in 10 days three times oversubscribed gave us momentum [to carry through] to the execution of our strategy and into the IPO.&#x201D;</p>' +
 				'<p><strong>Best mentor:</strong> &#x201C;Chris Baohm, my boss at Gresham Partners in Australia&#x2009;.&#x2009;.&#x2009;.&#x2009;made me understand the importance of breaking down complex situations into the core commercial objectives.&#x201D;</p></div></div>' +
@@ -57,7 +57,7 @@ describe('Promo Box New', function () {
 			'<promo-box>' +
 				'<promo-title><p>Tatomer Riesling 2012</p></promo-title>' +
 				'<promo-headline><p>Greece debt crisis</p></promo-headline>' +
-				'<promo-image><img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image ng-inline-element ng-pull-out" alt=""></promo-image>' +
+				'<promo-image><img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image" alt=""></promo-image>' +
 				'<promo-intro><p><strong>Breakthrough:</strong> “Closing our first seed round in 10 days three times oversubscribed gave us momentum [to carry through] to the execution of our strategy and into the IPO.”</p>' +
 				'<p><strong>Best mentor:</strong> “Chris Baohm, my boss at Gresham Partners in Australia . . . made me understand the importance of breaking down complex situations into the core commercial objectives.”</p>' +
 				'<p><strong>Biggest mistake:</strong> “It became very clear that we needed a strong team with us who we could trust to navigate the huge due diligence tasks we had in several countries, in a different language.”</p>' +
@@ -70,7 +70,7 @@ describe('Promo Box New', function () {
 			'<aside data-trackable=\"promobox\" role="complementary" class="promo-box ng-pull-out ng-inline-element o-expander promo-box--long" data-o-component="o-expander" data-o-expander-shrink-to="0" data-o-expander-count-selector=".promo-box__content__extension">' +
 				'<div class="promo-box__title__wrapper"><h3 class="promo-box__title">Tatomer Riesling 2012</h3></div>' +
 				'<h4 class="promo-box__headline">Greece debt crisis</h4>' +
-				'<img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image ng-inline-element promo-box__image promo-box--long__image" alt="">' +
+				'<img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image promo-box__image promo-box--long__image" alt="">' +
 				'<div class="promo-box__content o-expander__content">' +
 				'<div class="promo-box__content__initial"><p><strong>Breakthrough:</strong> &#x201C;Closing our first seed round in 10 days three times oversubscribed gave us momentum [to carry through] to the execution of our strategy and into the IPO.&#x201D;</p>' +
 				'<p><strong>Best mentor:</strong> &#x201C;Chris Baohm, my boss at Gresham Partners in Australia&#x2009;.&#x2009;.&#x2009;.&#x2009;made me understand the importance of breaking down complex situations into the core commercial objectives.&#x201D;</p></div>' +
@@ -85,7 +85,7 @@ describe('Promo Box New', function () {
 		var $ = cheerio.load(
 			'<promo-box>' +
 				'<promo-headline><p>Greece debt crisis</p></promo-headline>' +
-				'<promo-image><img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image ng-inline-element ng-pull-out" alt=""></promo-image>' +
+				'<promo-image><img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image" alt=""></promo-image>' +
 				'<promo-intro><p>Graham Tatomer worked at Austrian Riesling producer Emmerich Knoll and now fashions this example from the old vines of the Kick-on Ranch in Santa Barbara (£26.95, Roberson)</p></promo-intro>' +
 			'</promo-box>'
 		);
@@ -95,7 +95,7 @@ describe('Promo Box New', function () {
 			'<aside data-trackable=\"promobox\" role="complementary" class="promo-box ng-pull-out ng-inline-element">' +
 				'<div class="promo-box__title__wrapper"><h3 class="promo-box__title">Related Content</h3></div>' +
 				'<h4 class="promo-box__headline">Greece debt crisis</h4>' +
-				'<img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image ng-inline-element promo-box__image" alt="">' +
+				'<img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image promo-box__image" alt="">' +
 				'<div class="promo-box__content">' +
 				'<div class="promo-box__content__initial"><p>Graham Tatomer worked at Austrian Riesling producer Emmerich Knoll and now fashions this example from the old vines of the Kick-on Ranch in Santa Barbara (&#xA3;26.95, Roberson)</p></div></div>' +
 			'</aside>'
@@ -106,7 +106,7 @@ describe('Promo Box New', function () {
 		var $ = cheerio.load(
 			'<promo-box>' +
 				'<promo-title><p>Tatomer Riesling 2012</p></promo-title>' +
-				'<promo-image><img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image ng-inline-element ng-pull-out" alt=""></promo-image>' +
+				'<promo-image><img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image" alt=""></promo-image>' +
 				'<promo-intro><p>Graham Tatomer worked at Austrian Riesling producer Emmerich Knoll and now fashions this example from the old vines of the Kick-on Ranch in Santa Barbara (£26.95, Roberson)</p></promo-intro>' +
 			'</promo-box>'
 		);
@@ -115,7 +115,7 @@ describe('Promo Box New', function () {
 		$.html().should.equal(
 			'<aside data-trackable=\"promobox\" role="complementary" class="promo-box ng-pull-out ng-inline-element">' +
 				'<div class="promo-box__title__wrapper"><h3 class="promo-box__title">Tatomer Riesling 2012</h3></div>' +
-				'<img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image ng-inline-element promo-box__image" alt="">' +
+				'<img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image promo-box__image" alt="">' +
 				'<div class="promo-box__content">' +
 				'<div class="promo-box__content__initial"><p>Graham Tatomer worked at Austrian Riesling producer Emmerich Knoll and now fashions this example from the old vines of the Kick-on Ranch in Santa Barbara (&#xA3;26.95, Roberson)</p></div></div>' +
 			'</aside>'
@@ -147,7 +147,7 @@ describe('Promo Box New', function () {
 			'<promo-box>' +
 				'<promo-title><p>Tatomer Riesling 2012</p></promo-title>' +
 				'<promo-headline><p>Greece debt crisis</p></promo-headline>' +
-				'<promo-image><img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image ng-inline-element ng-pull-out" alt=""></promo-image>' +
+				'<promo-image><img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image" alt=""></promo-image>' +
 			'</promo-box>'
 		);
 
@@ -156,7 +156,7 @@ describe('Promo Box New', function () {
 			'<aside data-trackable=\"promobox\" role="complementary" class="promo-box ng-pull-out ng-inline-element">' +
 				'<div class="promo-box__title__wrapper"><h3 class="promo-box__title">Tatomer Riesling 2012</h3></div>' +
 				'<h4 class="promo-box__headline">Greece debt crisis</h4>' +
-				'<img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image ng-inline-element promo-box__image" alt="">' +
+				'<img data-image-set-id="ab3c20e8-15fe-11e5-2032-978e959e1689" class="article__image promo-box__image" alt="">' +
 			'</aside>'
 		);
 	});


### PR DESCRIPTION
Add logic into images transform to not add inline / pull out classes to images in article that are contained in something other than a <p>, eg. promo-boxes and tables.

From this
![screen shot 2015-07-20 at 15 24 54](https://cloud.githubusercontent.com/assets/8938227/8778081/b5855570-2ef3-11e5-90ee-801f79a01e3f.png)

to this
![screen shot 2015-07-20 at 15 25 26](https://cloud.githubusercontent.com/assets/8938227/8778091/be2ef9ec-2ef3-11e5-9ded-d979f8442693.png)

Plus added tests and changed some logic in promo-boxes transform that had fixed it just for promo-boxes.
