### PR TITLE
Correct encoding of image urls

### DIFF
--- a/client/components/special-report/_main.scss
+++ b/client/components/special-report/_main.scss
@@ -103,8 +103,8 @@
 		color: oColorsGetPaletteColor('blue-2');
 	}
 	.stream-card__article__link {
-		color: inherit;
 		@include nTypeAlpha(3);
+		color: inherit;
 		text-decoration: none;
 		border-bottom: 1px dotted transparent;
 		transition: border-bottom 100ms;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "ft-next-splunk-logger": "^1.3.2",
     "ft-poller": "0.0.4",
     "handlebars": "^2.0.0",
+    "html-entities": "^1.1.3",
     "lodash": "^3.6.0",
     "merge": "^1.2.0",
     "next-ft-api-client": "^3.9.5",

--- a/server/stylesheets/external-image.xsl
+++ b/server/stylesheets/external-image.xsl
@@ -7,6 +7,7 @@
         </figure>
     </xsl:template>
 
+    <!-- matches the main image, i.e. the first image on the page -->
     <xsl:template match="/html/body/img[count(preceding-sibling::*) = 0] | /html/body/p[normalize-space(string()) = '' and count(preceding-sibling::*) = 0]/img">
         <figure class="article__image-wrapper article__main-image ng-figure-reset">
             <xsl:apply-templates select="current()" mode="external-image" />
@@ -22,16 +23,7 @@
     <xsl:template match="img" mode="external-image">
         <xsl:param name="isInline" />
 
-        <img alt="">
-            <xsl:attribute name="src">
-                <xsl:value-of select="'https://next-geebee.ft.com/image/v1/images/raw/'" />
-                    <xsl:call-template name="string-replace-all">
-                        <xsl:with-param name="text" select="@src" />
-                        <xsl:with-param name="replace" select='"?"' />
-                        <xsl:with-param name="by" select='"%3F"' />
-                    </xsl:call-template>
-                <xsl:value-of select="'?source=next&amp;fit=scale-down&amp;width=710'" />
-            </xsl:attribute>
+        <img alt="" src="https://next-geebee.ft.com/image/v1/images/raw/{@src}?source=next&amp;fit=scale-down&amp;width=710">
             <xsl:attribute name="class">
                 <xsl:choose>
                     <xsl:when test="$isInline">article__image ng-inline-element ng-pull-out</xsl:when>

--- a/server/transforms/external-images.js
+++ b/server/transforms/external-images.js
@@ -1,13 +1,21 @@
 'use strict';
 
 var cheerio = require('cheerio');
+var Entities = require('html-entities').XmlEntities;
 
 module.exports = function($) {
+	var entities = new Entities();
+
 	$('img[src]').replaceWith(function(index, el) {
 		var $el = cheerio(el).clone();
 		var matcher = /^https:\/\/next-geebee.ft.com\/image\/v1\/images\/raw\/(.+)\?/;
 		var externalURI = $el.attr('src').match(matcher);
-		externalURI && $el.attr('src', $el.attr('src').replace(externalURI[1], encodeURIComponent(externalURI[1])));
+		if (externalURI) {
+			var imageSrc = externalURI[1];
+			// also unescape any html entites
+			var imageSrcEncoded = encodeURIComponent(entities.decode(imageSrc));
+			$el.attr('src', $el.attr('src').replace(imageSrc, imageSrcEncoded));
+		}
 		return $el;
 	});
 	return $;

--- a/test/server/stylesheets/external-image.test.js
+++ b/test/server/stylesheets/external-image.test.js
@@ -78,29 +78,4 @@ describe('External images', function () {
 			});
 	});
 
-	it('should encode a ? in an external url', function() {
-	 return transform(
-		 '<html>' +
-			 '<body>' +
-				 '<p>test test test</p>' +
-				 '<p><img src="http://markets.ft.com/ChartBuilder?t=indices&p=eYjhj93245"></img>Chart from chart builder.</p>' +
-			 '</body>' +
-		 '</html>',
-		 {
-			 fullWidthMainImages: 0
-		 }
-	 )
-	 .then(function (transformedXml) {
-		 transformedXml.should.equal(
-			 '<body>' +
-				 '<p>test test test</p>' +
-				 '<p>' +
-					 '<img alt="" src="https://next-geebee.ft.com/image/v1/images/raw/http://markets.ft.com/ChartBuilder%3Ft=indices&amp;p=eYjhj93245?source=next&amp;fit=scale-down&amp;width=710" class="article__image ng-inline-element ng-pull-out">' +
-					 'Chart from chart builder.' +
-				 '</p>' +
-			 '</body>\n'
-		 );
-	 });
-	});
-
 });

