### PR TITLE
photo diary initial image as main image

### DIFF
--- a/server/stylesheets/images.xsl
+++ b/server/stylesheets/images.xsl
@@ -7,7 +7,7 @@
         </figure>
     </xsl:template>
 
-    <xsl:template match="/html/body/img[count(preceding-sibling::*) = 0] | /html/body/p[normalize-space(string()) = '' and count(preceding-sibling::*) = 0]/img">
+    <xsl:template match="/html/body/img[count(preceding-sibling::*) = 0] | /html/body/p[normalize-space(string()) = '' and count(preceding-sibling::*) = 0]/img | /html/body/a[normalize-space(string()) = '' and count(preceding-sibling::*) = 0]/img">
         <figure class="article__image-wrapper article__main-image ng-figure-reset">
             <xsl:apply-templates select="current()" mode="external-image" />
         </figure>

--- a/test/server/stylesheets/image.test.js
+++ b/test/server/stylesheets/image.test.js
@@ -211,4 +211,33 @@ describe('Images', function () {
 		});
 	});
 
+	it('should not add ng-inline-element or ng-pull-out to an external image which is in a <a> at the start of an article, eg photo diary', function() {
+		return transform(
+			'<html>' +
+				'<body>' +
+					'<a href="http://blogs.ft.com/photo-diary/files/2015/07/seal.jpg">' +
+						'<img alt="A seal cools off at Belgrade Zoo during a heatwave on Tuesday. In Serbia where the meteoalarm has been raised to \'red\', extremely hot weather with temperatures up to 39 degrees Celsius is expected to continue over the next several days" height="1364" src="http://blogs.ft.com/photo-diary/files/2015/07/seal.jpg" width="2048"/>' +
+					'</a>' +
+					'<p>A seal cools off at Belgrade Zoo during a heatwave on Tuesday. In Serbia where the meteoalarm has been raised to ‘red’, extremely hot weather with temperatures up to 39 degrees Celsius</p>' +
+					'</body>' +
+			'</html>',
+			{
+				fullWidthMainImages: 0,
+				reserveSpaceForMasterImage: 1
+			}
+		)
+		.then(function (transformedXml) {
+			transformedXml.should.equal(
+				'<body>' +
+					'<a data-trackable="link" href="http://blogs.ft.com/photo-diary/files/2015/07/seal.jpg">' +
+						'<figure class="article__image-wrapper article__main-image ng-figure-reset">' +
+							'<img alt="" src="https://next-geebee.ft.com/image/v1/images/raw/http://blogs.ft.com/photo-diary/files/2015/07/seal.jpg?source=next&amp;fit=scale-down&amp;width=710" class="article__image">' +
+						'</figure>' +
+					'</a>' +
+					'<p>A seal cools off at Belgrade Zoo during a heatwave on Tuesday. In Serbia where the meteoalarm has been raised to ‘red’, extremely hot weather with temperatures up to 39 degrees Celsius</p>' +
+				'</body>\n'
+			);
+		});
+	});
+
 });


### PR DESCRIPTION
Ensure that photo on photo diary article page renders as main image rather than pull out.

Currently;
![screen shot 2015-07-22 at 08 36 49](https://cloud.githubusercontent.com/assets/8938227/8820379/ceaadbe2-304c-11e5-887b-4a547eec8f52.png)

With fix;
![screen shot 2015-07-22 at 08 36 26](https://cloud.githubusercontent.com/assets/8938227/8820387/d90bf1b6-304c-11e5-9051-1a54ff07e3c9.png)
