### PR TITLE
design unification promoboxes

### DIFF
--- a/client/components/article/_promo-box-new.scss
+++ b/client/components/article/_promo-box-new.scss
@@ -1,7 +1,7 @@
 .promo-box {
 	margin-top: 25px;
 	padding: 10px;
-	background-color: oColorsGetPaletteColor('warm-2');
+	background-color: getColor('pink');
 	> .promo-box__title__wrapper {
 		margin-top: -45px;
 		margin-left: -10px;
@@ -55,10 +55,10 @@
 	display: inline-block;
 	padding: 5px 10px;
 	margin-bottom: 0;
+	color: getColor('white');
 	background-color: #f57323;
-	color: #ffffff;
 	a {
-		color: #ffffff;
+		color: getColor('white');
 		background-color: #f57323;
 		border-bottom: 0;
 	}
@@ -79,9 +79,9 @@
 }
 
 .promo-box__headline {
-	@include nTypeAlpha(2);
+	@include nTypeFoxtrot(2);
 	margin: 10px 0 0;
-	color: #000000;
+	color: getColor('cold-3');
 
 	@include oGridRespondTo(S) {
 		font-size: 32px;

--- a/server/stylesheets/links.xsl
+++ b/server/stylesheets/links.xsl
@@ -14,13 +14,10 @@
     </xsl:template>
 
     <xsl:template match="a|ft-content" mode="link">
-        <xsl:param name="href" />
-        <a href="{$href}" data-trackable="link">
-            <xsl:if test="not(ancestor-or-self::big-number|ancestor-or-self::promo-box)">
-                <xsl:attribute name="class">article__body__link</xsl:attribute>
-            </xsl:if>
-            <xsl:apply-templates />
-        </a>
+      <xsl:param name="href" />
+      <a href="{$href}" data-trackable="link" class="article__body__link">
+        <xsl:apply-templates />
+      </a>
     </xsl:template>
 
 </xsl:stylesheet>

--- a/test/server/stylesheets/big-number.test.js
+++ b/test/server/stylesheets/big-number.test.js
@@ -40,8 +40,8 @@ describe('Big Number', function () {
 				transformedXml.should.equal(
 					'<body>' +
 						'<div class="article__big-number ng-pull-out ng-inline-element o-big-number o-big-number--standard">' +
-							'<span class="o-big-number__title"><a href="http://next.ft.com/1b852d96-ced7-11e4-893d-00144feab7de" data-trackable="link">33m</a></span>' +
-							'<span class="o-big-number__content">These are <a href="http://next.ft.com/712943a2-cda3-11e4-8760-00144feab7de" data-trackable="link">powerful but fragile</a> emissaries of a culture that not even their descendants remember</span>' +
+							'<span class="o-big-number__title"><a href="http://next.ft.com/1b852d96-ced7-11e4-893d-00144feab7de" data-trackable="link" class="article__body__link">33m</a></span>' +
+							'<span class="o-big-number__content">These are <a href="http://next.ft.com/712943a2-cda3-11e4-8760-00144feab7de" data-trackable="link" class="article__body__link">powerful but fragile</a> emissaries of a culture that not even their descendants remember</span>' +
 						'</div>' +
 					'</body>\n'
 				);

--- a/test/server/stylesheets/promo-box.test.js
+++ b/test/server/stylesheets/promo-box.test.js
@@ -157,7 +157,7 @@ describe('Promo-boxes', function() {
 				transformedXml.should.equal(
 					'<body>' +
 						'<aside class="promo-box ng-pull-out ng-inline-element" data-trackable="promobox" role="complementary">' +
-							'<div class="promo-box__title__wrapper"><h3 class="promo-box__title"><a href="/c9175806-3054-11e5-8873-775ba7c2ea3d" data-trackable="link">Greece crisis tests start-ups’ staying power</a></h3></div>' +
+							'<div class="promo-box__title__wrapper"><h3 class="promo-box__title"><a href="/c9175806-3054-11e5-8873-775ba7c2ea3d" data-trackable="link" class="article__body__link">Greece crisis tests start-ups’ staying power</a></h3></div>' +
 						'</aside>' +
 					'</body>\n'
 				);
@@ -178,7 +178,7 @@ describe('Promo-boxes', function() {
 					'<body>' +
 						'<aside class="promo-box ng-pull-out ng-inline-element" data-trackable="promobox" role="complementary">' +
 							'<div class="promo-box__title__wrapper"><h3 class="promo-box__title">Related Content</h3></div>' +
-							'<h4 class="promo-box__headline"><a href="/c9175806-3054-11e5-8873-775ba7c2ea3d" data-trackable="link">Greece crisis tests start-ups’ staying power</a></h4>' +
+							'<h4 class="promo-box__headline"><a href="/c9175806-3054-11e5-8873-775ba7c2ea3d" data-trackable="link" class="article__body__link">Greece crisis tests start-ups’ staying power</a></h4>' +
 						'</aside>' +
 					'</body>\n'
 				);
@@ -383,7 +383,7 @@ describe('Promo-boxes', function() {
 				transformedXml.should.equal(
 					'<body>' +
 						'<aside class="article__promo-box ng-pull-out ng-inline-element" data-trackable="promobox" role="complementary">' +
-							'<h3 class="article__promo-box__title"><a href="/c9175806-3054-11e5-8873-775ba7c2ea3d" data-trackable="link">Greece crisis tests start-ups’ staying power</a></h3>' +
+							'<h3 class="article__promo-box__title"><a href="/c9175806-3054-11e5-8873-775ba7c2ea3d" data-trackable="link" class="article__body__link">Greece crisis tests start-ups’ staying power</a></h3>' +
 						'</aside>' +
 					'</body>\n'
 				);
@@ -400,7 +400,7 @@ describe('Promo-boxes', function() {
 				transformedXml.should.equal(
 					'<body>' +
 						'<aside class="article__promo-box ng-pull-out ng-inline-element" data-trackable="promobox" role="complementary">' +
-							'<h4 class="article__promo-box__headline"><a href="/c9175806-3054-11e5-8873-775ba7c2ea3d" data-trackable="link">Greece crisis tests start-ups’ staying power</a></h4>' +
+							'<h4 class="article__promo-box__headline"><a href="/c9175806-3054-11e5-8873-775ba7c2ea3d" data-trackable="link" class="article__body__link">Greece crisis tests start-ups’ staying power</a></h4>' +
 						'</aside>' +
 					'</body>\n'
 				);


### PR DESCRIPTION
Small updates to promobox styling as part of design unification

Before
![screen shot 2015-08-26 at 13 51 16](https://cloud.githubusercontent.com/assets/8938227/9493838/6595c90e-4bfa-11e5-818a-132ba9f9432c.png)

After
![screen shot 2015-08-26 at 13 43 04](https://cloud.githubusercontent.com/assets/8938227/9493837/65950a46-4bfa-11e5-811f-eb92e5d92e4b.png)
