### PR TITLE
Design unification - header

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,6 +35,7 @@
     "next-buttons": "^2.1.0",
     "next-myft-ui": "^3.0.0",
     "o-buttons": "v3",
-    "next-card": "^6.1.0"
+    "next-card": "^6.1.0",
+    "next-feature-flags-client": "^v8.0.0"
   }
 }

--- a/client/components/article/_main.scss
+++ b/client/components/article/_main.scss
@@ -1,13 +1,9 @@
-//VARIABLES
-$header-offset: 30px;
-
 //ARTICLE HEADER
 .article__header {
-	background: oColorsGetPaletteColor(cold-2);
+	background: oColorsGetPaletteColor('pink');
 	position: relative;
-	padding-bottom: 20px;
+	padding-bottom: 15px;
 	font-weight: 100;
-	color: #ffffff;
 
 	@include print {
 		color: #000000;
@@ -21,15 +17,25 @@ $header-offset: 30px;
 		display: flex;
 	}
 }
-.article__header--overlap {
-	padding-bottom: $header-offset + 20;
-}
+
 .article__header-secondary {
-	border-left: 1px solid #ffffff;
 	margin-top: $spacing-unit / 2;
-	padding-left: $spacing-unit / 2;
 	@include print {
 		border-color: #000000;
+	}
+}
+
+.article__header-time-byline {
+	@include oGridRespondTo(M) {
+		width: 75%;
+		display: inline-block;
+	}
+}
+
+.article__header-actions {
+	@include oGridRespondTo(M) {
+		max-width: 25%;
+		display: inline-block;
 	}
 }
 