--- a/test/server/transforms/external-images.test.js
+++ b/test/server/transforms/external-images.test.js
@@ -7,22 +7,38 @@ require('chai').should();
 
 describe('External Images', function() {
 
-  it('should double encode spaces in src of external image urls', function() {
-    var $ = cheerio.load(
-      '<body>' +
-        '<p>test test test</p>' +
-        '<figure class="article__image-wrapper article__inline-image ng-figure-reset ng-inline-element ng-pull-out">' +
-        '<img alt="" src="https://next-geebee.ft.com/image/v1/images/raw/http://clamo.ftdata.co.uk/files/2015-07/21/FT%20Dow%20Stock%20Moves%20IBM%20UTX%207-21-15.png?source=next&fit=scale-down&width=710">' +
-        '</figure>' +
-      '</body>');
-    $ = externalImagesTransform($);
-		$.html().should.equal(
-      '<body>' +
-        '<p>test test test</p>' +
-        '<figure class="article__image-wrapper article__inline-image ng-figure-reset ng-inline-element ng-pull-out">' +
-        '<img alt="" src="https://next-geebee.ft.com/image/v1/images/raw/http%3A%2F%2Fclamo.ftdata.co.uk%2Ffiles%2F2015-07%2F21%2FFT%2520Dow%2520Stock%2520Moves%2520IBM%2520UTX%25207-21-15.png?source=next&amp;fit=scale-down&amp;width=710">' +
-        '</figure>' +
-      '</body>');
-  	});
+	it('should double encode spaces in src of external image urls', function() {
+		var $ = cheerio.load(
+			'<body>' +
+				'<p>test test test</p>' +
+				'<figure class="article__image-wrapper article__inline-image ng-figure-reset ng-inline-element ng-pull-out">' +
+					'<img alt="" src="https://next-geebee.ft.com/image/v1/images/raw/http://clamo.ftdata.co.uk/files/2015-07/21/FT%20Dow%20Stock%20Moves%20IBM%20UTX%207-21-15.png?source=next&fit=scale-down&width=710">' +
+				'</figure>' +
+			'</body>'
+		);
+		var transformed$ = externalImagesTransform($);
+		transformed$.html().should.equal(
+			'<body>' +
+				'<p>test test test</p>' +
+				'<figure class="article__image-wrapper article__inline-image ng-figure-reset ng-inline-element ng-pull-out">' +
+					'<img alt="" src="https://next-geebee.ft.com/image/v1/images/raw/http%3A%2F%2Fclamo.ftdata.co.uk%2Ffiles%2F2015-07%2F21%2FFT%2520Dow%2520Stock%2520Moves%2520IBM%2520UTX%25207-21-15.png?source=next&amp;fit=scale-down&amp;width=710">' +
+				'</figure>' +
+			'</body>'
+		);
+	});
+
+	it('should unescape html entites before encoding', function() {
+		var $ = cheerio.load(
+			'<body>' +
+				'<img alt="" src="https://next-geebee.ft.com/image/v1/images/raw/http://markets.ft.com/Research/API/ChartBuilder?t=equities&amp;p=eyJzeW1ib2wiOiIyNDQ1Nzl8NTcyMDA5IiwicmVnaW9uIjpudWxsLCJoZWlnaHQiOiIzMzgiLCJ3aWR0aCI6IjYwMCIsImxpbmVTdHlsZSI6ImxpbmUiLCJkdXJhdGlvbiI6IjUiLCJzdGFydERhdGUiOm51bGwsImVuZERhdGUiOm51bGwsInByaW1hcnlMYWJlbCI6IlJSLjpMU0UiLCJzZWNvbmRhcnlMYWJlbCI6IkZUU0UgMTAwIiwidGVydGlhcnlMYWJlbCI6bnVsbCwicXVhdGVybmFyeUxhYmVsIjpudWxsLCJpc01vYmlsZSI6ZmFsc2UsIlNob3dEaXNjbGFpbWVyIjp0cnVlLCJ1bml0IjoicHgifQ==?source=next&fit=scale-down&width=710">' +
+			'</body>'
+		);
+		var transformed$ = externalImagesTransform($);
+		transformed$.html().should.equal(
+			'<body>' +
+				'<img alt="" src="https://next-geebee.ft.com/image/v1/images/raw/http%3A%2F%2Fmarkets.ft.com%2FResearch%2FAPI%2FChartBuilder%3Ft%3Dequities%26p%3DeyJzeW1ib2wiOiIyNDQ1Nzl8NTcyMDA5IiwicmVnaW9uIjpudWxsLCJoZWlnaHQiOiIzMzgiLCJ3aWR0aCI6IjYwMCIsImxpbmVTdHlsZSI6ImxpbmUiLCJkdXJhdGlvbiI6IjUiLCJzdGFydERhdGUiOm51bGwsImVuZERhdGUiOm51bGwsInByaW1hcnlMYWJlbCI6IlJSLjpMU0UiLCJzZWNvbmRhcnlMYWJlbCI6IkZUU0UgMTAwIiwidGVydGlhcnlMYWJlbCI6bnVsbCwicXVhdGVybmFyeUxhYmVsIjpudWxsLCJpc01vYmlsZSI6ZmFsc2UsIlNob3dEaXNjbGFpbWVyIjp0cnVlLCJ1bml0IjoicHgifQ%3D%3D?source=next&amp;fit=scale-down&amp;width=710">' +
+			'</body>'
+		);
+	});
 
 });


### PR DESCRIPTION
Query string was being encoded twice - now all encoding occurs in `transforms/external-images.js`. 

Also, inline images' urls contain html entities - these need to be unencoded before sending to the image service