### PR TITLE
double encoding of spaces in external url

### DIFF
--- a/server/stylesheets/images.xsl
+++ b/server/stylesheets/images.xsl
@@ -24,11 +24,7 @@
           <img alt="">
             <xsl:attribute name="src">
               <xsl:value-of select="'https://next-geebee.ft.com/image/v1/images/raw/'" />
-                <xsl:call-template name="string-replace-all">
-                  <xsl:with-param name="text" select="@src" />
-                  <xsl:with-param name="replace" select='"?"' />
-                  <xsl:with-param name="by" select='"%3F"' />
-                </xsl:call-template>
+              <xsl:value-of select="@src" />
               <xsl:value-of select="'?source=next&amp;fit=scale-down&amp;width=710'" />
             </xsl:attribute>
             <xsl:attribute name="class">

--- a/server/transforms/external-images.js
+++ b/server/transforms/external-images.js
@@ -7,7 +7,7 @@ module.exports = function($) {
 		var $el = cheerio(el).clone();
 		var matcher = /^https:\/\/next-geebee.ft.com\/image\/v1\/images\/raw\/(.+)\?/;
 		var externalURI = $el.attr('src').match(matcher);
-		externalURI && $el.attr('src', $el.attr('src').replace(externalURI[1], encodeURIComponent(decodeURIComponent(externalURI[1]))));
+		externalURI && $el.attr('src', $el.attr('src').replace(externalURI[1], encodeURIComponent(externalURI[1])));
 		return $el;
 	});
 	return $;

--- a/test/server/stylesheets/image.test.js
+++ b/test/server/stylesheets/image.test.js
@@ -156,32 +156,6 @@ describe('Images', function () {
 			});
 	});
 
-	it('should encode a ? in an external url', function() {
-		return transform(
-			'<html>' +
-				'<body>' +
-					'<p>test test test</p>' +
-					'<p><img src="http://markets.ft.com/ChartBuilder?t=indices&p=eYjhj93245"></img>Chart from chart builder.</p>' +
-				'</body>' +
-			'</html>',
-			{
-				fullWidthMainImages: 0,
-				reserveSpaceForMasterImage: 1
-			}
-		)
-		.then(function (transformedXml) {
-			transformedXml.should.equal(
-				'<body>' +
-					'<p>test test test</p>' +
-					'<p>' +
-						'<img alt="" src="https://next-geebee.ft.com/image/v1/images/raw/http://markets.ft.com/ChartBuilder%3Ft=indices&amp;p=eYjhj93245?source=next&amp;fit=scale-down&amp;width=710" class="article__image ng-inline-element ng-pull-out">' +
-						'Chart from chart builder.' +
-					'</p>' +
-				'</body>\n'
-			);
-		});
-	});
-
 	it('should not add ng-inline-element or ng-pull-out to an image who\'s immediate parent is not a p tag, eg. promo-box or table', function() {
 		return transform(
 			'<html>' +

--- a/test/server/transforms/external-images.test.js
+++ b/test/server/transforms/external-images.test.js
@@ -7,7 +7,7 @@ require('chai').should();
 
 describe('External Images', function() {
 
-  it('should decode any encoded items in src of external image urls back to spaces and then re-encode', function() {
+  it('should double encode spaces in src of external image urls', function() {
     var $ = cheerio.load(
       '<body>' +
         '<p>test test test</p>' +
@@ -20,7 +20,7 @@ describe('External Images', function() {
       '<body>' +
         '<p>test test test</p>' +
         '<figure class="article__image-wrapper article__inline-image ng-figure-reset ng-inline-element ng-pull-out">' +
-        '<img alt="" src="https://next-geebee.ft.com/image/v1/images/raw/http%3A%2F%2Fclamo.ftdata.co.uk%2Ffiles%2F2015-07%2F21%2FFT%20Dow%20Stock%20Moves%20IBM%20UTX%207-21-15.png?source=next&amp;fit=scale-down&amp;width=710">' +
+        '<img alt="" src="https://next-geebee.ft.com/image/v1/images/raw/http%3A%2F%2Fclamo.ftdata.co.uk%2Ffiles%2F2015-07%2F21%2FFT%2520Dow%2520Stock%2520Moves%2520IBM%2520UTX%25207-21-15.png?source=next&amp;fit=scale-down&amp;width=710">' +
         '</figure>' +
       '</body>');
   	});


### PR DESCRIPTION
@richard-still-ft 
This should fix issue with getting both clamo and FTMarkets external images back from the image service by double encoding spaces in file names.