@@ -46,10 +52,10 @@ $header-offset: 30px;
 	}
 }
 .article__title {
-	@include nTypeAlpha(2);
+	@include nTypeFoxtrot(2);
 	margin: 0;
 	@include oGridRespondTo(L) {
-		@include nTypeAlphaSize(1);
+		@include nTypeFoxtrotSize(1);
 	}
 }
 .article__stand-first {
@@ -88,7 +94,7 @@ $header-offset: 30px;
 	}
 }
 .article__primary-theme {
-	@include nTypeBravo(4);
+	@include nLinksTopic;
 	margin: 0;
 	@include print {
 		display: none;
@@ -96,7 +102,9 @@ $header-offset: 30px;
 }
 .article__actions {
 	margin-top: 10px;
-	@include oGridRespondTo(L) {
+	text-align: left;
+	@include oGridRespondTo(M) {
+		margin-top: 0;
 		text-align: right;
 	}
 	@include print {
@@ -138,9 +146,9 @@ $header-offset: 30px;
 	}
 }
 .article__tag {
-	@include nListsItem($use-case: n-lists-inversed);
+	@include nListsItem($use-case: n-lists);
 	&:first-child {
-		border-top: 1px solid #ffffff;
+		border-top: 1px solid rgba(0, 0, 0, 0.25);
 	}
 }
 
@@ -188,16 +196,6 @@ $header-offset: 30px;
 
 	.o-quote--standard a {
 		color: inherit;
-	}
-	> {
-		.article__main-image,
-		a > .article__main-image,
-		.article__video-wrapper:first-child,
-		.article__gallery:first-child {
-			margin-top: -$header-offset - 15;
-			//HACK to allow for expected image not being returned
-			min-height: $header-offset + 15;
-		}
 	}
 }
 .article__main-image {

--- a/client/components/article/_main.scss
+++ b/client/components/article/_main.scss
@@ -74,7 +74,7 @@
 	margin: 0;
 }
 .article__author {
-	@include nLinksTopic($inversed: true);
+	@include nLinksTopic();
 	@include nTypeBravo(4);
 	font-style: normal;
 }
@@ -94,7 +94,6 @@
 	}
 }
 .article__primary-theme {
-	@include nLinksTopic;
 	margin: 0;
 	@include print {
 		display: none;
@@ -153,7 +152,7 @@
 }
 
 .article__primary-theme__link {
-	@include nLinksTopic($inversed: true);
+	@include nLinksTopic();
 }
 .article__main {
 	padding-top: 15px;

--- a/server/controllers/article.js
+++ b/server/controllers/article.js
@@ -125,9 +125,6 @@ module.exports = function(req, res, next) {
 						body: $.html(),
 						toc: $.html('.article__toc'),
 						isColumnist: isColumnist,
-						// if there's a main image, or slideshow or video, we overlap them on the header
-						headerOverlap:
-							$.root().children('.article__main-image, ft-slideshow:first-child, .article__video-wrapper:first-child').length || $.root().first().children('.article__main-image'),
 						layout: 'wrapper',
 						primaryTag: primaryTag,
 						save: {},
@@ -214,7 +211,6 @@ module.exports = function(req, res, next) {
 						viewModel.tags = null;
 						viewModel.relatedContent = null;
 						viewModel.moreOns = null;
-						viewModel.headerOverlap = null;
 						viewModel.shareButtons = null;
 						viewModel.myFTTray = null;
 					}

--- a/views/article-v2.html
+++ b/views/article-v2.html
@@ -10,7 +10,7 @@
 {{/defineBlock}}
 
 <article id="site-content" role="main" class="article{{#if visualCat}} article--{{visualCat}}{{/if}}" data-content-id="{{id}}" data-content-sources="{{#if articleV1}}v1{{/if}} {{#if article}}v2{{/if}}" data-trackable="article" data-trackable-terminate>
-	<div class="article__header{{#if headerOverlap}} article__header--overlap{{/if}}" data-trackable="header">
+	<div class="article__header" data-trackable="header">
 		<div class="article__leaderboard-advert"></div>
 		<div class="article__header-inner o-grid-row">
 			{{#if barrier}}
@@ -40,24 +40,27 @@
 					{{#if articleV1.editorial.standFirst}}
 						<p class="article__stand-first">{{{articleV1.editorial.standFirst}}}</p>
 					{{/if}}
-
-					{{#if article.publishedDate}}
-						<time class="article__timestamp o-date" data-o-component="o-date" datetime="{{#dateformat}}{{article.publishedDate}}{{/dateformat}}" data-o-date-js>
-							{{#dateformat "dddd, d mmmm, yyyy"}}{{article.publishedDate}}{{/dateformat}}
-						</time>
-					{{/if}}
-					{{#if byline}}
-					<p class="article__byline">
-						by: {{{byline}}}
-					</p>
-					{{/if}}
+						<div class="article__header-time-byline">
+						{{#if article.publishedDate}}
+							<time class="article__timestamp o-date" data-o-component="o-date" datetime="{{#dateformat}}{{article.publishedDate}}{{/dateformat}}" data-o-date-js>
+								{{#dateformat "dddd, d mmmm, yyyy"}}{{article.publishedDate}}{{/dateformat}}
+							</time>
+						{{/if}}
+						{{#if byline}}
+							<p class="article__byline">
+								by: {{{byline}}}
+							</p>
+						{{/if}}
+						</div>
+						<div class="article__header-actions">
+						{{#if save}}
+							<div class="article__actions">
+								{{>next-myft-ui/templates/save-for-later contentId=id}}
+							</div>
+						{{/if}}
+						</div>
 					</div>
 				</header>
-				{{#if save}}
-					<div class="article__actions">
-						{{>next-myft-ui/templates/save-for-later contentId=id variant='inverse'}}
-					</div>
-				{{/if}}
 			</div>
 			{{#if tags}}
 				<aside class="article__tags" data-o-grid-colspan="hide L3 Loffset1" role="complementary">


### PR DESCRIPTION
To implement the design unification work on the article header;

**M to XL**
Before;
![screen shot 2015-08-24 at 16 41 19](https://cloud.githubusercontent.com/assets/8938227/9444502/1d910758-4a7f-11e5-8ab3-89737b6147e1.png)

After;
![screen shot 2015-08-24 at 16 45 41](https://cloud.githubusercontent.com/assets/8938227/9444614/b39ebdd0-4a7f-11e5-9821-c0250d3fc8e0.png)


**Default & Small**
Before;
![screen shot 2015-08-24 at 16 41 47](https://cloud.githubusercontent.com/assets/8938227/9444559/71132be0-4a7f-11e5-9d47-27255b15a00e.png)

After;
![screen shot 2015-08-24 at 16 46 12](https://cloud.githubusercontent.com/assets/8938227/9444618/bbc38766-4a7f-11e5-91ff-1b54975c7849.png)

Changes to article body background, topic links, and save button will be handled by their respective components across the site.

