### PR TITLE
Try forcing old bower version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "superstore": "^1.0.0"
   },
   "devDependencies": {
+    "bower": "1.4.1",
     "chai": "^2.0.0",
     "debowerify": "^1.3.1",
     "es6-promise": "^2.1.1",


### PR DESCRIPTION
/cc @ironsidevsquincy Can do this in the meantime, so all the builds aren't blocked whilst we update component dependencies