### PR TITLE
default background for all article types pb titles

### DIFF
--- a/client/components/article/_promo-box-new.scss
+++ b/client/components/article/_promo-box-new.scss
@@ -55,17 +55,12 @@
 	display: inline-block;
 	padding: 5px 10px;
 	margin-bottom: 0;
+	background-color: #f57323;
 	color: #ffffff;
 	a {
 		color: #ffffff;
-		border-bottom: 0;
-	}
-}
-
-.article--default .promo-box__title {
-	background-color: #f57323;
-	a {
 		background-color: #f57323;
+		border-bottom: 0;
 	}
 }
 


### PR DESCRIPTION
Moved styling for .article--default .promo-box__title into .promo-box__title to ensure there is a default for all article types (no differentiated styling had been applied for .article--analysis for example). Future-proofs default for any new article types.