### PR TITLE
switch to use next-card for related story element

### DIFF
--- a/client/components/_story-package.scss
+++ b/client/components/_story-package.scss
@@ -1,85 +1,51 @@
+$image-width: 100px;
+$image-width-padding: 10px;
+$image-width-allowance: $image-width + $image-width-padding;
+$image-height: 56px;
+$height-padding: 8px;
+$image-height-allowance: $image-height + (2 * $height-padding);
+
 .story-package {
 	margin-top: 15px;
 	margin-bottom: 15px;
 	position: relative;
-	font-family: $fontSans;
-	font-weight: 100;
-	color: #000000;
 
 	@include print {
 		display: none;
 	}
-	&.story-package--inline {
-		margin-top: 0;
-	}
-}
-.story-package--inline {
-	@include oGridRespondTo(S) {
-		width: 300px;
-	}
-}
-.story-package__title {
-	@include nTypeBravo(4);
-	text-transform: uppercase;
-	margin: 0;
 }
 
 .story-package__article {
 	position: relative;
-	padding: 5px;
-	font-size: 17px;
-	font-weight: 200;
-	line-height: 1em;
 	box-sizing: border-box;
-	min-height: 56px;
-	border: 1px solid $box-colour;
+	min-height: $image-height-allowance;
+	padding-left: $image-width-allowance;
+	border-bottom: 2px solid oColorsGetPaletteColor('warm-2');
+}
 
-	@include oGridRespondTo(S) {
-		font-size: 20px;
+.story-package--inline {
+	.story-package__article {
+		padding-left: initial;
 	}
-	&:first-child {
-		margin-top: 0;
-		.story-package__article__link {
-			clear: left;
-		}
+	.story-package__article--with-image {
+		padding-right: $image-width-allowance;
 	}
-
-	&.story-package__article--with-image {
-		padding-right: 110px;
-	}
-	.story-package--with-image & {
-		@include oGridRespondTo(S) {
-			padding-right: 220px;
-		}
-		@include oGridRespondTo(M) {
-			padding-right: 320px;
-		}
-	}
-	.story-package--authors & {
-		@include oGridRespondTo(S) {
-			padding-right: 120px;
-		}
-	}
-	.story-package__article__link {
-		display: block;
-		color: inherit;
-		border: 0;
+	.story-package__article__image {
+		left: initial;
+		right: 0;
 	}
 }
 
 .story-package__article__image {
 	display: block;
-	border: 0;
 	position: absolute;
-	top: -1px;
-	right: -1px;
+	left: 0;
+	padding: $height-padding 0;
 }
 
-.story-package__article__timestamp {
-	@include nTypeAlpha(5);
-	margin-top: 5px;
-	color: oColorsGetPaletteColor('cold-1');
-	display: block;
-	margin: 8px 0;
-	text-transform: uppercase;
+.story-package__title {
+	@include nTypeBravo(3);
+	margin: 0;
+	border-bottom: 1px solid oColorsGetPaletteColor('cold-2');
+	padding: $height-padding 0;
 }

--- a/client/components/article/_main.scss
+++ b/client/components/article/_main.scss
@@ -171,9 +171,23 @@ $header-offset: 30px;
 	color: $next-grey-dark;
 	margin-bottom: 20px;
 
-	> p {
+	p {
 		margin: 0.3em 0 0.8em;
 		display: block;
+		a {
+			@include nLinksBody();
+			@include print {
+				&:after {
+					text-decoration: none;
+				}
+				&[href^='/']:after {
+					content: ' (http://next.ft.com' attr(href) ')';
+				}
+				&:not([href^='/']):after {
+					content: ' (' attr(href) ')';
+				}
+			}
+		}
 	}
 	> *:first-child {
 		margin-top: 0;
@@ -186,20 +200,6 @@ $header-offset: 30px;
 		}
 	}
 
-	a {
-		@include nLinksBody();
-		@include print {
-			&:after {
-				text-decoration: none;
-			}
-			&[href^='/']:after {
-				content: ' (http://next.ft.com' attr(href) ')';
-			}
-			&:not([href^='/']):after {
-				content: ' (' attr(href) ')';
-			}
-		}
-	}
 	.o-quote--standard a {
 		color: inherit;
 	}

--- a/client/components/article/_promo-box-new.scss
+++ b/client/components/article/_promo-box-new.scss
@@ -97,13 +97,7 @@
 
 .promo-box__content {
 	display: inline;
-}
-
-.promo-box__content p {
-	@include nTypeAlpha(3);
-	margin: 5px 0 0;
-	strong a {
-		@include nLinksHeadline();
-		border-bottom: 0;
+	p {
+		margin: 5px 0 0;
 	}
 }

--- a/server/controllers/related/story-package.js
+++ b/server/controllers/related/story-package.js
@@ -38,8 +38,9 @@ module.exports = function(req, res, next) {
 			var imagePromises = articles.map(function(article) {
 				var articleModel = {
 					id: extractUuid(article.id),
-					title: article.title,
-					publishedDate: article.publishedDate
+					headline: article.title,
+					lastUpdated: article.publishedDate,
+					isBlock: true
 				};
 				if (!article.mainImage) {
 					return Promise.resolve(articleModel);

--- a/views/related/story-package.html
+++ b/views/related/story-package.html
@@ -3,19 +3,10 @@
 	<ul class="story-package__articles ng-list-reset" data-trackable="articles">
 		{{#each articles}}
 			<li class="story-package__article{{#if image}} story-package__article--with-image{{/if}}">
-				<a class="story-package__article__link ng-title-link" href="/{{id}}" data-trackable="title">
-					{{title}}
-					{{#if image}}
-						<img class="story-package__article__image" src="{{image}}" />
-					{{/if}}
-				</a>
-				<time
-					class="story-package__article__timestamp ng-meta o-date"
-					data-o-component="o-date"
-					datetime="{{#dateformat}}{{publishedDate}}{{/dateformat}}"
-					data-o-date-js>
-					{{#dateformat "dddd, d mmmm, yyyy"}}{{publishedDate}}{{/dateformat}}
-				</time>
+				{{#if image}}
+					<img class="story-package__article__image" src="{{image}}" role="presentation" alt="" />
+				{{/if}}
+				{{>next-card/templates/card}}
 			</li>
 		{{/each}}
 	</ul>


### PR DESCRIPTION
Remove most of the bespoke styling for related story elements and replace with next-card components.

Plus update the styling slightly to bring it more in line with stream article / more ons.

Was;

![screen shot 2015-08-04 at 15 07 28](https://cloud.githubusercontent.com/assets/8938227/9062519/ddb7ef30-3aba-11e5-8468-2819503dc1a3.png)
![screen shot 2015-08-04 at 15 07 42](https://cloud.githubusercontent.com/assets/8938227/9062523/e01690f6-3aba-11e5-9067-930c47a6f9f2.png)

Will be;

![screen shot 2015-08-04 at 15 08 03](https://cloud.githubusercontent.com/assets/8938227/9062535/eab969d4-3aba-11e5-957d-94e9bc05d1c9.png)
![screen shot 2015-08-04 at 15 08 38](https://cloud.githubusercontent.com/assets/8938227/9062541/f0048b26-3aba-11e5-95e8-104e465f1bb9.png)
