### PR TITLE
next read - server side version of next read lead article

### DIFF
--- a/client/components/read-next/main.scss
+++ b/client/components/read-next/main.scss
@@ -1,0 +1,71 @@
+.article__standfirst {
+	@include nTypeBravo(2);
+}
+
+.next-up {
+	position: relative;
+	padding: 10px 10px 10px 25px;
+}
+
+.next-up__header {
+	margin-top: 10px;
+	padding-top: 15px;
+	border: 1px solid getColor('warm-3');
+}
+
+.next-up__intro {
+	@include nTypeFoxtrot(4);
+	position: absolute;
+	top: -20px;
+	left: 15px;
+	margin: 5px 0;
+	padding: 5px 10px;
+	background-color: getColor('warm-5');
+	color: getColor('cold-2');
+	font-weight: 900;
+	.next-up__bottom & {
+		@include nTypeFoxtrotSize(3);
+		left: -5px;
+		top: -25px;
+	}
+}
+
+.next-up__intro__header {
+	background-color: getColor('pink');
+}
+
+.next-up__headline {
+	@include nLinksHeadline;
+	@include nTypeFoxtrot(2);
+	position: relative;
+	color: getColor('cold-1');
+	text-decoration: none;
+	border-bottom: 0;
+	&::before {
+		content: '>';
+		speak: none;
+		position: absolute;
+		top: -2px;
+		left: -15px;
+	}
+}
+
+.next-up__timestamp {
+	@include nTypeAlpha(5);
+	color: oColorsGetColorFor(timestamp, text);
+	text-transform: uppercase;
+	white-space: nowrap;
+}
+
+.next-up__timestamp__more-recent {
+	color: getColor('claret-inverse');
+}
+
+.next-up__topic-link {
+	@include nLinksTopic;
+}
+
+.read-next__container {
+	margin-top: 40px;
+	border-top: 1px solid getColor('warm-3');
+}

--- a/client/main.scss
+++ b/client/main.scss
@@ -52,6 +52,7 @@ $o-comments-is-silent: false;
 @import "components/special-report/main";
 @import "components/related-toast/main";
 @import "components/suggested-reads/main";
+@import "components/read-next/main";
 
 @media print {
 	body > section,

--- a/package.json
+++ b/package.json
@@ -44,13 +44,14 @@
     "mocha": "^2.0.0",
     "myrtlejs": "^1.0.4",
     "next-build-tools": "^3.26.1",
-    "nightwatch": "^0.7.11",
+    "nightwatch": "~0.8.2",
     "nock": "^2.0.0",
     "node-mocks-http": "^1.4.3",
     "nodemon": "^1.3.5",
     "notify-saucelabs": "^1.0.1",
     "origami-build-tools": "^3.1.0",
     "request": "^2.55.0",
+    "rewire": "^2.3.4",
     "sinon": "^1.15.3"
   },
   "engines": {

--- a/readNextArticle2.json
+++ b/readNextArticle2.json
@@ -1,0 +1,23 @@
+{
+  "headline": "China eases limits on overseas debt",
+  "headlineLink": "/921d8c8e-5c47-11e5-a28b-50226830d644",
+  "lastUpdated": "2015-09-16T09:07:26Z",
+  "subheading": "Inbound fund controls loosened amid fears over capital outflows",
+  "topicName": "China Economic Slowdown",
+  "topicLink": "/stream/topicsId/NWIwYzgxZTgtZjc3MC00ODNkLWI1YjYtYTVhNGQ2OTNjYjVi-VG9waWNz",
+  "visualCategory": "default",
+  "image": {
+    "width": 972,
+    "mediaType": "image/jpeg",
+    "source": "AFP",
+    "type": "wide-format",
+    "url": "http://im.ft-static.com/content/images/0521f258-e325-4d8e-8cac-29e67523f43d.img",
+    "height": 547,
+    "srcset": {
+      "default": 100
+    },
+    "class": ""
+  },
+  "moreRecent": true,
+  "source": "topic"
+}

--- a/readNextArticle4.json
+++ b/readNextArticle4.json
@@ -1,0 +1,23 @@
+{
+  "headline": "China eases limits on overseas debt",
+  "headlineLink": "/921d8c8e-5c47-11e5-a28b-50226830d644",
+  "lastUpdated": "2015-09-16T09:07:26Z",
+  "subheading": "Inbound fund controls loosened amid fears over capital outflows",
+  "topicName": "China Economic Slowdown",
+  "topicLink": "/stream/topicsId/NWIwYzgxZTgtZjc3MC00ODNkLWI1YjYtYTVhNGQ2OTNjYjVi-VG9waWNz",
+  "visualCategory": "default",
+  "image": {
+    "width": 972,
+    "mediaType": "image/jpeg",
+    "source": "AFP",
+    "type": "wide-format",
+    "url": "http://im.ft-static.com/content/images/0521f258-e325-4d8e-8cac-29e67523f43d.img",
+    "height": 547,
+    "srcset": {
+      "default": 100
+    },
+    "class": ""
+  },
+  "moreRecent": true,
+  "source": "topic"
+}

--- a/server/lib/read-next.js
+++ b/server/lib/read-next.js
@@ -1,0 +1,76 @@
+"use strict";
+
+var articlePodMapping = require('../mappings/article-pod-mapping');
+var articleTopicMapping = require('../mappings/article-topic-mapping');
+var api = require('next-ft-api-client');
+
+module.exports = function(articleV1, useElasticSearch) {
+	var parent = articleV1;
+	var parentLastPublishedDateTime = parent.item.lifecycle.lastPublishDateTime;
+
+	var storyPackagePromise;
+	if (parent.item.package.length) {
+		storyPackagePromise = api.contentLegacy({
+			uuid: parent.item.package[0].id,
+			useElasticSearch: useElasticSearch
+		})
+		.then(function(storyPackageArticle) {
+			return articlePodMapping(storyPackageArticle);
+		})
+		.catch(function(error) {
+			return ;
+		});
+	}
+
+	var parentTopic = articleTopicMapping(parent.item.metadata);
+	var topicPromise;
+	if (parentTopic) {
+		topicPromise = api.searchLegacy({
+			query: parentTopic.taxonomy + 'Id:"' + parentTopic.id + '"',
+			count: 2,
+			fields: true,
+			useElasticSearch: useElasticSearch
+		})
+		.then(function(topicArticlesES) {
+			var topicArticle = topicArticlesES.map(function(topicArticleES) {
+				return topicArticleES._source;
+			})
+				.filter(function(topicArticle) {
+					return topicArticle.item.id !== parent.item.id;
+				})
+				.slice(0,1);
+			return articlePodMapping(topicArticle[0]);
+		})
+		.catch(function(error) {
+			return ;
+		});
+	}
+
+	return Promise.all([storyPackagePromise,topicPromise])
+		.then(function(results) {
+			var packageArticle = results[0];
+			if (packageArticle) {
+				packageArticle.source = "package";
+			}
+			var topicArticle = results[1];
+			if (!topicArticle && packageArticle) {
+					return packageArticle;
+			}
+			if (!topicArticle && !packageArticle) {
+				return ;
+			}
+			topicArticle.source = "topic";
+			// hierarchy of compellingness governing which read next article to return
+			// 1. return article with same topic as parent if more recent
+			if (new Date(topicArticle.lastUpdated) > new Date(parentLastPublishedDateTime)) {
+				topicArticle.moreRecent = true;
+				return topicArticle;
+			} else if (packageArticle) {
+			// 2. otherwise if story package return the first one
+				return packageArticle;
+			} else {
+			// 3. failing that return the article on the same topic
+				return topicArticle;
+			}
+		});
+};

--- a/server/mappings/article-pod-mapping.js
+++ b/server/mappings/article-pod-mapping.js
@@ -1,0 +1,35 @@
+"use strict";
+
+var getVisualCategory = require('ft-next-article-genre');
+var articleTopicMapping = require('../mappings/article-topic-mapping');
+
+module.exports = function(article, imageOptions) {
+	imageOptions = imageOptions || {
+		imageSrcset: { default: 100 },
+		imageClass: ""
+	};
+
+	var articleModel = {
+		headline: {
+			text: article.item.title.title,
+			url: '/' + article.item.id
+		},
+		lastUpdated: article.item.lifecycle.lastPublishDateTime,
+		subheading: article.item.editorial.subheading,
+		topic: articleTopicMapping(article.item.metadata),
+		visualCategory: getVisualCategory(article.item.metadata)
+	};
+	if (!article.item.images) {
+		return articleModel;
+	}
+	var images = {};
+	article.item.images.forEach(function(img) {
+		images[img.type] = img;
+	});
+	articleModel.image = images['wide-format'] || images.article || images.primary;
+	if (articleModel.image) {
+		articleModel.image.srcset = imageOptions.imageSrcset;
+		articleModel.image.class = imageOptions.imageClass;
+	}
+	return articleModel;
+};

--- a/server/mappings/article-topic-mapping.js
+++ b/server/mappings/article-topic-mapping.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = function(metadata) {
+	var tagToUse = metadata.primaryTheme;
+	if (!tagToUse) {
+		tagToUse = metadata.primarySection;
+	}
+	if (!tagToUse) {
+		return ;
+	}
+	tagToUse.term.url = '/stream/' +	tagToUse.term.taxonomy + 'Id/' + tagToUse.term.id;
+	return tagToUse.term;
+};

--- a/server/stylesheets/main.xsl
+++ b/server/stylesheets/main.xsl
@@ -33,12 +33,12 @@
     <xsl:include href="interactive-graphics.xsl" />
     <xsl:include href="internal-image.xsl" />
     <xsl:include href="links.xsl" />
+    <xsl:include href="paragraph-one.xsl" />
     <xsl:include href="promo-box.xsl" />
     <xsl:include href="pull-quotes.xsl" />
     <xsl:include href="related-inline.xsl" />
     <xsl:include href="slideshow.xsl" />
     <xsl:include href="subheaders.xsl" />
-    <xsl:include href="toc.xsl" />
     <xsl:include href="video.xsl" />
 
 </xsl:stylesheet>

--- a/server/stylesheets/paragraph-one.xsl
+++ b/server/stylesheets/paragraph-one.xsl
@@ -2,6 +2,11 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
     <xsl:template match="/html/body/p[1]">
+      <xsl:if test="$suggestedRead = 1">
+          <p class="article__standfirst">
+            <xsl:value-of select="$standFirst" />
+          </p>
+      </xsl:if>
         <xsl:apply-templates select="current()" mode="default" />
         <xsl:if test="$renderTOC = 1 and count(/html/body/h3[contains(@class, 'ft-subhead')]/strong) > 2">
             <div class="article__toc" data-trackable="table-of-contents">

--- a/test/fixtures/articlePodMapping/articlePodMappingStoryPackage.json
+++ b/test/fixtures/articlePodMapping/articlePodMappingStoryPackage.json
@@ -1,0 +1,30 @@
+{
+  "headline": {
+    "text": "Greece, democracy and the labour of Hercules",
+    "url": "/ae7fb5a2-52f4-11e5-8642-453585f2cfcd"
+  },
+  "lastUpdated": "2015-09-06T14:40:10Z",
+  "subheading": "Elections are fine but what matters is a sincere reform effort",
+  "topic": {
+    "attributes": [],
+    "name": "Greece Politics",
+    "id": "MTJmY2U0ZTQtZDU5Ni00ZGY0LTg5NGItMTJjMTkwM2ZkZWJj-VG9waWNz",
+    "taxonomy": "topics",
+    "url": "/stream/topicsId/MTJmY2U0ZTQtZDU5Ni00ZGY0LTg5NGItMTJjMTkwM2ZkZWJj-VG9waWNz"
+  },
+  "visualCategory": "default",
+  "image": {
+    "alt": "Snap elections in Greece...epa04903313 Outgoing Greek Prime Minister and leader of SYRIZA party Alexis Tsipras delivers his speech during a nationwide meeting of his party in Athens, Greece, 29 August 2015. Elections will be held on 20 September 2015. EPA/YANNIS KOLESIDIS",
+    "width": 972,
+    "caption": "Alexis Tsipras",
+    "mediaType": "image/jpeg",
+    "source": "EPA",
+    "type": "wide-format",
+    "url": "http://im.ft-static.com/content/images/6a972f19-355a-4a96-8b11-66479c636a8b.img",
+    "height": 547,
+    "srcset": {
+      "default": 100
+    },
+    "class": ""
+  }
+}

--- a/test/fixtures/articlePodMapping/suggestedReadStoryPackageArticle.json
+++ b/test/fixtures/articlePodMapping/suggestedReadStoryPackageArticle.json
@@ -1,0 +1,466 @@
+{
+  "requestUrl": "http://api.ft.com/content/items/v1/ae7fb5a2-52f4-11e5-8642-453585f2cfcd?feature.blogposts=on&h=6464909518",
+  "item": {
+    "aspectSet": "article",
+    "aspects": [
+      "assets",
+      "body",
+      "editorial",
+      "images",
+      "lifecycle",
+      "location",
+      "master",
+      "mediaAssets",
+      "metadata",
+      "package",
+      "packaging",
+      "provenance",
+      "summary",
+      "title"
+    ],
+    "modelVersion": "1",
+    "id": "ae7fb5a2-52f4-11e5-8642-453585f2cfcd",
+    "apiUrl": "http://api.ft.com/content/items/v1/ae7fb5a2-52f4-11e5-8642-453585f2cfcd",
+    "title": {
+      "title": "Greece, democracy and the labour of Hercules"
+    },
+    "body": {
+      "mediaType": "text/html",
+      "body": "<p><a title=\"Greece politics related stories - FT.com\" href=\"http://www.ft.com/topics/themes/Greece_Politics\">Greece</a>, the eurozone’s inveterately delinquent pupil, is top of the class when it comes to consulting the will of the people. The parliamentary election scheduled for September 20 will mark the fifth time since October 2009 that voters have been asked to choose a new government. Include July’s referendum on what emerged as <a title=\"Greece Debt Crisis in-depth - FT.com\" href=\"http://www.ft.com/indepth/greece-debt-crisis\">Greece’s third emergency financial rescue</a>, and that makes six nationwide exercises in democracy in as many years. No country in the world matches this record.</p>\n<p>Greece’s European creditors are putting a brave face on the election, suggesting that it will produce a clear mandate for the next government to carry out the reforms demanded for the €86bn bailout. Back in the real world, matters look rather different. The election campaign paints a picture of a nation pulverised by economic distress and mistrustful both of the incompetent political elites that created Greece’s disaster and of the tattered radical alternative represented by Syriza, the leftist party led by <a title=\"Alexis through the looking-glass world of Greek politics - FT.com\" href=\"http://www.ft.com/cms/s/0/6e5d6d4e-5226-11e5-8642-453585f2cfcd.html#axzz3kx7iKnMp\">Alexis Tsipras</a>, the former premier.</p>\n<p>Voters have every right to be suspicious. In Mr Tsipras they see a leader who swept to power in January promising to end austerity and slash foreign supervision of Greek economic policy. He asked them to reaffirm this stance in the referendum and won an emphatic victory. Then he performed a stupefying somersault and signed up to exactly the type of aid-for-reform programme that he had denounced so passionately on his path to power.</p>\n<p>It is unsurprising that many Greeks, especially young voters, are losing faith in a politician who asks them to support policies that are the polar opposite of what he stood for eight months ago. Moreover, thoughtful voters appreciate that the Syriza government’s irresponsible conduct resulted in bailout terms more onerous than Mr Tsipras would have secured had he negotiated in better faith with the creditors, and in the imposition of capital controls that cripple the Greek economy. </p>\n<p>As for New Democracy, the conservative party that is the only serious challenger to Syriza, it acts and sounds like a political force still exhausted after its two-and-a-half year spell in power between June 2012 and January this year. The party has yet to complete the renewal of its leadership made necessary by the resignation in July of Antonis Samaras, former prime minister. To its surprise, New Democracy may find itself propelled into government at just the moment when it might have preferred Mr Tsipras and his fellow leftists to shoulder the burden of implementing another politically contentious, foreign-dictated reform plan.</p>\n<p>It appears certain that the winner of the Greek election, be it Syriza or New Democracy, will fall short of an outright parliamentary majority and will therefore need to govern with at least one coalition partner. Whether such an outcome will yield a government stable, skilled and confident enough to satisfy the conditions set by Greece’s European creditors remains to be seen. </p>\n<p>All Greek governments since 2009 — centre-left, technocratic, centre-right and radical leftist — have struggled to root out corruption, modernise the public administration and loosen the grip of oligarchs on the economy.</p>\n<p>It will be a labour of Hercules but the next government must make an effort. For one thing, this will persuade the creditors to grant timely, substantial debt relief, essential for long-term economic recovery. For another, the latest bailout will surely be Greece’s last. Two months ago, the threat of being dumped out of the eurozone loomed as a real possibility. Next time, in the absence of a sincere reform effort, this threat will be deadly serious.</p>\n"
+    },
+    "lifecycle": {
+      "initialPublishDateTime": "2015-09-06T14:40:10Z",
+      "lastPublishDateTime": "2015-09-06T14:40:10Z"
+    },
+    "location": {
+      "uri": "http://www.ft.com/cms/s/0/ae7fb5a2-52f4-11e5-8642-453585f2cfcd.html"
+    },
+    "summary": {
+      "excerpt": "Elections are fine but what matters is a sincere reform effort"
+    },
+    "packaging": {
+      "spHeadline": "Greece, democracy and labours of Hercules"
+    },
+    "master": {
+      "masterSource": "Methode",
+      "masterEntityId": "ae7fb5a2-52f4-11e5-8642-453585f2cfcd"
+    },
+    "editorial": {
+      "otherTitles": [
+        "Greece, democracy and labours of Hercules"
+      ],
+      "subheading": "Elections are fine but what matters is a sincere reform effort",
+      "standFirst": "Elections are fine but what matters is a sincere reform effort"
+    },
+    "provenance": {
+      "originatingParty": "FT"
+    },
+    "metadata": {
+      "primarySection": {
+        "term": {
+          "name": "FT View",
+          "id": "MDRkMzU4YjktMjA0OS00MWEzLWJiY2ItYmJkZWNhMmVmMzQ0-QnJhbmRz",
+          "attributes": [],
+          "taxonomy": "brand"
+        }
+      },
+      "primaryTheme": {
+        "term": {
+          "name": "Greece Politics",
+          "id": "MTJmY2U0ZTQtZDU5Ni00ZGY0LTg5NGItMTJjMTkwM2ZkZWJj-VG9waWNz",
+          "attributes": [],
+          "taxonomy": "topics"
+        }
+      },
+      "tags": [
+        {
+          "term": {
+            "name": "Greece Politics",
+            "attributes": [],
+            "id": "MTJmY2U0ZTQtZDU5Ni00ZGY0LTg5NGItMTJjMTkwM2ZkZWJj-VG9waWNz",
+            "taxonomy": "topics"
+          }
+        },
+        {
+          "term": {
+            "name": "FT View",
+            "attributes": [],
+            "id": "MDRkMzU4YjktMjA0OS00MWEzLWJiY2ItYmJkZWNhMmVmMzQ0-QnJhbmRz",
+            "taxonomy": "brand"
+          }
+        },
+        {
+          "term": {
+            "name": "Comment",
+            "attributes": [],
+            "id": "OA==-R2VucmVz",
+            "taxonomy": "genre"
+          }
+        },
+        {
+          "term": {
+            "name": "Text",
+            "attributes": [],
+            "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+            "taxonomy": "mediaType"
+          }
+        },
+        {
+          "term": {
+            "name": "11003000 - election",
+            "attributes": [],
+            "id": "MTEwMDMwMDA=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "11006009 - ministers (government)",
+            "attributes": [],
+            "id": "MTEwMDYwMDk=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "11010000 - parties and movements",
+            "attributes": [],
+            "id": "MTEwMTAwMDA=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "Syriza",
+            "attributes": [
+              {
+                "value": "false",
+                "key": "is_company"
+              }
+            ],
+            "id": "ZjczODAyMzItMzdiNy00N2NlLThjNWQtODNjNDAzNTdmNmQ2-T04=",
+            "taxonomy": "organisations"
+          }
+        },
+        {
+          "term": {
+            "name": "Antonis Samaras",
+            "attributes": [],
+            "id": "TnN0ZWluX1BOX1BvbGl0aWNpYW5zXzIwMDlfMTBfMl80ODkyNw==-UE4=",
+            "taxonomy": "people"
+          }
+        },
+        {
+          "term": {
+            "name": "Alexis Tsipras",
+            "attributes": [],
+            "id": "TnN0ZWluX1BOX1BvbGl0aWNpYW5zXzIwMDlfMTBfMl81NTEzNA==-UE4=",
+            "taxonomy": "people"
+          }
+        },
+        {
+          "term": {
+            "name": "Greece",
+            "attributes": [],
+            "id": "TnN0ZWluX0dMX0dS-R0w=",
+            "taxonomy": "regions"
+          }
+        },
+        {
+          "term": {
+            "name": "Opinion",
+            "attributes": [
+              {
+                "value": "opinion",
+                "key": "dfpSite"
+              }
+            ],
+            "id": "MTE2-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Politics",
+            "attributes": [],
+            "id": "MTAx-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "Political Parties",
+            "attributes": [],
+            "id": "MTAy-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "General News",
+            "attributes": [],
+            "id": "MTE4-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "Comment & Analysis",
+            "attributes": [],
+            "id": "MTIz-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "Elections",
+            "attributes": [],
+            "id": "OTA=-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "Greece Debt Crisis",
+            "attributes": [],
+            "id": "ZmEzMmRmNDAtNDc0Zi00ODk3LWE2ZmQtZWFmYzJlZTRjZTVk-VG9waWNz",
+            "taxonomy": "topics"
+          }
+        }
+      ],
+      "authors": [],
+      "brand": [
+        {
+          "term": {
+            "name": "FT View",
+            "attributes": [],
+            "id": "MDRkMzU4YjktMjA0OS00MWEzLWJiY2ItYmJkZWNhMmVmMzQ0-QnJhbmRz",
+            "taxonomy": "brand"
+          }
+        }
+      ],
+      "genre": [
+        {
+          "term": {
+            "name": "Comment",
+            "attributes": [],
+            "id": "OA==-R2VucmVz",
+            "taxonomy": "genre"
+          }
+        }
+      ],
+      "icb": [],
+      "iptc": [
+        {
+          "term": {
+            "name": "11003000 - election",
+            "attributes": [],
+            "id": "MTEwMDMwMDA=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "11006009 - ministers (government)",
+            "attributes": [],
+            "id": "MTEwMDYwMDk=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "11010000 - parties and movements",
+            "attributes": [],
+            "id": "MTEwMTAwMDA=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        }
+      ],
+      "mediaType": [
+        {
+          "term": {
+            "name": "Text",
+            "attributes": [],
+            "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+            "taxonomy": "mediaType"
+          }
+        }
+      ],
+      "organisations": [
+        {
+          "term": {
+            "name": "Syriza",
+            "attributes": [
+              {
+                "value": "false",
+                "key": "is_company"
+              }
+            ],
+            "id": "ZjczODAyMzItMzdiNy00N2NlLThjNWQtODNjNDAzNTdmNmQ2-T04=",
+            "taxonomy": "organisations"
+          }
+        }
+      ],
+      "people": [
+        {
+          "term": {
+            "name": "Antonis Samaras",
+            "attributes": [],
+            "id": "TnN0ZWluX1BOX1BvbGl0aWNpYW5zXzIwMDlfMTBfMl80ODkyNw==-UE4=",
+            "taxonomy": "people"
+          }
+        },
+        {
+          "term": {
+            "name": "Alexis Tsipras",
+            "attributes": [],
+            "id": "TnN0ZWluX1BOX1BvbGl0aWNpYW5zXzIwMDlfMTBfMl81NTEzNA==-UE4=",
+            "taxonomy": "people"
+          }
+        }
+      ],
+      "regions": [
+        {
+          "term": {
+            "name": "Greece",
+            "attributes": [],
+            "id": "TnN0ZWluX0dMX0dS-R0w=",
+            "taxonomy": "regions"
+          }
+        }
+      ],
+      "sections": [
+        {
+          "term": {
+            "name": "Opinion",
+            "attributes": [
+              {
+                "value": "opinion",
+                "key": "dfpSite"
+              }
+            ],
+            "id": "MTE2-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        }
+      ],
+      "specialReports": [],
+      "subjects": [
+        {
+          "term": {
+            "name": "Politics",
+            "attributes": [],
+            "id": "MTAx-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "Political Parties",
+            "attributes": [],
+            "id": "MTAy-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "General News",
+            "attributes": [],
+            "id": "MTE4-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "Comment & Analysis",
+            "attributes": [],
+            "id": "MTIz-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "Elections",
+            "attributes": [],
+            "id": "OTA=-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        }
+      ],
+      "topics": [
+        {
+          "term": {
+            "name": "Greece Politics",
+            "attributes": [],
+            "id": "MTJmY2U0ZTQtZDU5Ni00ZGY0LTg5NGItMTJjMTkwM2ZkZWJj-VG9waWNz",
+            "taxonomy": "topics"
+          }
+        },
+        {
+          "term": {
+            "name": "Greece Debt Crisis",
+            "attributes": [],
+            "id": "ZmEzMmRmNDAtNDc0Zi00ODk3LWE2ZmQtZWFmYzJlZTRjZTVk-VG9waWNz",
+            "taxonomy": "topics"
+          }
+        }
+      ]
+    },
+    "images": [
+      {
+        "alt": "Snap elections in Greece...epa04903313 Outgoing Greek Prime Minister and leader of SYRIZA party Alexis Tsipras delivers his speech during a nationwide meeting of his party in Athens, Greece, 29 August 2015. Elections will be held on 20 September 2015. EPA/YANNIS KOLESIDIS",
+        "width": 272,
+        "caption": "Alexis Tsipras",
+        "mediaType": "image/jpeg",
+        "source": "EPA",
+        "type": "primary",
+        "url": "http://im.ft-static.com/content/images/de48ab99-d555-4e13-91c8-516a75cdd0e6.img",
+        "height": 153
+      },
+      {
+        "alt": "Snap elections in Greece...epa04903313 Outgoing Greek Prime Minister and leader of SYRIZA party Alexis Tsipras delivers his speech during a nationwide meeting of his party in Athens, Greece, 29 August 2015. Elections will be held on 20 September 2015. EPA/YANNIS KOLESIDIS",
+        "width": 167,
+        "caption": "Alexis Tsipras",
+        "mediaType": "image/jpeg",
+        "source": "EPA",
+        "type": "secondary",
+        "url": "http://im.ft-static.com/content/images/b7c21a29-393a-42c1-9a4f-fce195f4cedd.img",
+        "height": 94
+      },
+      {
+        "alt": "Snap elections in Greece...epa04903313 Outgoing Greek Prime Minister and leader of SYRIZA party Alexis Tsipras delivers his speech during a nationwide meeting of his party in Athens, Greece, 29 August 2015. Elections will be held on 20 September 2015. EPA/YANNIS KOLESIDIS",
+        "width": 600,
+        "caption": "Alexis Tsipras",
+        "mediaType": "image/jpeg",
+        "source": "EPA",
+        "type": "article",
+        "url": "http://im.ft-static.com/content/images/ef0a3525-c338-4b4a-b1f8-c82e4050c8ad.img",
+        "height": 338
+      },
+      {
+        "alt": "Snap elections in Greece...epa04903313 Outgoing Greek Prime Minister and leader of SYRIZA party Alexis Tsipras delivers his speech during a nationwide meeting of his party in Athens, Greece, 29 August 2015. Elections will be held on 20 September 2015. EPA/YANNIS KOLESIDIS",
+        "width": 414,
+        "caption": "Alexis Tsipras",
+        "mediaType": "image/jpeg",
+        "source": "EPA",
+        "type": "leader",
+        "url": "http://im.ft-static.com/content/images/c007b0d7-7942-45a0-9d77-35f5bf5a6f54.img",
+        "height": 233
+      },
+      {
+        "alt": "Snap elections in Greece...epa04903313 Outgoing Greek Prime Minister and leader of SYRIZA party Alexis Tsipras delivers his speech during a nationwide meeting of his party in Athens, Greece, 29 August 2015. Elections will be held on 20 September 2015. EPA/YANNIS KOLESIDIS",
+        "width": 972,
+        "caption": "Alexis Tsipras",
+        "mediaType": "image/jpeg",
+        "source": "EPA",
+        "type": "wide-format",
+        "url": "http://im.ft-static.com/content/images/6a972f19-355a-4a96-8b11-66479c636a8b.img",
+        "height": 547
+      }
+    ],
+    "package": [],
+    "assets": [],
+    "mediaAssets": []
+  },
+  "_lastUpdatedDateTime": "2015-09-07T17:57:23.797Z"
+}

--- a/test/fixtures/articleTopicMapping/metadata-has-no-primaries.json
+++ b/test/fixtures/articleTopicMapping/metadata-has-no-primaries.json
@@ -1,0 +1,11 @@
+{
+  "tags": [
+    {
+    "term": {
+      "name": "US Politics & Policy",
+      "id": "Mw==-U2VjdGlvbnM=",
+      "attributes": [ ],
+      "taxonomy": "sections"
+    }
+  }]
+}

--- a/test/fixtures/articleTopicMapping/metadata-has-primary-section.json
+++ b/test/fixtures/articleTopicMapping/metadata-has-primary-section.json
@@ -1,0 +1,19 @@
+{
+  "primarySection": {
+    "term": {
+      "name": "US Politics & Policy",
+      "id": "Mw==-U2VjdGlvbnM=",
+      "attributes": [ ],
+      "taxonomy": "sections"
+    }
+  },
+  "tags": [
+    {
+    "term": {
+      "name": "US Politics & Policy",
+      "id": "Mw==-U2VjdGlvbnM=",
+      "attributes": [ ],
+      "taxonomy": "sections"
+    }
+  }]
+}

--- a/test/fixtures/articleTopicMapping/metadata-has-primary-theme.json
+++ b/test/fixtures/articleTopicMapping/metadata-has-primary-theme.json
@@ -1,0 +1,27 @@
+{
+  "primarySection": {
+    "term": {
+      "name": "US Politics & Policy",
+      "id": "Mw==-U2VjdGlvbnM=",
+      "attributes": [ ],
+      "taxonomy": "sections"
+    }
+  },
+  "primaryTheme": {
+    "term": {
+      "name": "US presidential election",
+      "id": "MGUzYTRlZTAtNGMwNS00MjhkLWJhMzMtNTg5MTA5ZDA3NTMx-VG9waWNz",
+      "attributes": [ ],
+      "taxonomy": "topics"
+    }
+  },
+  "tags": [
+    {
+    "term": {
+      "name": "US Politics & Policy",
+      "id": "Mw==-U2VjdGlvbnM=",
+      "attributes": [ ],
+      "taxonomy": "sections"
+    }
+  }]
+}

--- a/test/fixtures/readNext/parentArticle1.json
+++ b/test/fixtures/readNext/parentArticle1.json
@@ -1,0 +1,742 @@
+{
+  "requestUrl": "http://api.ft.com/content/items/v1/1438c26a-57d4-11e5-97e9-7f0bf5e7177b?feature.blogposts=on&h=4093377336",
+  "item": {
+    "aspectSet": "article",
+    "aspects": [
+      "assets",
+      "body",
+      "editorial",
+      "images",
+      "lifecycle",
+      "location",
+      "master",
+      "mediaAssets",
+      "metadata",
+      "package",
+      "packaging",
+      "provenance",
+      "summary",
+      "title"
+    ],
+    "modelVersion": "1",
+    "id": "1438c26a-57d4-11e5-97e9-7f0bf5e7177b",
+    "apiUrl": "http://api.ft.com/content/items/v1/1438c26a-57d4-11e5-97e9-7f0bf5e7177b",
+    "title": {
+      "title": "Apple TV wants viewers to change channel"
+    },
+    "body": {
+      "mediaType": "text/html",
+      "body": "<p>Apple made its first steps into two huge new markets in 2007. One product would go on to reshape the technology industry, bringing entrenched rivals to their knees and propelling Apple to become the world’s most valuable company. The other has failed to revolutionise much of anything, despite a reboot in 2010. </p>\n<p>The contrasting fortunes of the <a title=\"Apple TV and iPad revamp with new iPhone 6S - FT.com\" href=\"http://www.ft.com/cms/s/0/33012b18-5713-11e5-9846-de406ccb37f2.html#slide0\">iPhone</a> and Apple TV were brought into focus on Wednesday by chief executive Tim Cook himself, as he insisted that — this time — Apple really was serious about transforming television.</p>\n<p>“The television experience has been virtually standing still while innovation has been thriving in the mobile space,” he said at Apple’s launch event in San Francisco. </p>\n<p>Mr Cook is hoping that <a title=\"Apple news headlines - FT.com\" href=\"http://www.ft.com/topics/organisations/Apple_Inc\">Apple</a> can use the iPhone’s playbook of apps, games and Siri to repeat the success of its smartphone. “Our vision for TV is simple, and perhaps a little provocative. We believe the future of television is apps,” he said.</p>\n<p>For some, this future has been a long time coming. It is four years since Steve Jobs, Apple’s co-founder, told his biographer Walter Isaacson that he had “finally cracked it” with an easy-to-use, cloud-connected television set. Even Mr Cook acknowledged that Apple had been working “really hard — and really long — to bring all these things together”. </p>\n<p>“Because of the long wait and because we didn’t talk about content today, it felt like the audience wasn’t as excited about Apple TV as some of the other announcements,” says Carolina Milanesi, chief of research at Kantar Worldpanel ComTech. </p>\n<p>But for others in the media industry, Apple’s arrival brings mixed feelings. “I’d say a little more exciting than terrifying but terrifying if you want to worry about it ... I try to look on the bright side,” said Josh Sapan, chief executive of AMC Networks, told Recode on Wednesday.</p>\n<p>Apple’s clear statement of its ambitions may be more important than the technology it unveiled on Wednesday. </p>\n<p>In its features and functions, the new product largely sees the iPhone maker playing catch-up with the gaming, search and voice-control capabilities already available on competitors’ boxes such as Amazon’s Fire TV and the Android-based Nvidia Shield. </p>\n<p>The motion-sensitive remote control bears a strong resemblance to the Nintendo Wii gaming system, which was released a year before Apple made its first foray into the living room. </p>\n<p><img height=\"494\" alt=\"Video streaming\" width=\"600\" class=\"ft-web-inline-picture\" src=\"http://im.ft-static.com/content/images/2172f688-57d6-11e5-9846-de406ccb37f2.img\"/>\n</p>\n<p>That makes Mr Cook’s statement of intent all the more important.</p>\n<p>“We believe that the industry is facing a perfect storm: apps, App Stores and Apple,” says Simon Khalaf, senior vice-president at Yahoo, which acquired his mobile analytics company Flurry last year. Wednesday’s event sent a “warning shot at the cable industry in particular and the media industry in general”. </p>\n<p>Comparing Flurry’s analytics with US government figures on TV viewing, he says Americans spent an average of 198 minutes using apps every day in the second quarter, overtaking the typical 168 minutes watching TV. </p>\n<p>“If the content continues to move to apps and streamed over the wire, the cable industry will simply be squeezed and will lose its exclusive position as the sole distribution channel between media companies and US consumers,” Mr Khalaf said in a <a title=\"The Cable Industry Faces The Perfect Storm: Apps, App Stores and Apple - flurrymobile.tumblr.com\" href=\"http://flurrymobile.tumblr.com/post/128773968605/the-cable-industry-faces-the-perfect-storm-apps.\">blogpost</a>. </p>\n<aside data-asset-type=\"video\" data-asset-name=\"asset1\"></aside>\n\n<aside data-asset-type=\"promoBox\" data-asset-name=\"asset2\"></aside><p>\n</p>\n<p>The opportunity for Apple is not just in traditional programming. As a box focused on the online world rather than the traditional broadcast one, Apple TV could become the ideal platform for YouTube stars.  </p>\n<p>Frank Sinton, chief executive of Beachfront Media, says a number of YouTube “influencers” have contacted him about setting up their own Apple TV app in the run-up to the launch. Beachfront creates apps on platforms such as Amazon Fire for individual video creators such as fashion star Michelle Phan, who have built their followings on YouTube and then want to take their most loyal fans with them on to other platforms.  </p>\n<p>“That is the major shift: users consume TV by launching an app, not flipping a channel,” he says, adding that this allows for a richer and more interactive user experience.  </p>\n<p>Mr Sinton praises Apple for doing what “every smart TV has been trying to do for five years” by creating a simple and robust App Store. By contrast, he says smart TV makers such as Samsung and LG had created “very cumbersome” platforms for developers, with app stores where it was very difficult to get approval for new apps. </p>\n<p>But media observers were sceptical that the revamped Apple TV would have a big impact on the sector. </p>\n<p>“The television industry as it is structured today is incredibly profitable and works well for content companies,” says Michael Nathanson, an analyst with MoffettNathanson.  </p>\n<aside data-asset-type=\"promoBox\" data-asset-name=\"asset3\"></aside><p>\n</p>\n<p>“I don’t know how you go from an economic model that has created billions of dollars in value — and that is based on a bundle — to an a la carte app model. There’s no incentive for companies like Fox, Disney and Time Warner that have made money bundling their channels to move to an app-driven world.” </p>\n<p>The revamped Apple TV offers improved search and discovery functions. But consumers will need a subscription to some of the many streaming services available — or buy programmes individually from iTunes — to take full advantage of this functionality. </p>\n<p>“If you don’t have a subscription you get to look at a whole lot of nothing,” says one industry observer.  </p>\n<p>The real inflection point for Apple may lie ahead. The company has been in discussions with cable networks and other content owners about offering a streaming subscription service similar to the bundles provided by cable and satellite operators, according to people close to the negotiations.  </p>\n<p>Such a service would compete directly with companies such as Comcast and Time Warner Cable, the leading pay-TV operators in the US, as well as Sling TV from Dish Networks and Sony’s PlayStation Vue.  </p>\n<p>Analysts say an Apple channel bundle would have to be competitively priced to consumers and offer sufficient incentives to channel owners to make their content available. “The content owners have to be incentivised to move to that kind of model,” says Mr Nathanson. “The transition is going to take a while.” </p>\n"
+    },
+    "lifecycle": {
+      "initialPublishDateTime": "2015-09-10T17:35:33Z",
+      "lastPublishDateTime": "2015-09-10T18:32:34Z"
+    },
+    "location": {
+      "uri": "http://www.ft.com/cms/s/0/1438c26a-57d4-11e5-97e9-7f0bf5e7177b.html"
+    },
+    "summary": {
+      "excerpt": "Relaunch of television offering with app store at its centre could up-end traditional media"
+    },
+    "packaging": {
+      "spHeadline": "Apple TV wants viewers to change channel"
+    },
+    "master": {
+      "masterSource": "Methode",
+      "masterEntityId": "1438c26a-57d4-11e5-97e9-7f0bf5e7177b"
+    },
+    "editorial": {
+      "subheading": "Relaunch of television offering has app store at its core",
+      "standFirst": "Relaunch of television offering with app store at its centre could up-end traditional media",
+      "byline": "Tim Bradshaw and Hannah Kuchler in San Francisco and Matthew Garrahan in New York"
+    },
+    "provenance": {
+      "originatingParty": "FT"
+    },
+    "metadata": {
+      "primarySection": {
+        "term": {
+          "name": "Technology",
+          "id": "NTM=-U2VjdGlvbnM=",
+          "attributes": [
+            {
+              "value": "companies",
+              "key": "dfpSite"
+            },
+            {
+              "value": "technology",
+              "key": "dfpZone"
+            }
+          ],
+          "taxonomy": "sections"
+        }
+      },
+      "primaryTheme": {
+        "term": {
+          "name": "Apple Inc",
+          "id": "TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0FBUEw=-T04=",
+          "attributes": [
+            {
+              "value": "us:AAPL",
+              "key": "wsod_key"
+            },
+            {
+              "value": "true",
+              "key": "is_company"
+            }
+          ],
+          "taxonomy": "organisations"
+        }
+      },
+      "tags": [
+        {
+          "term": {
+            "name": "Apple Inc",
+            "attributes": [
+              {
+                "value": "us:AAPL",
+                "key": "wsod_key"
+              },
+              {
+                "value": "true",
+                "key": "is_company"
+              }
+            ],
+            "id": "TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0FBUEw=-T04=",
+            "taxonomy": "organisations"
+          }
+        },
+        {
+          "term": {
+            "name": "Technology",
+            "attributes": [
+              {
+                "value": "companies",
+                "key": "dfpSite"
+              },
+              {
+                "value": "technology",
+                "key": "dfpZone"
+              }
+            ],
+            "id": "NTM=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "News",
+            "attributes": [],
+            "id": "Nw==-R2VucmVz",
+            "taxonomy": "genre"
+          }
+        },
+        {
+          "term": {
+            "name": "Text",
+            "attributes": [],
+            "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+            "taxonomy": "mediaType"
+          }
+        },
+        {
+          "term": {
+            "name": "Tim Bradshaw",
+            "attributes": [],
+            "id": "Q0ItMDAwMDY4OA==-QXV0aG9ycw==",
+            "taxonomy": "authors"
+          }
+        },
+        {
+          "term": {
+            "name": "Hannah Kuchler",
+            "attributes": [],
+            "id": "Q0ItMDAwMDc5Ng==-QXV0aG9ycw==",
+            "taxonomy": "authors"
+          }
+        },
+        {
+          "term": {
+            "name": "Matthew Garrahan",
+            "attributes": [],
+            "id": "Q0ItMDAwMTMzNQ==-QXV0aG9ycw==",
+            "taxonomy": "authors"
+          }
+        },
+        {
+          "term": {
+            "name": "5550 Media",
+            "attributes": [],
+            "id": "MTEy-SUNC",
+            "taxonomy": "icb"
+          }
+        },
+        {
+          "term": {
+            "name": "9000 Technology",
+            "attributes": [],
+            "id": "MTc0-SUNC",
+            "taxonomy": "icb"
+          }
+        },
+        {
+          "term": {
+            "name": "9500 Technology",
+            "attributes": [],
+            "id": "MTc1-SUNC",
+            "taxonomy": "icb"
+          }
+        },
+        {
+          "term": {
+            "name": "9530 Software & Computer Services",
+            "attributes": [],
+            "id": "MTc2-SUNC",
+            "taxonomy": "icb"
+          }
+        },
+        {
+          "term": {
+            "name": "9535 Internet",
+            "attributes": [],
+            "id": "MTc4-SUNC",
+            "taxonomy": "icb"
+          }
+        },
+        {
+          "term": {
+            "name": "9570 Technology Hardware & Equipment",
+            "attributes": [],
+            "id": "MTgw-SUNC",
+            "taxonomy": "icb"
+          }
+        },
+        {
+          "term": {
+            "name": "9572 Computer Hardware",
+            "attributes": [],
+            "id": "MTgx-SUNC",
+            "taxonomy": "icb"
+          }
+        },
+        {
+          "term": {
+            "name": "01016000 - television",
+            "attributes": [],
+            "id": "MDEwMTYwMDA=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "04010000 - media",
+            "attributes": [],
+            "id": "MDQwMTAwMDA=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "04010010 - television industry",
+            "attributes": [],
+            "id": "MDQwMTAwMTA=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "Tim Cook (Executive)",
+            "attributes": [],
+            "id": "MzJmYWJlNDAtOWY4NS00ZWMzLTg2OTItZjMxODdiY2RiNzYz-UE4=",
+            "taxonomy": "people"
+          }
+        },
+        {
+          "term": {
+            "name": "Companies",
+            "attributes": [
+              {
+                "value": "companies",
+                "key": "dfpSite"
+              }
+            ],
+            "id": "Mjk=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Media",
+            "attributes": [
+              {
+                "value": "companies",
+                "key": "dfpSite"
+              },
+              {
+                "value": "media",
+                "key": "dfpZone"
+              }
+            ],
+            "id": "NTU=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "US & Canadian Companies",
+            "attributes": [],
+            "id": "NjU=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Company News",
+            "attributes": [],
+            "id": "MQ==-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "Marketing",
+            "attributes": [],
+            "id": "MTk=-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "New Products & Services",
+            "attributes": [],
+            "id": "MjE=-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        }
+      ],
+      "authors": [
+        {
+          "term": {
+            "name": "Tim Bradshaw",
+            "attributes": [],
+            "id": "Q0ItMDAwMDY4OA==-QXV0aG9ycw==",
+            "taxonomy": "authors"
+          }
+        },
+        {
+          "term": {
+            "name": "Hannah Kuchler",
+            "attributes": [],
+            "id": "Q0ItMDAwMDc5Ng==-QXV0aG9ycw==",
+            "taxonomy": "authors"
+          }
+        },
+        {
+          "term": {
+            "name": "Matthew Garrahan",
+            "attributes": [],
+            "id": "Q0ItMDAwMTMzNQ==-QXV0aG9ycw==",
+            "taxonomy": "authors"
+          }
+        }
+      ],
+      "brand": [],
+      "genre": [
+        {
+          "term": {
+            "name": "News",
+            "attributes": [],
+            "id": "Nw==-R2VucmVz",
+            "taxonomy": "genre"
+          }
+        }
+      ],
+      "icb": [
+        {
+          "term": {
+            "name": "5550 Media",
+            "attributes": [],
+            "id": "MTEy-SUNC",
+            "taxonomy": "icb"
+          }
+        },
+        {
+          "term": {
+            "name": "9000 Technology",
+            "attributes": [],
+            "id": "MTc0-SUNC",
+            "taxonomy": "icb"
+          }
+        },
+        {
+          "term": {
+            "name": "9500 Technology",
+            "attributes": [],
+            "id": "MTc1-SUNC",
+            "taxonomy": "icb"
+          }
+        },
+        {
+          "term": {
+            "name": "9530 Software & Computer Services",
+            "attributes": [],
+            "id": "MTc2-SUNC",
+            "taxonomy": "icb"
+          }
+        },
+        {
+          "term": {
+            "name": "9535 Internet",
+            "attributes": [],
+            "id": "MTc4-SUNC",
+            "taxonomy": "icb"
+          }
+        },
+        {
+          "term": {
+            "name": "9570 Technology Hardware & Equipment",
+            "attributes": [],
+            "id": "MTgw-SUNC",
+            "taxonomy": "icb"
+          }
+        },
+        {
+          "term": {
+            "name": "9572 Computer Hardware",
+            "attributes": [],
+            "id": "MTgx-SUNC",
+            "taxonomy": "icb"
+          }
+        }
+      ],
+      "iptc": [
+        {
+          "term": {
+            "name": "01016000 - television",
+            "attributes": [],
+            "id": "MDEwMTYwMDA=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "04010000 - media",
+            "attributes": [],
+            "id": "MDQwMTAwMDA=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "04010010 - television industry",
+            "attributes": [],
+            "id": "MDQwMTAwMTA=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        }
+      ],
+      "mediaType": [
+        {
+          "term": {
+            "name": "Text",
+            "attributes": [],
+            "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+            "taxonomy": "mediaType"
+          }
+        }
+      ],
+      "organisations": [
+        {
+          "term": {
+            "name": "Apple Inc",
+            "attributes": [
+              {
+                "value": "us:AAPL",
+                "key": "wsod_key"
+              },
+              {
+                "value": "true",
+                "key": "is_company"
+              }
+            ],
+            "id": "TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0FBUEw=-T04=",
+            "taxonomy": "organisations"
+          }
+        }
+      ],
+      "people": [
+        {
+          "term": {
+            "name": "Tim Cook (Executive)",
+            "attributes": [],
+            "id": "MzJmYWJlNDAtOWY4NS00ZWMzLTg2OTItZjMxODdiY2RiNzYz-UE4=",
+            "taxonomy": "people"
+          }
+        }
+      ],
+      "regions": [],
+      "sections": [
+        {
+          "term": {
+            "name": "Companies",
+            "attributes": [
+              {
+                "value": "companies",
+                "key": "dfpSite"
+              }
+            ],
+            "id": "Mjk=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Technology",
+            "attributes": [
+              {
+                "value": "companies",
+                "key": "dfpSite"
+              },
+              {
+                "value": "technology",
+                "key": "dfpZone"
+              }
+            ],
+            "id": "NTM=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Media",
+            "attributes": [
+              {
+                "value": "companies",
+                "key": "dfpSite"
+              },
+              {
+                "value": "media",
+                "key": "dfpZone"
+              }
+            ],
+            "id": "NTU=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "US & Canadian Companies",
+            "attributes": [],
+            "id": "NjU=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        }
+      ],
+      "specialReports": [],
+      "subjects": [
+        {
+          "term": {
+            "name": "Company News",
+            "attributes": [],
+            "id": "MQ==-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "Marketing",
+            "attributes": [],
+            "id": "MTk=-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "New Products & Services",
+            "attributes": [],
+            "id": "MjE=-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        }
+      ],
+      "topics": []
+    },
+    "images": [
+      {
+        "width": 272,
+        "caption": "Eddy Cue, head of internet software and services, demonstrates the new remote control for Apple TV",
+        "mediaType": "image/jpeg",
+        "source": "Getty",
+        "type": "primary",
+        "url": "http://im.ft-static.com/content/images/83b950b7-5992-42b2-86f1-13c4164c8e17.img",
+        "height": 153
+      },
+      {
+        "width": 167,
+        "caption": "Eddy Cue, head of internet software and services, demonstrates the new remote control for Apple TV",
+        "mediaType": "image/jpeg",
+        "source": "Getty",
+        "type": "secondary",
+        "url": "http://im.ft-static.com/content/images/35538b8f-a79b-4d10-a78b-bb2af6223fb4.img",
+        "height": 94
+      },
+      {
+        "width": 600,
+        "caption": "Eddy Cue, head of internet software and services, demonstrates the new remote control for Apple TV",
+        "mediaType": "image/jpeg",
+        "source": "Getty",
+        "type": "article",
+        "url": "http://im.ft-static.com/content/images/03bc3000-6b13-4e02-a8d1-8b816472d947.img",
+        "height": 338
+      },
+      {
+        "width": 414,
+        "caption": "Eddy Cue, head of internet software and services, demonstrates the new remote control for Apple TV",
+        "mediaType": "image/jpeg",
+        "source": "Getty",
+        "type": "leader",
+        "url": "http://im.ft-static.com/content/images/ec682660-0655-4190-a8a1-3d0f524cee4d.img",
+        "height": 233
+      },
+      {
+        "width": 972,
+        "caption": "Eddy Cue, head of internet software and services, demonstrates the new remote control for Apple TV",
+        "mediaType": "image/jpeg",
+        "source": "Getty",
+        "type": "wide-format",
+        "url": "http://im.ft-static.com/content/images/f62d337a-4e60-4b94-847d-b4d19ba4065d.img",
+        "height": 547
+      },
+      {
+        "alt": "Video streaming",
+        "width": 600,
+        "mediaType": "image/png",
+        "type": "inline",
+        "url": "http://im.ft-static.com/content/images/2172f688-57d6-11e5-9846-de406ccb37f2.img",
+        "height": 494
+      },
+      {
+        "width": 150,
+        "mediaType": "image/jpeg",
+        "type": "inline",
+        "url": "http://im.ft-static.com/content/images/91b39ae8-ccff-11e1-92c1-00144feabdc0.img",
+        "height": 100
+      },
+      {
+        "alt": "Lex",
+        "width": 167,
+        "mediaType": "image/jpeg",
+        "source": "Financial Times",
+        "type": "promo",
+        "url": "http://im.ft-static.com/content/images/77e5c048-0752-11df-a9b7-00144feabdc0.img",
+        "height": 96
+      },
+      {
+        "width": 272,
+        "mediaType": "image/jpeg",
+        "source": "Bloomberg",
+        "type": "promo",
+        "url": "http://im.ft-static.com/content/images/9f797ffd-b2f3-49bb-933b-c299faac7846.img",
+        "height": 153
+      },
+      {
+        "width": 972,
+        "mediaType": "image/jpeg",
+        "source": "Bloomberg",
+        "type": "promo",
+        "url": "http://im.ft-static.com/content/images/c28954e5-5057-41a7-aeab-2e77a0af78d1.img",
+        "height": 547
+      }
+    ],
+    "package": [
+      {
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "apiUrl": "http://api.ft.com/content/items/v1/9a2b7608-5746-11e5-9846-de406ccb37f2",
+        "packaging": {
+          "spHeadline": "T-Mobile takes on Apple with iPhone plan"
+        },
+        "id": "9a2b7608-5746-11e5-9846-de406ccb37f2"
+      },
+      {
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "apiUrl": "http://api.ft.com/content/items/v1/beee7cdc-576f-11e5-a28b-50226830d644",
+        "packaging": {
+          "spHeadline": "Apple — carried away",
+          "kicker": "Comment"
+        },
+        "id": "beee7cdc-576f-11e5-a28b-50226830d644"
+      },
+      {
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "apiUrl": "http://api.ft.com/content/items/v1/33012b18-5713-11e5-9846-de406ccb37f2",
+        "packaging": {
+          "spHeadline": "Apple TV and iPad revamp with iPhone 6S"
+        },
+        "id": "33012b18-5713-11e5-9846-de406ccb37f2"
+      },
+      {
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "apiUrl": "http://api.ft.com/content/items/v1/44022e2a-541e-3fff-9f6f-bd56d72330ff",
+        "packaging": {
+          "spHeadline": "new iPhone 6S and Apple TV launch",
+          "kicker": "As it happened"
+        },
+        "id": "44022e2a-541e-3fff-9f6f-bd56d72330ff"
+      }
+    ],
+    "assets": [
+      {
+        "name": "asset1",
+        "type": "video",
+        "fields": {
+          "sourceReference": "4474074856001",
+          "source": "Brightcove"
+        }
+      },
+      {
+        "name": "asset2",
+        "type": "promoBox",
+        "fields": {
+          "images": [
+            {
+              "width": 972,
+              "mediaType": "image/jpeg",
+              "source": "Bloomberg",
+              "type": "promo",
+              "url": "http://im.ft-static.com/content/images/c28954e5-5057-41a7-aeab-2e77a0af78d1.img",
+              "height": 547
+            },
+            {
+              "width": 272,
+              "mediaType": "image/jpeg",
+              "source": "Bloomberg",
+              "type": "promo",
+              "url": "http://im.ft-static.com/content/images/9f797ffd-b2f3-49bb-933b-c299faac7846.img",
+              "height": 153
+            }
+          ],
+          "intro": "<p>New leasing option to upgrade handsets designed to head off competitive threat from tech group</p>\n<p><a href=\"/cms/s/9a2b7608-5746-11e5-9846-de406ccb37f2.html\">Read more</a>\n</p>",
+          "headline": "<p>T-Mobile takes on Apple with iPhone upgrade plan</p>"
+        }
+      },
+      {
+        "name": "asset3",
+        "type": "promoBox",
+        "fields": {
+          "intro": "<p>The iPhone maker is leaving financing to a UK-backed bank but will make life harder for carriers</p>\n<p><a title=\"Apple: carried away - Lex - FT.com\" href=\"http://www.ft.com/intl/cms/s/3/beee7cdc-576f-11e5-a28b-50226830d644.html#axzz3lM4bf4XC\">Full story</a>\n</p>",
+          "headline": "<p>Lex: carried away</p>"
+        }
+      }
+    ],
+    "mediaAssets": []
+  },
+  "_lastUpdatedDateTime": "2015-09-14T13:31:19.971Z"
+}

--- a/test/fixtures/readNext/parentArticle2.json
+++ b/test/fixtures/readNext/parentArticle2.json
@@ -1,0 +1,595 @@
+{
+  "requestUrl": "http://api.ft.com/content/items/v1/5eeeb84a-5aaa-11e5-97e9-7f0bf5e7177b?feature.blogposts=on&h=4301210744",
+  "item": {
+    "aspectSet": "article",
+    "aspects": [
+      "assets",
+      "body",
+      "editorial",
+      "images",
+      "lifecycle",
+      "location",
+      "master",
+      "mediaAssets",
+      "metadata",
+      "package",
+      "packaging",
+      "provenance",
+      "summary",
+      "title"
+    ],
+    "modelVersion": "1",
+    "id": "5eeeb84a-5aaa-11e5-97e9-7f0bf5e7177b",
+    "apiUrl": "http://api.ft.com/content/items/v1/5eeeb84a-5aaa-11e5-97e9-7f0bf5e7177b",
+    "title": {
+      "title": "China’s state-owned enterprise reform plans face compromise"
+    },
+    "body": {
+      "mediaType": "text/html",
+      "body": "<p>China’s release of a <a title=\"China plans shake-up of state-owned enterprises to boost growth - FT.com\" href=\"http://www.ft.com/intl/cms/s/0/aff90924-5a01-11e5-9846-de406ccb37f2.html\">long-awaited plan</a> to overhaul the country’s bloated state-owned enterprises (SOEs) has proved another triumph for entrenched interests over the <a title=\"China Tremors in depth - FT.com\" href=\"http://www.ft.com/intl/indepth/china-tremors\">broader economy</a>.</p>\n\n<p>Reform of the SOEs, which control everything from telecoms to banking but produce returns far inferior to their private peers, is widely regarded as the key element of the broad economic reform plan released by top Communist party leaders at a plenary meeting in November 2013. The slowing economy makes it more vital still.</p>\n<p>The nub, as ever, is that the status quo works for some: SOE management and their political patrons have grown rich over the past decade due to preferential access to loans from state banks and protection from competition.</p>\n\n\n\n\n\n\n<p>“Any reform plan is a compromise of different constituencies, and SOE reform is no different — in fact, it’s particularly so. It cannot fully satisfy the market,” said Tao Wang, chief China economist at UBS.</p>\n<p>The latest plan aims to improve SOE efficiency and competitiveness without relying on <a title=\"China SOE’s restructuring leaves state ownership intact - FT.com\" href=\"http://www.ft.com/intl/cms/s/0/902826f4-c878-11e4-8617-00144feab7de.html\">outright privatisation</a>. Its approach reflects contradictions inherent in the 2013 reform blueprint, which called for giving markets a “decisive role” in resource allocation while preserving a “dominant role” for the state sector.</p>\n<p>The question is whether incremental changes, including minority stake sales, stock market listings and changes to how directors and executives are appointed will be sufficient to fundamentally reshape the state sector.</p>\n<p>The influence of conservative elements keen to protect SOE privileges is clear.</p>\n<p>The call to promote “mixed ownership” of SOEs — a euphemism for partial privatisation — is followed by caution to protect against the “leaching away of state assets”, a reference to worries about national wealth being sold off on the cheap. The plan wants to increase financial returns but also calls for strengthening party control.</p>\n<p>On the positive side, the emphasis on stock market listings was stronger than expected. Most large SOEs completed listings on Hong Kong and mainland bourses over the past decade, but the free float is typically less than 20 per cent. SOEs also often hold less profitable assets outside the listed entity. </p>\n<aside data-asset-type=\"promoBox\" data-asset-name=\"asset1\"></aside><p>The current plan says that any assets that can be listed should be. The hope is that governments will be forced to improve the performance of previously unlisted assets or dispose of them.</p>\n<p>“A lot of SOEs are really happy being SOEs and a number of them are now trying to come to terms with having to think about return on capital,” said Jonathan Slone, chief executive of CLSA, the Asia-focused brokerage owned by Citic Securities, China’s largest brokerage.</p>\n<p>Average return on assets for state companies was at about 4.6 per cent in 2014, compared with 9.1 per cent for private businesses, according to estimates by Gavekal Dragonomics, a Beijing-based economic research company.</p>\n<p>“There are conversations with investment banks, asking: ‘If we do this, how will the market react’,” adds Mr Slone.</p>\n<p>Citic Securities’ parent company, Citic Group, laid down a <a title=\"Citic Group a test case for reform - FT.com\" href=\"http://www.ft.com/intl/cms/s/0/f6c9f900-1eb9-11e4-ad93-00144feabdc0.html\">model for SOE reform</a> last year when it injected $37bn worth of unlisted assets into a Hong Kong-listed subsidiary.</p>\n<p>An issue largely unaddressed in the plan is whether SOEs will be allowed to fail. In the previous round of Chinese SOE reform, led by then-premier Zhu Rongji in the late 1990s, tens of thousands of SOEs were privatised or liquidated, resulting in more than 25m employees being laid off. The current plan refers in passing to SOE “exits” but does not dwell on it. The emphasis is on strengthening the state sector rather than shrinking it. </p>\n<aside data-asset-type=\"video\" data-asset-name=\"asset2\"></aside>\n\n<p>Yet some analysts fear that without more aggressive sell-offs, the weaker parts of the state sector will turn into zombies, kept alive on bailouts and cheap credit.</p>\n<p>With the plan itself a grab bag of initiatives meant to satisfy various interest groups and ideological camps, much will depend on implementation. While acknowledging limitations, Ms Wang sees it as a modest step in the right direction.</p>\n<p>“People from the financial markets and media tend to look for things like major privatisation. That’s out of the question. But developing mixed ownership and IPOs — in my view that’s state divestment. It’s significant,” said Ms Wang.</p>\n<p>Twitter: <a title=\"@gabewildau - Twitter.com\" href=\"https://twitter.com/gabewildau\">@gabewildau</a>\n</p>\n<p><span class=\"ft-italic\">Additional reporting by Ma Nan and Jennifer Hughes in Hong Kong</span>\n</p>"
+    },
+    "lifecycle": {
+      "initialPublishDateTime": "2015-09-14T10:35:49Z",
+      "lastPublishDateTime": "2015-09-14T10:35:49Z"
+    },
+    "location": {
+      "uri": "http://www.ft.com/cms/s/0/5eeeb84a-5aaa-11e5-97e9-7f0bf5e7177b.html"
+    },
+    "summary": {
+      "excerpt": "Incremental changes may be insufficient to revitalise state groups"
+    },
+    "packaging": {
+      "spHeadline": "China’s SOE reform plans face compromise"
+    },
+    "master": {
+      "masterSource": "Methode",
+      "masterEntityId": "5eeeb84a-5aaa-11e5-97e9-7f0bf5e7177b"
+    },
+    "editorial": {
+      "otherTitles": [
+        "China’s SOE reform plans face compromise"
+      ],
+      "subheading": "Incremental changes may be insufficient to revitalise state groups",
+      "standFirst": "Incremental changes may be insufficient to revitalise state groups",
+      "byline": "Gabriel Wildau in Shanghai"
+    },
+    "provenance": {
+      "originatingParty": "FT"
+    },
+    "metadata": {
+      "primarySection": {
+        "term": {
+          "name": "China",
+          "attributes": [],
+          "id": "TnN0ZWluX0dMX0NO-R0w=",
+          "taxonomy": "regions"
+        }
+      },
+      "primaryTheme": {
+        "term": {
+          "name": "China Business",
+          "id": "NjM3ZTU3MDUtMmY1ZS00ZGExLThkNjYtYWY4YWUzY2U1YWVm-VG9waWNz",
+          "attributes": [],
+          "taxonomy": "topics"
+        }
+      },
+      "tags": [
+        {
+          "term": {
+            "name": "China Business",
+            "attributes": [],
+            "id": "NjM3ZTU3MDUtMmY1ZS00ZGExLThkNjYtYWY4YWUzY2U1YWVm-VG9waWNz",
+            "taxonomy": "topics"
+          }
+        },
+        {
+          "term": {
+            "name": "China",
+            "attributes": [],
+            "id": "TnN0ZWluX0dMX0NO-R0w=",
+            "taxonomy": "regions"
+          }
+        },
+        {
+          "term": {
+            "name": "News",
+            "attributes": [],
+            "id": "Nw==-R2VucmVz",
+            "taxonomy": "genre"
+          }
+        },
+        {
+          "term": {
+            "name": "Text",
+            "attributes": [],
+            "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+            "taxonomy": "mediaType"
+          }
+        },
+        {
+          "term": {
+            "name": "04008023 - financial markets",
+            "attributes": [],
+            "id": "MDQwMDgwMjM=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "04008026 - stocks",
+            "attributes": [],
+            "id": "MDQwMDgwMjY=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "04016034 - privatisation",
+            "attributes": [],
+            "id": "MDQwMTYwMzQ=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "11006000 - government",
+            "attributes": [],
+            "id": "MTEwMDYwMDA=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "11006011 - privatisation",
+            "attributes": [],
+            "id": "MTEwMDYwMTE=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "11010000 - parties and movements",
+            "attributes": [],
+            "id": "MTEwMTAwMDA=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "Communist Party of China",
+            "attributes": [
+              {
+                "value": "false",
+                "key": "is_company"
+              }
+            ],
+            "id": "TnN0ZWluX09OX0FGVE1fT05fODEyMTA=-T04=",
+            "taxonomy": "organisations"
+          }
+        },
+        {
+          "term": {
+            "name": "Tao Wang",
+            "attributes": [],
+            "id": "TnN0ZWluX1BOX1Nwb3J0c18yMDA5XzEwXzRfNTcwMjY=-UE4=",
+            "taxonomy": "people"
+          }
+        },
+        {
+          "term": {
+            "name": "Soe",
+            "attributes": [],
+            "id": "TnN0ZWluX0dMX0FGVE1fR0xfMTM2MTMw-R0w=",
+            "taxonomy": "regions"
+          }
+        },
+        {
+          "term": {
+            "name": "World",
+            "attributes": [
+              {
+                "value": "world",
+                "key": "dfpSite"
+              }
+            ],
+            "id": "MQ==-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "General News",
+            "attributes": [],
+            "id": "MTE4-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "Natural Resources",
+            "attributes": [],
+            "id": "MTMw-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "Mergers & Acquisitions",
+            "attributes": [],
+            "id": "Mjc=-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "Mergers & Acquisitions",
+            "attributes": [],
+            "id": "Mjk=-VG9waWNz",
+            "taxonomy": "topics"
+          }
+        },
+        {
+          "term": {
+            "name": "China Economic Slowdown",
+            "attributes": [],
+            "id": "NWIwYzgxZTgtZjc3MC00ODNkLWI1YjYtYTVhNGQ2OTNjYjVi-VG9waWNz",
+            "taxonomy": "topics"
+          }
+        }
+      ],
+      "authors": [],
+      "brand": [],
+      "genre": [
+        {
+          "term": {
+            "name": "News",
+            "attributes": [],
+            "id": "Nw==-R2VucmVz",
+            "taxonomy": "genre"
+          }
+        }
+      ],
+      "icb": [],
+      "iptc": [
+        {
+          "term": {
+            "name": "04008023 - financial markets",
+            "attributes": [],
+            "id": "MDQwMDgwMjM=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "04008026 - stocks",
+            "attributes": [],
+            "id": "MDQwMDgwMjY=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "04016034 - privatisation",
+            "attributes": [],
+            "id": "MDQwMTYwMzQ=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "11006000 - government",
+            "attributes": [],
+            "id": "MTEwMDYwMDA=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "11006011 - privatisation",
+            "attributes": [],
+            "id": "MTEwMDYwMTE=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "11010000 - parties and movements",
+            "attributes": [],
+            "id": "MTEwMTAwMDA=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        }
+      ],
+      "mediaType": [
+        {
+          "term": {
+            "name": "Text",
+            "attributes": [],
+            "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+            "taxonomy": "mediaType"
+          }
+        }
+      ],
+      "organisations": [
+        {
+          "term": {
+            "name": "Communist Party of China",
+            "attributes": [
+              {
+                "value": "false",
+                "key": "is_company"
+              }
+            ],
+            "id": "TnN0ZWluX09OX0FGVE1fT05fODEyMTA=-T04=",
+            "taxonomy": "organisations"
+          }
+        }
+      ],
+      "people": [
+        {
+          "term": {
+            "name": "Tao Wang",
+            "attributes": [],
+            "id": "TnN0ZWluX1BOX1Nwb3J0c18yMDA5XzEwXzRfNTcwMjY=-UE4=",
+            "taxonomy": "people"
+          }
+        }
+      ],
+      "regions": [
+        {
+          "term": {
+            "name": "Soe",
+            "attributes": [],
+            "id": "TnN0ZWluX0dMX0FGVE1fR0xfMTM2MTMw-R0w=",
+            "taxonomy": "regions"
+          }
+        },
+        {
+          "term": {
+            "name": "China",
+            "attributes": [],
+            "id": "TnN0ZWluX0dMX0NO-R0w=",
+            "taxonomy": "regions"
+          }
+        }
+      ],
+      "sections": [
+        {
+          "term": {
+            "name": "World",
+            "attributes": [
+              {
+                "value": "world",
+                "key": "dfpSite"
+              }
+            ],
+            "id": "MQ==-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        }
+      ],
+      "specialReports": [],
+      "subjects": [
+        {
+          "term": {
+            "name": "General News",
+            "attributes": [],
+            "id": "MTE4-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "Natural Resources",
+            "attributes": [],
+            "id": "MTMw-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "Mergers & Acquisitions",
+            "attributes": [],
+            "id": "Mjc=-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        }
+      ],
+      "topics": [
+        {
+          "term": {
+            "name": "Mergers & Acquisitions",
+            "attributes": [],
+            "id": "Mjk=-VG9waWNz",
+            "taxonomy": "topics"
+          }
+        },
+        {
+          "term": {
+            "name": "China Economic Slowdown",
+            "attributes": [],
+            "id": "NWIwYzgxZTgtZjc3MC00ODNkLWI1YjYtYTVhNGQ2OTNjYjVi-VG9waWNz",
+            "taxonomy": "topics"
+          }
+        },
+        {
+          "term": {
+            "name": "China Business",
+            "attributes": [],
+            "id": "NjM3ZTU3MDUtMmY1ZS00ZGExLThkNjYtYWY4YWUzY2U1YWVm-VG9waWNz",
+            "taxonomy": "topics"
+          }
+        }
+      ]
+    },
+    "images": [
+      {
+        "alt": "Pedestrians walk in the central business district of Beijing, China, on Wednesday, March 4, 2015. China's leaders are gathered this week in Beijing, where they'll map out policies on state-owned enterprises, the environment, and deliver the nation's budget. Photographer: Tomohiro Ohsumi/Bloomberg",
+        "width": 272,
+        "mediaType": "image/jpeg",
+        "source": "Bloomberg",
+        "type": "primary",
+        "url": "http://im.ft-static.com/content/images/0891f8df-0cc7-49d9-b5a4-34d28abd7cf4.img",
+        "height": 153
+      },
+      {
+        "alt": "Pedestrians walk in the central business district of Beijing, China, on Wednesday, March 4, 2015. China's leaders are gathered this week in Beijing, where they'll map out policies on state-owned enterprises, the environment, and deliver the nation's budget. Photographer: Tomohiro Ohsumi/Bloomberg",
+        "width": 167,
+        "mediaType": "image/jpeg",
+        "source": "Bloomberg",
+        "type": "secondary",
+        "url": "http://im.ft-static.com/content/images/a5cc646a-29bb-4682-8b78-ee3ab842a131.img",
+        "height": 94
+      },
+      {
+        "alt": "Pedestrians walk in the central business district of Beijing, China, on Wednesday, March 4, 2015. China's leaders are gathered this week in Beijing, where they'll map out policies on state-owned enterprises, the environment, and deliver the nation's budget. Photographer: Tomohiro Ohsumi/Bloomberg",
+        "width": 600,
+        "mediaType": "image/jpeg",
+        "source": "Bloomberg",
+        "type": "article",
+        "url": "http://im.ft-static.com/content/images/1b48b62c-ccef-413b-944d-17f43e1c75d4.img",
+        "height": 338
+      },
+      {
+        "alt": "Pedestrians walk in the central business district of Beijing, China, on Wednesday, March 4, 2015. China's leaders are gathered this week in Beijing, where they'll map out policies on state-owned enterprises, the environment, and deliver the nation's budget. Photographer: Tomohiro Ohsumi/Bloomberg",
+        "width": 414,
+        "mediaType": "image/jpeg",
+        "source": "Bloomberg",
+        "type": "leader",
+        "url": "http://im.ft-static.com/content/images/7fc883cb-cc3e-4ecb-9630-d4b9e1be6a30.img",
+        "height": 233
+      },
+      {
+        "alt": "Pedestrians walk in the central business district of Beijing, China, on Wednesday, March 4, 2015. China's leaders are gathered this week in Beijing, where they'll map out policies on state-owned enterprises, the environment, and deliver the nation's budget. Photographer: Tomohiro Ohsumi/Bloomberg",
+        "width": 972,
+        "mediaType": "image/jpeg",
+        "source": "Bloomberg",
+        "type": "wide-format",
+        "url": "http://im.ft-static.com/content/images/0c4480c1-8e28-4991-8287-f364b05a2812.img",
+        "height": 547
+      },
+      {
+        "width": 150,
+        "mediaType": "image/jpeg",
+        "type": "inline",
+        "url": "http://im.ft-static.com/content/images/91b39ae8-ccff-11e1-92c1-00144feabdc0.img",
+        "height": 100
+      },
+      {
+        "alt": "epa04793150 (FILE) A file picture dated 01 November 2010 shows Chinese Zhou Yongkang, then member of the Standing Committee of the Politburo and Secretary of Political and Legislative Affairs Committee, addressing a seminar in New Delhi, India. Zhou Yongkang has been sentenced to life in prison, it was reported 11 June 2015. He was found guilty of bribery, abuse of power and 'intentionally disclosing national secrets', Chinese media reports. EPA/ANINDITO MUKHERJEE",
+        "width": 272,
+        "caption": "Zhou Yongkang, China’s disgraced energy and security tsar, whose influence thrived in CNPC’s Soluxe hotel chain",
+        "mediaType": "image/jpeg",
+        "source": "EPA",
+        "type": "promo",
+        "url": "http://im.ft-static.com/content/images/fab1b192-b82d-4bd7-83d2-71a97970671c.img",
+        "height": 153
+      },
+      {
+        "alt": "epa04793150 (FILE) A file picture dated 01 November 2010 shows Chinese Zhou Yongkang, then member of the Standing Committee of the Politburo and Secretary of Political and Legislative Affairs Committee, addressing a seminar in New Delhi, India. Zhou Yongkang has been sentenced to life in prison, it was reported 11 June 2015. He was found guilty of bribery, abuse of power and 'intentionally disclosing national secrets', Chinese media reports. EPA/ANINDITO MUKHERJEE",
+        "width": 972,
+        "caption": "Zhou Yongkang, China’s disgraced energy and security tsar, whose influence thrived in CNPC’s Soluxe hotel chain",
+        "mediaType": "image/jpeg",
+        "source": "EPA",
+        "type": "promo",
+        "url": "http://im.ft-static.com/content/images/b29be4bd-ef06-4839-984b-d21ead0c0a06.img",
+        "height": 547
+      }
+    ],
+    "package": [
+      {
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "apiUrl": "http://api.ft.com/content/items/v1/a581b44e-5acb-11e5-a28b-50226830d644",
+        "packaging": {
+          "spHeadline": "CNPC forced to dispose of hotel chain"
+        },
+        "id": "a581b44e-5acb-11e5-a28b-50226830d644"
+      },
+      {
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "apiUrl": "http://api.ft.com/content/items/v1/aff90924-5a01-11e5-9846-de406ccb37f2",
+        "packaging": {
+          "spHeadline": "China’s state-owned groups face shake-up"
+        },
+        "id": "aff90924-5a01-11e5-9846-de406ccb37f2"
+      },
+      {
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "apiUrl": "http://api.ft.com/content/items/v1/3186f3dc-5310-11e5-b029-b9d50a74fd14",
+        "packaging": {
+          "spHeadline": "Robert Zoellick – China will stumble if Xi stalls on reform",
+          "kicker": "Comment"
+        },
+        "id": "3186f3dc-5310-11e5-b029-b9d50a74fd14"
+      },
+      {
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "apiUrl": "http://api.ft.com/content/items/v1/8dfcd43e-507b-11e5-b029-b9d50a74fd14",
+        "packaging": {
+          "spHeadline": "China urges companies to shore up market"
+        },
+        "id": "8dfcd43e-507b-11e5-b029-b9d50a74fd14"
+      },
+      {
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "apiUrl": "http://api.ft.com/content/items/v1/e9b56844-4ece-11e5-b029-b9d50a74fd14",
+        "packaging": {
+          "spHeadline": "China to form top aluminium producer"
+        },
+        "id": "e9b56844-4ece-11e5-b029-b9d50a74fd14"
+      }
+    ],
+    "assets": [
+      {
+        "name": "asset1",
+        "type": "promoBox",
+        "fields": {
+          "images": [
+            {
+              "alt": "epa04793150 (FILE) A file picture dated 01 November 2010 shows Chinese Zhou Yongkang, then member of the Standing Committee of the Politburo and Secretary of Political and Legislative Affairs Committee, addressing a seminar in New Delhi, India. Zhou Yongkang has been sentenced to life in prison, it was reported 11 June 2015. He was found guilty of bribery, abuse of power and 'intentionally disclosing national secrets', Chinese media reports. EPA/ANINDITO MUKHERJEE",
+              "width": 272,
+              "caption": "Zhou Yongkang, China’s disgraced energy and security tsar, whose influence thrived in CNPC’s Soluxe hotel chain",
+              "mediaType": "image/jpeg",
+              "source": "EPA",
+              "type": "promo",
+              "url": "http://im.ft-static.com/content/images/fab1b192-b82d-4bd7-83d2-71a97970671c.img",
+              "height": 153
+            },
+            {
+              "alt": "epa04793150 (FILE) A file picture dated 01 November 2010 shows Chinese Zhou Yongkang, then member of the Standing Committee of the Politburo and Secretary of Political and Legislative Affairs Committee, addressing a seminar in New Delhi, India. Zhou Yongkang has been sentenced to life in prison, it was reported 11 June 2015. He was found guilty of bribery, abuse of power and 'intentionally disclosing national secrets', Chinese media reports. EPA/ANINDITO MUKHERJEE",
+              "width": 972,
+              "caption": "Zhou Yongkang, China’s disgraced energy and security tsar, whose influence thrived in CNPC’s Soluxe hotel chain",
+              "mediaType": "image/jpeg",
+              "source": "EPA",
+              "type": "promo",
+              "url": "http://im.ft-static.com/content/images/b29be4bd-ef06-4839-984b-d21ead0c0a06.img",
+              "height": 547
+            }
+          ],
+          "intro": "<p>Hotel chains and taxi businesses among the non-core businesses to be sold</p>\n<p><a href=\"/cms/s/a581b44e-5acb-11e5-a28b-50226830d644.html\">Read more</a>\n</p>",
+          "headline": "<p>CNPC forced to sell businesses as China’s crackdown widens</p>"
+        }
+      },
+      {
+        "name": "asset2",
+        "type": "video",
+        "fields": {
+          "sourceReference": "4478244741001",
+          "source": "Brightcove"
+        }
+      }
+    ],
+    "mediaAssets": []
+  },
+  "_lastUpdatedDateTime": "2015-09-14T15:06:38.373Z"
+}

--- a/test/fixtures/readNext/parentArticle3.json
+++ b/test/fixtures/readNext/parentArticle3.json
@@ -1,0 +1,652 @@
+{
+  "requestUrl": "http://api.ft.com/content/items/v1/0c789340-296a-11e5-acfb-cbd2e1c81cca",
+  "item": {
+    "aspectSet": "article",
+    "aspects": [
+      "assets",
+      "body",
+      "editorial",
+      "images",
+      "lifecycle",
+      "location",
+      "master",
+      "mediaAssets",
+      "metadata",
+      "package",
+      "packaging",
+      "provenance",
+      "summary",
+      "title"
+    ],
+    "modelVersion": "1",
+    "id": "0c789340-296a-11e5-acfb-cbd2e1c81cca",
+    "apiUrl": "http://api.ft.com/content/items/v1/0c789340-296a-11e5-acfb-cbd2e1c81cca",
+    "title": {
+      "title": "UK angered by moves to help fund Greek bailout"
+    },
+    "body": {
+      "mediaType": "text/html",
+      "body": "<p>George Osborne will reject calls for the UK to take part in the latest <a title=\"Eurozone leaders reach deal on Greece - FT.com\" href=\"http://www.ft.com/cms/s/0/c895f7a8-2932-11e5-8db8-c033edba8a6e.html\">Greek bailout</a>, amid anger in Downing Street that the idea had been floated by the European Commission, supported by France.</p>\n<p>The chancellor will on Tuesday tell eurozone colleagues that the idea of Britain being on the hook for the <a title=\"Greece debt crisis in depth - FT.com\" href=\"http://www.ft.com/indepth/greece-debt-crisis\">Greece</a> rescue package is unacceptable and would be in breach of an agreement between EU leaders in 2010.</p>\n<p>He will tell a meeting of finance ministers in Brussels that the so-called European Financial Stabilisation Mechanism — a fund involving all 28 EU members — cannot be used for a bridging loan to Greece.</p>\n<p>Britain’s share of the EFSM is thought to be about €1bn. Mr Osborne spoke to Wolfgang Schäuble, his German counterpart, and others on Monday to try to head off a row in Brussels.</p>\n<p>“Our eurozone colleagues have received the message loud and clear that it would not be acceptable for this issue of British support for eurozone bailouts to be revisited,” one UK Treasury insider said. “The idea that British taxpayers’ money is going to be on the line in this latest Greek deal is a non-starter.” </p>\n<p>The idea of involving Britain in the Greek bailout emerged during acrimonious talks between eurozone leaders in the early hours of Monday morning, to the alarm of some officials in the room.</p>\n<p>Several officials raised concerns that the use of emergency cash on behalf of all 28 member states was being discussed without consulting London, where David Cameron’s objections to using the fund is well known.</p>\n<p>“We may prevent Grexit but we’d cause Brexit,” said one eurozone official.</p>\n<p>EU officials said that Martin Selmayr, the chief of staff to European Commission president Jean-Claude Juncker, was urging the use of the EFSM as a means of unlocking urgent bridge financing.</p>\n<aside data-asset-type=\"promoBox\" data-asset-name=\"asset1\"></aside><p>It is understood that France was particularly keen to use the EFSM, whose funds can be activated by a qualified majority vote following a recommendation by the commission. </p>\n<p>Greece must pay the European Central Bank €3.5bn on Monday next week, but because the International Monetary Fund is senior to all other lenders, Athens must reimburse the IMF before paying the ECB — meaning Greece must find about €7bn by Monday. Another €5bn is needed in August to meet similar bills.</p>\n<p>About half of the €7bn due on Monday can be made up in profits on Greek bonds held by the ECB, profits that were promised to Athens as part of a second bailout agreement in 2012.</p>\n<p>But eurozone authorities are struggling to find the rest of the cash quickly, and the EFSM was being sold as a ready pile of money that could be quickly deployed.</p>\n<p>David Cameron thought that he had killed off any prospect of Britain being involved in a eurozone bailout during negotiations in 2010, arguing that it would be “quite wrong”.</p>\n<p>Leaders at an EU summit in Brussels agreed in 2010 that only eurozone countries should participate in a future bailout of Greece, although Britain would participate through its membership of the IMF.</p>\n<aside data-asset-type=\"promoteNumber\" data-asset-name=\"asset2\"></aside><p>Mr Cameron has frequently hailed that decision as one of his negotiating successes in Brussels, but commission lawyers have questioned whether it is legally watertight.</p>\n<p>One hardline interpretation sees the agreement at the European Council in 2010 as merely political, not legally binding. The EFSM can be activated through a qualified majority vote, possibly leaving the UK outvoted.</p>\n<p>But such legal semantics would not play well in Britain, where any suggestion that the UK should be paying to sort out problems in the eurozone would provoke a strong political reaction.</p>\n<p>Mr Cameron, who is planning a referendum on <a title=\"Britain and the EU in depth - FT.com\" href=\"http://www.ft.com/indepth/britain-and-the-eu\">Britain’s EU membership </a>before the end of 2017, would see such a move as deeply unhelpful and liable to fuel euroscepticism.</p>"
+    },
+    "lifecycle": {
+      "initialPublishDateTime": "2015-07-13T17:30:11Z",
+      "lastPublishDateTime": "2015-07-13T17:53:12Z"
+    },
+    "location": {
+      "uri": "http://www.ft.com/cms/s/0/0c789340-296a-11e5-acfb-cbd2e1c81cca.html"
+    },
+    "summary": {
+      "excerpt": "Chancellor to reject calls for Britain to take part"
+    },
+    "packaging": {
+      "spHeadline": "UK angered by Greek bailout moves"
+    },
+    "master": {
+      "masterSource": "Methode",
+      "masterEntityId": "0c789340-296a-11e5-acfb-cbd2e1c81cca"
+    },
+    "editorial": {
+      "otherTitles": [
+        "UK angered by Greek bailout moves"
+      ],
+      "subheading": "Chancellor to reject calls for Britain to take part",
+      "standFirst": "Chancellor to reject calls for Britain to take part",
+      "byline": "George Parker in London and Alex Barker and Peter Spiegel in Brussels"
+    },
+    "provenance": {
+      "originatingParty": "FT"
+    },
+    "metadata": {
+      "primarySection": {
+        "term": {
+          "name": "UK Politics & Policy",
+          "id": "OA==-U2VjdGlvbnM=",
+          "attributes": [],
+          "taxonomy": "sections"
+        }
+      },
+      "primaryTheme": {
+        "term": {
+          "name": "Greece Debt Crisis",
+          "id": "ZmEzMmRmNDAtNDc0Zi00ODk3LWE2ZmQtZWFmYzJlZTRjZTVk-VG9waWNz",
+          "attributes": [],
+          "taxonomy": "topics"
+        }
+      },
+      "tags": [
+        {
+          "term": {
+            "name": "Greece Debt Crisis",
+            "attributes": [],
+            "id": "ZmEzMmRmNDAtNDc0Zi00ODk3LWE2ZmQtZWFmYzJlZTRjZTVk-VG9waWNz",
+            "taxonomy": "topics"
+          }
+        },
+        {
+          "term": {
+            "name": "UK Politics & Policy",
+            "attributes": [],
+            "id": "OA==-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "News",
+            "attributes": [],
+            "id": "Nw==-R2VucmVz",
+            "taxonomy": "genre"
+          }
+        },
+        {
+          "term": {
+            "name": "Text",
+            "attributes": [],
+            "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+            "taxonomy": "mediaType"
+          }
+        },
+        {
+          "term": {
+            "name": "Alex Barker",
+            "attributes": [],
+            "id": "Q0ItMDAwMDY3Mg==-QXV0aG9ycw==",
+            "taxonomy": "authors"
+          }
+        },
+        {
+          "term": {
+            "name": "George Parker",
+            "attributes": [],
+            "id": "Q0ItMDAwMDgzMA==-QXV0aG9ycw==",
+            "taxonomy": "authors"
+          }
+        },
+        {
+          "term": {
+            "name": "Peter Spiegel",
+            "attributes": [],
+            "id": "Q0ItMDAwMTMyMQ==-QXV0aG9ycw==",
+            "taxonomy": "authors"
+          }
+        },
+        {
+          "term": {
+            "name": "02002001 - lawyer",
+            "attributes": [],
+            "id": "MDIwMDIwMDE=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "04008010 - international economic institution",
+            "attributes": [],
+            "id": "MDQwMDgwMTA=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "11005001 - economic sanction",
+            "attributes": [],
+            "id": "MTEwMDUwMDE=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "11006000 - government",
+            "attributes": [],
+            "id": "MTEwMDYwMDA=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "11006008 - public officials",
+            "attributes": [],
+            "id": "MTEwMDYwMDg=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "International Monetary Fund",
+            "attributes": [
+              {
+                "value": "false",
+                "key": "is_company"
+              }
+            ],
+            "id": "VC0xNDcyNTU2-T04=",
+            "taxonomy": "organisations"
+          }
+        },
+        {
+          "term": {
+            "name": "George Osborne",
+            "attributes": [],
+            "id": "TnN0ZWluX1BOX1BvbGl0aWNpYW5fNTk4-UE4=",
+            "taxonomy": "people"
+          }
+        },
+        {
+          "term": {
+            "name": "France",
+            "attributes": [],
+            "id": "TnN0ZWluX0dMX0ZS-R0w=",
+            "taxonomy": "regions"
+          }
+        },
+        {
+          "term": {
+            "name": "United Kingdom",
+            "attributes": [],
+            "id": "TnN0ZWluX0dMX0dC-R0w=",
+            "taxonomy": "regions"
+          }
+        },
+        {
+          "term": {
+            "name": "Greece",
+            "attributes": [],
+            "id": "TnN0ZWluX0dMX0dS-R0w=",
+            "taxonomy": "regions"
+          }
+        },
+        {
+          "term": {
+            "name": "Brussels",
+            "attributes": [],
+            "id": "MTA=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "UK",
+            "attributes": [
+              {
+                "value": "world",
+                "key": "dfpSite"
+              },
+              {
+                "value": "uk",
+                "key": "dfpZone"
+              }
+            ],
+            "id": "Ng==-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Europe",
+            "attributes": [
+              {
+                "value": "world",
+                "key": "dfpSite"
+              },
+              {
+                "value": "europe",
+                "key": "dfpZone"
+              }
+            ],
+            "id": "OQ==-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Politics",
+            "attributes": [],
+            "id": "MTAx-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "Government News",
+            "attributes": [],
+            "id": "ODk=-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "Foreign Aid",
+            "attributes": [],
+            "id": "OTI=-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "International Affairs",
+            "attributes": [],
+            "id": "OTc=-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "Britain in Europe",
+            "attributes": [],
+            "id": "NDdiMzAyNzctMTRlMy00Zjk1LWEyZjYtYmYwZWIwYWU2NzAy-VG9waWNz",
+            "taxonomy": "topics"
+          }
+        },
+        {
+          "term": {
+            "name": "Euro in crisis",
+            "attributes": [],
+            "id": "OTZhMTRiZDItYjI2ZS00NGMzLTg1MjAtNjlkNzVmZjk2NTI1-VG9waWNz",
+            "taxonomy": "topics"
+          }
+        }
+      ],
+      "authors": [
+        {
+          "term": {
+            "name": "Alex Barker",
+            "attributes": [],
+            "id": "Q0ItMDAwMDY3Mg==-QXV0aG9ycw==",
+            "taxonomy": "authors"
+          }
+        },
+        {
+          "term": {
+            "name": "George Parker",
+            "attributes": [],
+            "id": "Q0ItMDAwMDgzMA==-QXV0aG9ycw==",
+            "taxonomy": "authors"
+          }
+        },
+        {
+          "term": {
+            "name": "Peter Spiegel",
+            "attributes": [],
+            "id": "Q0ItMDAwMTMyMQ==-QXV0aG9ycw==",
+            "taxonomy": "authors"
+          }
+        }
+      ],
+      "brand": [],
+      "genre": [
+        {
+          "term": {
+            "name": "News",
+            "attributes": [],
+            "id": "Nw==-R2VucmVz",
+            "taxonomy": "genre"
+          }
+        }
+      ],
+      "icb": [],
+      "iptc": [
+        {
+          "term": {
+            "name": "02002001 - lawyer",
+            "attributes": [],
+            "id": "MDIwMDIwMDE=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "04008010 - international economic institution",
+            "attributes": [],
+            "id": "MDQwMDgwMTA=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "11005001 - economic sanction",
+            "attributes": [],
+            "id": "MTEwMDUwMDE=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "11006000 - government",
+            "attributes": [],
+            "id": "MTEwMDYwMDA=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "11006008 - public officials",
+            "attributes": [],
+            "id": "MTEwMDYwMDg=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        }
+      ],
+      "mediaType": [
+        {
+          "term": {
+            "name": "Text",
+            "attributes": [],
+            "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+            "taxonomy": "mediaType"
+          }
+        }
+      ],
+      "organisations": [
+        {
+          "term": {
+            "name": "International Monetary Fund",
+            "attributes": [
+              {
+                "value": "false",
+                "key": "is_company"
+              }
+            ],
+            "id": "VC0xNDcyNTU2-T04=",
+            "taxonomy": "organisations"
+          }
+        }
+      ],
+      "people": [
+        {
+          "term": {
+            "name": "George Osborne",
+            "attributes": [],
+            "id": "TnN0ZWluX1BOX1BvbGl0aWNpYW5fNTk4-UE4=",
+            "taxonomy": "people"
+          }
+        }
+      ],
+      "regions": [
+        {
+          "term": {
+            "name": "France",
+            "attributes": [],
+            "id": "TnN0ZWluX0dMX0ZS-R0w=",
+            "taxonomy": "regions"
+          }
+        },
+        {
+          "term": {
+            "name": "United Kingdom",
+            "attributes": [],
+            "id": "TnN0ZWluX0dMX0dC-R0w=",
+            "taxonomy": "regions"
+          }
+        },
+        {
+          "term": {
+            "name": "Greece",
+            "attributes": [],
+            "id": "TnN0ZWluX0dMX0dS-R0w=",
+            "taxonomy": "regions"
+          }
+        }
+      ],
+      "sections": [
+        {
+          "term": {
+            "name": "Brussels",
+            "attributes": [],
+            "id": "MTA=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "UK",
+            "attributes": [
+              {
+                "value": "world",
+                "key": "dfpSite"
+              },
+              {
+                "value": "uk",
+                "key": "dfpZone"
+              }
+            ],
+            "id": "Ng==-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "UK Politics & Policy",
+            "attributes": [],
+            "id": "OA==-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Europe",
+            "attributes": [
+              {
+                "value": "world",
+                "key": "dfpSite"
+              },
+              {
+                "value": "europe",
+                "key": "dfpZone"
+              }
+            ],
+            "id": "OQ==-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        }
+      ],
+      "specialReports": [],
+      "subjects": [
+        {
+          "term": {
+            "name": "Politics",
+            "attributes": [],
+            "id": "MTAx-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "Government News",
+            "attributes": [],
+            "id": "ODk=-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "Foreign Aid",
+            "attributes": [],
+            "id": "OTI=-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "International Affairs",
+            "attributes": [],
+            "id": "OTc=-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        }
+      ],
+      "topics": [
+        {
+          "term": {
+            "name": "Britain in Europe",
+            "attributes": [],
+            "id": "NDdiMzAyNzctMTRlMy00Zjk1LWEyZjYtYmYwZWIwYWU2NzAy-VG9waWNz",
+            "taxonomy": "topics"
+          }
+        },
+        {
+          "term": {
+            "name": "Euro in crisis",
+            "attributes": [],
+            "id": "OTZhMTRiZDItYjI2ZS00NGMzLTg1MjAtNjlkNzVmZjk2NTI1-VG9waWNz",
+            "taxonomy": "topics"
+          }
+        },
+        {
+          "term": {
+            "name": "Greece Debt Crisis",
+            "attributes": [],
+            "id": "ZmEzMmRmNDAtNDc0Zi00ODk3LWE2ZmQtZWFmYzJlZTRjZTVk-VG9waWNz",
+            "taxonomy": "topics"
+          }
+        }
+      ]
+    },
+    "images": [
+      {
+        "alt": "File photo dated 1/4/2015 of Chancellor of the Exchequer George Osborne who is expected to declare today that it s time for major cities in England to take control of their own affairs. PRESS ASSOCIATION Photo. Issue date: Thursday May 14, 2015. Making his first major speech of the new Parliament, Osborne will promise \"radical devolution\" for cities to allow them to grow their local economies. The plans under the Cities Devolution Bill will help to implement the so-called northern powerhouse vision Mr Osborne has previously outlined as a way to rebalance the UK economy. See PA story POLITICS Osborne. Photo credit should read: Stefan Rousseau/PA Wire",
+        "width": 272,
+        "mediaType": "image/jpeg",
+        "source": "PA",
+        "type": "primary",
+        "url": "http://im.ft-static.com/content/images/0a3f31e2-4c32-4dea-933a-5d56515272a9.img",
+        "height": 153
+      },
+      {
+        "alt": "File photo dated 1/4/2015 of Chancellor of the Exchequer George Osborne who is expected to declare today that it s time for major cities in England to take control of their own affairs. PRESS ASSOCIATION Photo. Issue date: Thursday May 14, 2015. Making his first major speech of the new Parliament, Osborne will promise \"radical devolution\" for cities to allow them to grow their local economies. The plans under the Cities Devolution Bill will help to implement the so-called northern powerhouse vision Mr Osborne has previously outlined as a way to rebalance the UK economy. See PA story POLITICS Osborne. Photo credit should read: Stefan Rousseau/PA Wire",
+        "width": 167,
+        "mediaType": "image/jpeg",
+        "source": "PA",
+        "type": "secondary",
+        "url": "http://im.ft-static.com/content/images/5a7428cb-a56a-4111-a534-92edcca55232.img",
+        "height": 94
+      },
+      {
+        "alt": "File photo dated 1/4/2015 of Chancellor of the Exchequer George Osborne who is expected to declare today that it s time for major cities in England to take control of their own affairs. PRESS ASSOCIATION Photo. Issue date: Thursday May 14, 2015. Making his first major speech of the new Parliament, Osborne will promise \"radical devolution\" for cities to allow them to grow their local economies. The plans under the Cities Devolution Bill will help to implement the so-called northern powerhouse vision Mr Osborne has previously outlined as a way to rebalance the UK economy. See PA story POLITICS Osborne. Photo credit should read: Stefan Rousseau/PA Wire",
+        "width": 600,
+        "mediaType": "image/jpeg",
+        "source": "PA",
+        "type": "article",
+        "url": "http://im.ft-static.com/content/images/b44ce242-7c38-4196-a957-28d02828a54e.img",
+        "height": 338
+      },
+      {
+        "alt": "File photo dated 1/4/2015 of Chancellor of the Exchequer George Osborne who is expected to declare today that it s time for major cities in England to take control of their own affairs. PRESS ASSOCIATION Photo. Issue date: Thursday May 14, 2015. Making his first major speech of the new Parliament, Osborne will promise \"radical devolution\" for cities to allow them to grow their local economies. The plans under the Cities Devolution Bill will help to implement the so-called northern powerhouse vision Mr Osborne has previously outlined as a way to rebalance the UK economy. See PA story POLITICS Osborne. Photo credit should read: Stefan Rousseau/PA Wire",
+        "width": 414,
+        "mediaType": "image/jpeg",
+        "source": "PA",
+        "type": "leader",
+        "url": "http://im.ft-static.com/content/images/bfb3caf4-99a2-420a-bd57-237b5a4d3e5b.img",
+        "height": 233
+      },
+      {
+        "alt": "File photo dated 1/4/2015 of Chancellor of the Exchequer George Osborne who is expected to declare today that it s time for major cities in England to take control of their own affairs. PRESS ASSOCIATION Photo. Issue date: Thursday May 14, 2015. Making his first major speech of the new Parliament, Osborne will promise \"radical devolution\" for cities to allow them to grow their local economies. The plans under the Cities Devolution Bill will help to implement the so-called northern powerhouse vision Mr Osborne has previously outlined as a way to rebalance the UK economy. See PA story POLITICS Osborne. Photo credit should read: Stefan Rousseau/PA Wire",
+        "width": 972,
+        "mediaType": "image/jpeg",
+        "source": "PA",
+        "type": "wide-format",
+        "url": "http://im.ft-static.com/content/images/a82fa6e9-13f8-4d6a-8de3-0b8a924b0687.img",
+        "height": 547
+      },
+      {
+        "alt": "Greece debt crisis",
+        "width": 167,
+        "mediaType": "image/jpeg",
+        "type": "promo",
+        "url": "http://im.ft-static.com/content/images/e1ce46ac-ac83-11e4-9aaa-00144feab7de.img",
+        "height": 96
+      }
+    ],
+    "package": [],
+    "assets": [
+      {
+        "name": "asset1",
+        "type": "promoBox",
+        "fields": {
+          "images": [
+            {
+              "alt": "Greece debt crisis",
+              "width": 167,
+              "mediaType": "image/jpeg",
+              "type": "promo",
+              "url": "http://im.ft-static.com/content/images/e1ce46ac-ac83-11e4-9aaa-00144feab7de.img",
+              "height": 96
+            }
+          ],
+          "intro": "<p>Greece has caved in to an ultimatum from Germany and its other creditors and agreed to rush through long-resisted economic reforms in a desperate bid to secure a €82bn-€86bn rescue and stay in the eurozone</p>\n<p><a title=\"www.ft.com\" href=\"http://www.ft.com/indepth/greece-debt-crisis\">Further reading</a>\n</p>",
+          "title": "<p>In depth</p>",
+          "headline": "<p><a title=\"Greece debt crisis in depth - FT.com\" href=\"http://www.ft.com/indepth/greece-debt-crisis\">Greece debt crisis</a>\n</p>"
+        }
+      },
+      {
+        "name": "asset2",
+        "type": "promoteNumber",
+        "fields": {
+          "intro": "<p>Amount Greece must find to pay the IMF and European Central Bank by Monday next week</p>",
+          "headline": "<p>€7bn</p>"
+        }
+      }
+    ],
+    "mediaAssets": []
+  },
+  "_lastUpdatedDateTime": "2015-09-12T18:11:21.777Z"
+}

--- a/test/fixtures/readNext/parentArticle4.json
+++ b/test/fixtures/readNext/parentArticle4.json
@@ -1,0 +1,413 @@
+{
+  "requestUrl": "http://api.ft.com/content/items/v1/d77bba14-5899-11e5-a28b-50226830d644?feature.blogposts=on&h=2988601686",
+  "item": {
+    "aspectSet": "article",
+    "aspects": [
+      "assets",
+      "body",
+      "editorial",
+      "images",
+      "lifecycle",
+      "location",
+      "master",
+      "mediaAssets",
+      "metadata",
+      "package",
+      "packaging",
+      "provenance",
+      "summary",
+      "title"
+    ],
+    "modelVersion": "1",
+    "id": "d77bba14-5899-11e5-a28b-50226830d644",
+    "apiUrl": "http://api.ft.com/content/items/v1/d77bba14-5899-11e5-a28b-50226830d644",
+    "title": {
+      "title": "Craft beers and palate patriotism"
+    },
+    "body": {
+      "mediaType": "text/html",
+      "body": "<p>Chinese nationalism comes in many flavours. There’s the tanks-in-the-street, I-hate-the-Japanese variety that was on display earlier this month when Beijing closed many of its streets and factories to parade killing machines through <a title=\"China cuts troops but parades its military might - ft.com\" href=\"http://www.ft.com/intl/cms/s/0/d4dda3a6-51de-11e5-8642-453585f2cfcd.html#slide0\">Tiananmen Square</a>. </p>\n<p>\n</p>\n<p>But there is also the altogether more palatable Sichuan-peppercorn-beer kind of nationalism, which involves brewing beer from local ingredients, for local palates, and seasoning it with a bit of Chinese philosophy, a dash of middle kingdom history — everything short of an actual Chinese flag. It sure beats that watered down, German-inspired brew that they sell for almost nothing, down at my local convenience store.</p>\n<p>These days, there’s more and more “palate patriotism” around in the country — foods, drinks, even coffees made by Chinese people, with Chinese ingredients for Chinese taste buds. I’m betting on that second kind of nationalism to power the mainland through to a “new normal” of growth based on something other than just copycatting what everyone else already does better.</p>\n<p>And yes, I have noticed that the rest of the world is worried that   the country’s economy is imploding. But the middle class doesn’t seem to have got that memo. So they’re still happy to spend 10, 20 or even 40 times as much on a craft beer with Chinese characteristics as on a bottle of<br/>Snow or Tsingtao. And it’s not just so they can drown their economic sorrows either: they still feel pretty flush. Sales of iPhones are booming — rising 75 per cent on the mainland year on year, Apple’s <a title=\"Apple TV and iPad revamp with new iPhone 6S - ft.com\" href=\"http://www.ft.com/intl/cms/s/0/33012b18-5713-11e5-9846-de406ccb37f2.html#slide0\">Tim Cook said last week</a>. </p>\n<p>“Demand is slowing, but there’s an underlying shift from mainstream to more specialised and niche consumption,” says Torsten Stocker, greater China retail partner at AT Kearney.</p>\n<p>Case in point: traditional beers had a bad year in 2014, with domestic production falling for the first time in two decades. This was partly due to competition from wine and other drinks, and partly due to the slowdown. But craft brewers can sell as much as they can make in China — which admittedly is not a huge amount yet, since the government treats craft breweries as basically illegal.  </p>\n<aside data-asset-type=\"pullQuote\" data-asset-name=\"asset1\"></aside><p>Most of the beer that is drunk in China today was not originally Chinese. Even Tsingtao, which the west thinks of as that most Chinese of beers, was set up by Germans in Qingdao, which was then a German colony: think alcoholic imperialism. Wikipedia says that China has been drinking beer, in one form or another, for 9,000 years — and since nobody really knows what the Chinese were doing 9,000 years ago, Wikipedia <br/>is as likely to be right about that as anyone else.</p>\n<p>Fermentation was — and still is — used in many primitive societies to help purify water. My first Financial Times job, back in 1980, involved drinking home-brewed sorghum beer in northern Ghana, which at the time had no reliable source of clean water. It was drunk all day long, like coffee or Diet Coke in other cultures — except that it got stronger as the day progressed. The same was once true in China. But what’s drunk in here today, in the main, is not at all indigenous.</p>\n<p>But now that’s changing. The country has a new generation of indigenous brewmasters (or foreigners who are well integrated into the society), and most of their customers are Chinese. Gao Yan — who prefers to be known as Master Gao, because of his US masters degree in chemistry — brews craft beers infused with the know-how of traditional Chinese medicine, in the second-tier Chinese city of Nanjing.</p>\n<p>He says his best-seller is jasmine tea lager, but his sweet potato beer — his first made from Chinese-inspired ingredients — did darned well too. He has brewed with purple rice, chilli peppers and sweet osmanthus flowers, while rival brewers use Sichuan peppercorns and Iron Buddha tea. Master Gao, whose first brewery was shut down by the government, says that most of his ingredients are western, “but the way we brew it, we build beer according to Chinese culture and customs”. </p>\n<p>And he’s happy to admit that that patriotic backstory has helped him sell four times as much beer this year as last. Sure beats missiles.</p>\n\n<p><span class=\"ft-italic\"><a title=\"Email the writer\" href=\"mailto:patti.waldmeir@ft.com\">patti.waldmeir@ft.com</a>\n</span>\n</p>"
+    },
+    "lifecycle": {
+      "initialPublishDateTime": "2015-09-14T12:27:09Z",
+      "lastPublishDateTime": "2015-09-14T12:27:09Z"
+    },
+    "location": {
+      "uri": "http://www.ft.com/cms/s/0/d77bba14-5899-11e5-a28b-50226830d644.html"
+    },
+    "summary": {
+      "excerpt": "Brews from local ingredients, infused with Chinese philosophy, are quenching a thirst"
+    },
+    "packaging": {
+      "spHeadline": "China’s new palate patriotism"
+    },
+    "master": {
+      "masterSource": "Methode",
+      "masterEntityId": "d77bba14-5899-11e5-a28b-50226830d644"
+    },
+    "editorial": {
+      "subheading": "Brews from local ingredients, infused with Chinese philosophy, are quenching a thirst",
+      "standFirst": "Brews from local ingredients, infused with Chinese philosophy, are quenching a thirst",
+      "byline": "Patti Waldmeir – Shanghai"
+    },
+    "provenance": {
+      "originatingParty": "FT"
+    },
+    "metadata": {
+      "primarySection": {
+        "term": {
+          "name": "Columnists",
+          "id": "MTE3-U2VjdGlvbnM=",
+          "attributes": [
+            {
+              "value": "opinion",
+              "key": "dfpSite"
+            },
+            {
+              "value": "columnists",
+              "key": "dfpZone"
+            }
+          ],
+          "taxonomy": "sections"
+        }
+      },
+      "primaryTheme": {
+        "term": {
+          "name": "Patti Waldmeir",
+          "id": "Q0ItMDAwMDg4Ng==-QXV0aG9ycw==",
+          "attributes": [],
+          "taxonomy": "authors"
+        }
+      },
+      "tags": [
+        {
+          "term": {
+            "name": "Patti Waldmeir",
+            "attributes": [],
+            "id": "Q0ItMDAwMDg4Ng==-QXV0aG9ycw==",
+            "taxonomy": "authors"
+          }
+        },
+        {
+          "term": {
+            "name": "Columnists",
+            "attributes": [
+              {
+                "value": "opinion",
+                "key": "dfpSite"
+              },
+              {
+                "value": "columnists",
+                "key": "dfpZone"
+              }
+            ],
+            "id": "MTE3-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "China Society",
+            "attributes": [],
+            "id": "MmFlY2ExNzQtYmM4Ni00ZjRkLWI4NmItNjgxOTBhMDNkMjY5-VG9waWNz",
+            "taxonomy": "topics"
+          }
+        },
+        {
+          "term": {
+            "name": "Comment",
+            "attributes": [],
+            "id": "OA==-R2VucmVz",
+            "taxonomy": "genre"
+          }
+        },
+        {
+          "term": {
+            "name": "Text",
+            "attributes": [],
+            "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+            "taxonomy": "mediaType"
+          }
+        },
+        {
+          "term": {
+            "name": "Shanghai",
+            "attributes": [],
+            "id": "TnN0ZWluX0dMX0FGVE1fR0xfNjg2MDc=-R0w=",
+            "taxonomy": "regions"
+          }
+        },
+        {
+          "term": {
+            "name": "China",
+            "attributes": [],
+            "id": "TnN0ZWluX0dMX0NO-R0w=",
+            "taxonomy": "regions"
+          }
+        },
+        {
+          "term": {
+            "name": "World",
+            "attributes": [
+              {
+                "value": "world",
+                "key": "dfpSite"
+              }
+            ],
+            "id": "MQ==-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Opinion",
+            "attributes": [
+              {
+                "value": "opinion",
+                "key": "dfpSite"
+              }
+            ],
+            "id": "MTE2-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Asia Pacific",
+            "attributes": [
+              {
+                "value": "world",
+                "key": "dfpSite"
+              },
+              {
+                "value": "asia.pacific",
+                "key": "dfpZone"
+              }
+            ],
+            "id": "MTE=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "General News",
+            "attributes": [],
+            "id": "MTE4-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "Comment & Analysis",
+            "attributes": [],
+            "id": "MTIz-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        }
+      ],
+      "authors": [
+        {
+          "term": {
+            "name": "Patti Waldmeir",
+            "attributes": [],
+            "id": "Q0ItMDAwMDg4Ng==-QXV0aG9ycw==",
+            "taxonomy": "authors"
+          }
+        }
+      ],
+      "brand": [],
+      "genre": [
+        {
+          "term": {
+            "name": "Comment",
+            "attributes": [],
+            "id": "OA==-R2VucmVz",
+            "taxonomy": "genre"
+          }
+        }
+      ],
+      "icb": [],
+      "iptc": [],
+      "mediaType": [
+        {
+          "term": {
+            "name": "Text",
+            "attributes": [],
+            "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+            "taxonomy": "mediaType"
+          }
+        }
+      ],
+      "organisations": [],
+      "people": [],
+      "regions": [
+        {
+          "term": {
+            "name": "Shanghai",
+            "attributes": [],
+            "id": "TnN0ZWluX0dMX0FGVE1fR0xfNjg2MDc=-R0w=",
+            "taxonomy": "regions"
+          }
+        },
+        {
+          "term": {
+            "name": "China",
+            "attributes": [],
+            "id": "TnN0ZWluX0dMX0NO-R0w=",
+            "taxonomy": "regions"
+          }
+        }
+      ],
+      "sections": [
+        {
+          "term": {
+            "name": "World",
+            "attributes": [
+              {
+                "value": "world",
+                "key": "dfpSite"
+              }
+            ],
+            "id": "MQ==-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Opinion",
+            "attributes": [
+              {
+                "value": "opinion",
+                "key": "dfpSite"
+              }
+            ],
+            "id": "MTE2-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Columnists",
+            "attributes": [
+              {
+                "value": "opinion",
+                "key": "dfpSite"
+              },
+              {
+                "value": "columnists",
+                "key": "dfpZone"
+              }
+            ],
+            "id": "MTE3-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Asia Pacific",
+            "attributes": [
+              {
+                "value": "world",
+                "key": "dfpSite"
+              },
+              {
+                "value": "asia.pacific",
+                "key": "dfpZone"
+              }
+            ],
+            "id": "MTE=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        }
+      ],
+      "specialReports": [],
+      "subjects": [
+        {
+          "term": {
+            "name": "General News",
+            "attributes": [],
+            "id": "MTE4-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        },
+        {
+          "term": {
+            "name": "Comment & Analysis",
+            "attributes": [],
+            "id": "MTIz-U3ViamVjdHM=",
+            "taxonomy": "subjects"
+          }
+        }
+      ],
+      "topics": [
+        {
+          "term": {
+            "name": "China Society",
+            "attributes": [],
+            "id": "MmFlY2ExNzQtYmM4Ni00ZjRkLWI4NmItNjgxOTBhMDNkMjY5-VG9waWNz",
+            "taxonomy": "topics"
+          }
+        }
+      ]
+    },
+    "images": [
+      {
+        "alt": "Guests mingle at the opening of Diageo Plc's Johnnie Walker brand store in Shanghai, China, on Thursday, May 19, 2011. In a converted villa in the fashionable French Concession in Shanghai, Diageo Plc is trying to wean wealthy Chinese drinkers from their love of cognac. Photographer: Kevin Lee/Bloomberg",
+        "width": 272,
+        "mediaType": "image/jpeg",
+        "source": "Bloomberg",
+        "type": "primary",
+        "url": "http://im.ft-static.com/content/images/5e69e49b-7a62-4b2e-a974-d3ca7c4b5bc5.img",
+        "height": 153
+      },
+      {
+        "alt": "Guests mingle at the opening of Diageo Plc's Johnnie Walker brand store in Shanghai, China, on Thursday, May 19, 2011. In a converted villa in the fashionable French Concession in Shanghai, Diageo Plc is trying to wean wealthy Chinese drinkers from their love of cognac. Photographer: Kevin Lee/Bloomberg",
+        "width": 167,
+        "mediaType": "image/jpeg",
+        "source": "Bloomberg",
+        "type": "secondary",
+        "url": "http://im.ft-static.com/content/images/aaf127e4-51aa-4ab5-b2e6-3ab9a8038931.img",
+        "height": 94
+      },
+      {
+        "alt": "Guests mingle at the opening of Diageo Plc's Johnnie Walker brand store in Shanghai, China, on Thursday, May 19, 2011. In a converted villa in the fashionable French Concession in Shanghai, Diageo Plc is trying to wean wealthy Chinese drinkers from their love of cognac. Photographer: Kevin Lee/Bloomberg",
+        "width": 600,
+        "mediaType": "image/jpeg",
+        "source": "Bloomberg",
+        "type": "article",
+        "url": "http://im.ft-static.com/content/images/18d3068e-3bc5-451f-a78d-41ec9d74d59f.img",
+        "height": 338
+      },
+      {
+        "alt": "Guests mingle at the opening of Diageo Plc's Johnnie Walker brand store in Shanghai, China, on Thursday, May 19, 2011. In a converted villa in the fashionable French Concession in Shanghai, Diageo Plc is trying to wean wealthy Chinese drinkers from their love of cognac. Photographer: Kevin Lee/Bloomberg",
+        "width": 414,
+        "mediaType": "image/jpeg",
+        "source": "Bloomberg",
+        "type": "leader",
+        "url": "http://im.ft-static.com/content/images/21d1c731-5890-41f2-aeff-8e262cf5fcbf.img",
+        "height": 233
+      },
+      {
+        "alt": "Guests mingle at the opening of Diageo Plc's Johnnie Walker brand store in Shanghai, China, on Thursday, May 19, 2011. In a converted villa in the fashionable French Concession in Shanghai, Diageo Plc is trying to wean wealthy Chinese drinkers from their love of cognac. Photographer: Kevin Lee/Bloomberg",
+        "width": 972,
+        "mediaType": "image/jpeg",
+        "source": "Bloomberg",
+        "type": "wide-format",
+        "url": "http://im.ft-static.com/content/images/b9cb7364-e2f9-4f56-8a0b-7ddc96973c16.img",
+        "height": 547
+      }
+    ],
+    "package": [],
+    "assets": [
+      {
+        "name": "asset1",
+        "type": "pullQuote",
+        "fields": {
+          "body": "<p>The country has a new generation of indigenous brewmasters, and most of their customers are Chinese</p>"
+        }
+      }
+    ],
+    "mediaAssets": []
+  },
+  "_lastUpdatedDateTime": "2015-09-14T15:29:38.343Z"
+}

--- a/test/fixtures/readNext/readNextArticle1.json
+++ b/test/fixtures/readNext/readNextArticle1.json
@@ -1,0 +1,31 @@
+{
+  "headline": {
+    "text": "Steve Jobs film will upset fans but misreads underdog mindset",
+    "url": "/41129eec-5b9d-11e5-a28b-50226830d644"
+    },
+  "lastUpdated": "2015-09-16T11:44:13Z",
+  "subheading": "Documentary paints critical picture of Apple founder",
+  "topic": {
+    "name": "Steve Jobs",
+    "id": "TnN0ZWluX1BOX0VudGVydGFpbm1lbnRfMjAwOV8xMF85XzQ1MDQ3-UE4=",
+    "attributes": [],
+    "taxonomy": "people",
+    "url": "/stream/peopleId/TnN0ZWluX1BOX0VudGVydGFpbm1lbnRfMjAwOV8xMF85XzQ1MDQ3-UE4="
+  },
+  "visualCategory": "default",
+  "image": {
+    "alt": "Steve Jobs",
+    "width": 972,
+    "mediaType": "image/jpeg",
+    "source": "FT",
+    "type": "wide-format",
+    "url": "http://im.ft-static.com/content/images/abda36f3-8afa-48a8-9bc8-58d7a6cfdd4f.img",
+    "height": 547,
+    "srcset": {
+      "default": 100
+    },
+    "class": ""
+  },
+  "source": "topic",
+  "moreRecent": true
+}

--- a/test/fixtures/readNext/readNextArticle2.json
+++ b/test/fixtures/readNext/readNextArticle2.json
@@ -1,0 +1,29 @@
+{
+  "headline": {
+    "text": "CNPC forced to sell businesses as China’s crackdown widens",
+    "url": "/a581b44e-5acb-11e5-a28b-50226830d644"
+    },
+  "lastUpdated":"2015-09-14T14:26:37Z",
+  "subheading":"Non-core businesses to go as SEOs come under government pressure",
+  "topic": {
+    "name": "China",
+    "id": "TnN0ZWluX0dMX0NO-R0w=",
+    "attributes": [],
+    "taxonomy": "regions",
+    "url": "/stream/regionsId/TnN0ZWluX0dMX0NO-R0w="
+  },
+  "visualCategory":"default",
+  "image":{
+    "alt":"epa04793150 (FILE) A file picture dated 01 November 2010 shows Chinese Zhou Yongkang, then member of the Standing Committee of the Politburo and Secretary of Political and Legislative Affairs Committee, addressing a seminar in New Delhi, India. Zhou Yongkang has been sentenced to life in prison, it was reported 11 June 2015. He was found guilty of bribery, abuse of power and 'intentionally disclosing national secrets', Chinese media reports. EPA/ANINDITO MUKHERJEE",
+    "width":972,
+    "caption":"Zhou Yongkang, China’s disgraced energy and security tsar, whose influence thrived in CNPC’s Soluxe hotel chain",
+    "mediaType":"image/jpeg",
+    "source":"EPA",
+    "type":"wide-format",
+    "url":"http://im.ft-static.com/content/images/b29be4bd-ef06-4839-984b-d21ead0c0a06.img",
+    "height":547,
+    "srcset":{"default":100},
+    "class":""
+  },
+  "source": "package"
+}

--- a/test/fixtures/readNext/readNextArticle3.json
+++ b/test/fixtures/readNext/readNextArticle3.json
@@ -1,0 +1,18 @@
+{
+  "headline": {
+    "text": "Free Lunch: Lessons from Greece",
+    "url": "/eaa2adf0-5bb4-11e5-9846-de406ccb37f2"
+  },
+  "lastUpdated": "2015-09-16T11:58:53Z",
+  "subheading": "A long and tragic history of external debt crises",
+  "topic": {
+    "name": "Euro in crisis",
+    "id": "OTZhMTRiZDItYjI2ZS00NGMzLTg1MjAtNjlkNzVmZjk2NTI1-VG9waWNz",
+    "attributes": [],
+    "taxonomy": "topics",
+    "url": "/stream/topicsId/OTZhMTRiZDItYjI2ZS00NGMzLTg1MjAtNjlkNzVmZjk2NTI1-VG9waWNz"
+  },
+  "visualCategory": "default",
+  "source": "topic",
+  "moreRecent": true
+}

--- a/test/fixtures/readNext/readNextArticle4.json
+++ b/test/fixtures/readNext/readNextArticle4.json
@@ -1,0 +1,26 @@
+{
+  "headline": {
+    "text": "China eases limits on overseas debt",
+    "url": "/921d8c8e-5c47-11e5-a28b-50226830d644"
+    },
+  "lastUpdated":"2015-08-16T09:07:26Z",
+  "subheading":"Inbound fund controls loosened amid fears over capital outflows",
+  "topic": {
+    "name": "China Economic Slowdown",
+    "id": "NWIwYzgxZTgtZjc3MC00ODNkLWI1YjYtYTVhNGQ2OTNjYjVi-VG9waWNz",
+    "attributes": [],
+    "taxonomy": "topics",
+    "url": "/stream/topicsId/NWIwYzgxZTgtZjc3MC00ODNkLWI1YjYtYTVhNGQ2OTNjYjVi-VG9waWNz"
+  },
+  "visualCategory":"default",
+  "image":{
+    "width":972,"mediaType":"image/jpeg",
+    "source":"AFP","type":"wide-format",
+    "url":"http://im.ft-static.com/content/images/0521f258-e325-4d8e-8cac-29e67523f43d.img",
+    "height":547,
+    "srcset":{
+      "default":100},
+      "class":""
+      },
+  "source":"topic"
+}

--- a/test/fixtures/readNext/storyPackageArticle1.json
+++ b/test/fixtures/readNext/storyPackageArticle1.json
@@ -1,0 +1,986 @@
+{
+  "requestUrl": "http://api.ft.com/content/items/v1/9a2b7608-5746-11e5-9846-de406ccb37f2?feature.blogposts=on&h=9402714334",
+  "item": {
+    "aspectSet": "article",
+    "aspects": [
+      "assets",
+      "body",
+      "editorial",
+      "images",
+      "lifecycle",
+      "location",
+      "master",
+      "mediaAssets",
+      "metadata",
+      "package",
+      "packaging",
+      "provenance",
+      "summary",
+      "title"
+    ],
+    "modelVersion": "1",
+    "id": "9a2b7608-5746-11e5-9846-de406ccb37f2",
+    "apiUrl": "http://api.ft.com/content/items/v1/9a2b7608-5746-11e5-9846-de406ccb37f2",
+    "title": {
+      "title": "T-Mobile takes on Apple with iPhone upgrade plan"
+    },
+    "body": {
+      "mediaType": "text/html",
+      "body": "<aside data-asset-type=\"slideshow\" data-asset-name=\"asset1\"></aside><p>\n</p>\n<p>T-Mobile US has unveiled a generous deal that will allow customers to lease the latest iPhone for as little as $20 a month, in a move designed to head off the competitive threat of a new upgrade plan from Apple. </p>\n<p>The iPhone maker on Wednesday <a title=\"Apple TV and iPad revamp with new iPhone 6S - FT.com\" href=\"http://www.ft.com/intl/cms/s/0/33012b18-5713-11e5-9846-de406ccb37f2.html#axzz3lBpzxejN\">announced</a> its first ever upgrade plan, which will let customers trade up to the latest model of its smartphone every year, in a move that threatens to disrupt the relationship between wireless carriers and their subscribers. </p>\n<p>For a monthly fee starting at $32.41 for an entry-level iPhone 6S, customers will receive an unlocked handset every year which they can use with a carrier of their choice. The price equates to the full, unsubsidised cost of a new iPhone split over 24 months, including AppleCare+, which offers technical support and insurance against some accidental damage. </p>\n<p>Customers will only receive a new handset if they give Apple back their year-old device and renew the two-year financing plan at the same time. The financing will be provided by Citizens One Personal Loans.</p>\n<p>As part of a fightback, T-Mobile said on Thursday that consumers would be able to pre-order the same iPhone model for $20 a month through its Jump! On Demand leasing plan, which lets customers upgrade their phone up to three times a year.</p>\n<p>Even factoring in the cost of insurance and technical support, the deal is significantly cheaper than the Apple plan. After 18 months, the customer will either be able to hand back the phone in exchange for an upgrade or pay a final instalment of $164 to keep it. </p>\n<p>That would bring the total cost of the iPhone 6S to $524 — a saving of $125 on Apple’s price — and shows the degree to which T-Mobile is willing to subsidise the handset to maintain its blistering growth rate. </p>\n<p>British carrier O2 said it would also offer an iPhone 6S bundled with free insurance, and that customers on one of its tariffs would be able to upgrade to a new handset after 12 months without charge. It will announce prices on Friday. <br/>\n</p>\n<p>Apple’s new leasing plan is designed to boost the proportion of customers upgrading their phones during each cycle. </p>\n<p>Analysts at Morgan Stanley estimated the program would boost iPhone shipments by 6.5m units in 2017, increasing to 24m units if the scheme is rolled out globally. This projection is based on the assumption that 10 per cent of iPhone purchasers will opt for the plan. </p>\n<p>But the decision by carriers to start selling most phones on a two-year instalment plan could dampen demand when Apple launches a new iPhone because consumers are “tied in” to their existing contract. </p>\n<aside data-asset-type=\"video\" data-asset-name=\"asset2\"></aside>\n\n<p>Apple’s new upgrade plan represents something of a double-edged sword for US carriers, which do not make a profit from selling phones.</p>\n<p>“Carriers aren’t in the phone-selling business — they don’t make any money from it, and there is in fact a cost associated with managing inventory, and taking reserves against bad debts in case they can’t collect payments,” said Jonathan Chaplin, an analyst at New Street Research. </p>\n<aside data-asset-type=\"pullQuote\" data-asset-name=\"asset3\"></aside><p>\n</p>\n<p>Craig Moffett, an analyst at MoffettNathanson, added: “Selling handsets is a cost centre for carriers, not a profit centre, so offloading the bad debt and financing burden isn’t all bad.”</p>\n<p>However, Apple’s plan could weaken the ties between telecoms groups such as Verizon and AT&amp;T and their customers, turning them into groups providers of wireless access but taking away the opportunity to sell higher margin products and services. </p>\n<p>“Apple would love to commoditise the carriers and be the source of the entire relationship,” said Mr Chaplin.</p>\n<p>But analysts said it would be wrong to interpret Apple’s move as a declaration on the telecoms sector, which is still by far its biggest customer. Nonetheless, any move by the technology company to reinterpret the relationship between carriers and their customers would probably be viewed with suspicion by the industry. </p>\n<p>The impact of the Apple program is likely to be exacerbated by a recent shift in the business models of wireless carriers, which are ditching traditional service contracts that tie in customers for up to two years in favour of rolling agreements that can be cancelled at any time.</p>\n<aside data-asset-type=\"pullQuote\" data-asset-name=\"asset4\"></aside><p>\n</p>\n<p>Under these new agreements, carriers sell phones to customers separately, in most cases through a financing program known as an equipment instalment plan or EIP, which typically recoups the cost of the handset over two years. </p>\n<p>Increasingly, it is this contract that discourages customers from switching to a rival carrier: if they decide to leave, they have to pay off the full cost of the handset at a price that is often prohibitively expensive. </p>\n<p>However, if a customer were to lease their phone directly from Apple, they would be able to switch carriers more easily. That scenario would likely to benefit the smallest networks, T-Mobile US and Sprint, which have made a <a title=\"T-Mobile in the pink as it hurts rivals - FT.com\" href=\"http://www.ft.com/intl/cms/s/0/7cc41b5a-edfc-11e4-987e-00144feab7de.html#axzz3lFUHIHjN\">concerted effort </a>to win new subscribers with steep price cuts. </p>\n<p>Whether customers sign up to Apple’s upgrade scheme in large numbers depends on the prices and plans that wireless carriers unveil for the new iPhones in the coming days, analysts said.</p>\n<p>Sprint already offers a leasing plan similar to Apple’s for $22 a month with a pledge to upgrade a customer whenever a new iPhone is launched, while T-Mobile offers a $25 a month plan that lets subscribers upgrade their <a title=\"T-Mobile in fresh assault on US mobile market - FT.com\" href=\"http://www.ft.com/intl/cms/s/0/36f95aac-1b53-11e5-8201-cbdb03d71480.html#axzz3lFUHIHjN\">handset </a>up to three times a year. </p>\n<p>The iPhone upgrade scheme could encourage Verizon and AT&amp;T to follow Sprint and T-Mobile — and Apple — by offering their own leasing plans. </p>\n<p>Michael Rollins, an analyst at Citi, said: “We see the move by Apple as a further affirmation that carriers will probably move to 100 per cent device financing and leasing over the next few years.”</p>"
+    },
+    "lifecycle": {
+      "initialPublishDateTime": "2015-09-10T01:00:50Z",
+      "lastPublishDateTime": "2015-09-10T17:18:07Z"
+    },
+    "location": {
+      "uri": "http://www.ft.com/cms/s/0/9a2b7608-5746-11e5-9846-de406ccb37f2.html"
+    },
+    "summary": {
+      "excerpt": "New leasing option to upgrade handsets designed to head off competitive threat from tech group"
+    },
+    "packaging": {
+      "spHeadline": "T-Mobile takes on Apple with iPhone plan"
+    },
+    "master": {
+      "masterSource": "Methode",
+      "masterEntityId": "9a2b7608-5746-11e5-9846-de406ccb37f2"
+    },
+    "editorial": {
+      "subheading": "Leasing option aimed at heading off competitive threat",
+      "standFirst": "New leasing option to upgrade handsets designed to head off competitive threat from tech group",
+      "byline": "David Crow in New York and Tim Bradshaw in San Francisco",
+      "otherTitles": [
+        "T-Mobile takes on Apple with iPhone plan"
+      ]
+    },
+    "provenance": {
+      "originatingParty": "FT"
+    },
+    "metadata": {
+      "primarySection": {
+        "term": {
+          "name": "Telecoms",
+          "id": "NTY=-U2VjdGlvbnM=",
+          "attributes": [
+            {
+              "value": "companies",
+              "key": "dfpSite"
+            },
+            {
+              "value": "telecoms",
+              "key": "dfpZone"
+            }
+          ],
+          "taxonomy": "sections"
+        }
+      },
+      "primaryTheme": {
+        "term": {
+          "name": "Apple Inc",
+          "id": "TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0FBUEw=-T04=",
+          "attributes": [
+            {
+              "value": "us:AAPL",
+              "key": "wsod_key"
+            },
+            {
+              "value": "true",
+              "key": "is_company"
+            }
+          ],
+          "taxonomy": "organisations"
+        }
+      },
+      "tags": [
+        {
+          "term": {
+            "name": "Apple Inc",
+            "attributes": [
+              {
+                "value": "us:AAPL",
+                "key": "wsod_key"
+              },
+              {
+                "value": "true",
+                "key": "is_company"
+              }
+            ],
+            "id": "TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0FBUEw=-T04=",
+            "taxonomy": "organisations"
+          }
+        },
+        {
+          "term": {
+            "name": "Telecoms",
+            "attributes": [
+              {
+                "value": "companies",
+                "key": "dfpSite"
+              },
+              {
+                "value": "telecoms",
+                "key": "dfpZone"
+              }
+            ],
+            "id": "NTY=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "News",
+            "attributes": [],
+            "id": "Nw==-R2VucmVz",
+            "taxonomy": "genre"
+          }
+        },
+        {
+          "term": {
+            "name": "Text",
+            "attributes": [],
+            "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+            "taxonomy": "mediaType"
+          }
+        },
+        {
+          "term": {
+            "name": "David Crow",
+            "attributes": [],
+            "id": "NGJkMGI5NTUtOThiMC00MjU0LWI3ZGEtNzBmMWFjODRjYTZm-QXV0aG9ycw==",
+            "taxonomy": "authors"
+          }
+        },
+        {
+          "term": {
+            "name": "Tim Bradshaw",
+            "attributes": [],
+            "id": "Q0ItMDAwMDY4OA==-QXV0aG9ycw==",
+            "taxonomy": "authors"
+          }
+        },
+        {
+          "term": {
+            "name": "04003007 - telecommunication service",
+            "attributes": [],
+            "id": "MDQwMDMwMDc=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "04003009 - wireless technology",
+            "attributes": [],
+            "id": "MDQwMDMwMDk=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "04008017 - prices",
+            "attributes": [],
+            "id": "MDQwMDgwMTc=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "04016055 - consumers",
+            "attributes": [],
+            "id": "MDQwMTYwNTU=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "T-Mobile USA Inc",
+            "attributes": [
+              {
+                "value": "true",
+                "key": "is_company"
+              }
+            ],
+            "id": "OGI2MjhjNjYtMDNmOS00NDI5LWFjZDYtOTZkNzE4Zjc5ZGJj-T04=",
+            "taxonomy": "organisations"
+          }
+        },
+        {
+          "term": {
+            "name": "AT&T Inc",
+            "attributes": [
+              {
+                "value": "us:T",
+                "key": "wsod_key"
+              },
+              {
+                "value": "true",
+                "key": "is_company"
+              }
+            ],
+            "id": "TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X1Q=-T04=",
+            "taxonomy": "organisations"
+          }
+        },
+        {
+          "term": {
+            "name": "Verizon Communications Inc",
+            "attributes": [
+              {
+                "value": "us:VZ",
+                "key": "wsod_key"
+              },
+              {
+                "value": "true",
+                "key": "is_company"
+              }
+            ],
+            "id": "TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X1Za-T04=",
+            "taxonomy": "organisations"
+          }
+        },
+        {
+          "term": {
+            "name": "Sprint Corp",
+            "attributes": [
+              {
+                "value": "false",
+                "key": "is_company"
+              }
+            ],
+            "id": "ZWY1ZDNkZDYtYWVjNi00ZTFkLTk2OWYtZGUzYmIwNDI3NzEw-T04=",
+            "taxonomy": "organisations"
+          }
+        },
+        {
+          "term": {
+            "name": "United States of America",
+            "attributes": [],
+            "id": "TnN0ZWluX0dMX1VT-R0w=",
+            "taxonomy": "regions"
+          }
+        },
+        {
+          "term": {
+            "name": "Companies",
+            "attributes": [
+              {
+                "value": "companies",
+                "key": "dfpSite"
+              }
+            ],
+            "id": "Mjk=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Technology",
+            "attributes": [
+              {
+                "value": "companies",
+                "key": "dfpSite"
+              },
+              {
+                "value": "technology",
+                "key": "dfpZone"
+              }
+            ],
+            "id": "NTM=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Companies By Region",
+            "attributes": [],
+            "id": "NjI=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "US & Canadian Companies",
+            "attributes": [],
+            "id": "NjU=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        }
+      ],
+      "authors": [
+        {
+          "term": {
+            "name": "David Crow",
+            "attributes": [],
+            "id": "NGJkMGI5NTUtOThiMC00MjU0LWI3ZGEtNzBmMWFjODRjYTZm-QXV0aG9ycw==",
+            "taxonomy": "authors"
+          }
+        },
+        {
+          "term": {
+            "name": "Tim Bradshaw",
+            "attributes": [],
+            "id": "Q0ItMDAwMDY4OA==-QXV0aG9ycw==",
+            "taxonomy": "authors"
+          }
+        }
+      ],
+      "brand": [],
+      "genre": [
+        {
+          "term": {
+            "name": "News",
+            "attributes": [],
+            "id": "Nw==-R2VucmVz",
+            "taxonomy": "genre"
+          }
+        }
+      ],
+      "icb": [],
+      "iptc": [
+        {
+          "term": {
+            "name": "04003007 - telecommunication service",
+            "attributes": [],
+            "id": "MDQwMDMwMDc=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "04003009 - wireless technology",
+            "attributes": [],
+            "id": "MDQwMDMwMDk=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "04008017 - prices",
+            "attributes": [],
+            "id": "MDQwMDgwMTc=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "04016055 - consumers",
+            "attributes": [],
+            "id": "MDQwMTYwNTU=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        }
+      ],
+      "mediaType": [
+        {
+          "term": {
+            "name": "Text",
+            "attributes": [],
+            "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+            "taxonomy": "mediaType"
+          }
+        }
+      ],
+      "organisations": [
+        {
+          "term": {
+            "name": "T-Mobile USA Inc",
+            "attributes": [
+              {
+                "value": "true",
+                "key": "is_company"
+              }
+            ],
+            "id": "OGI2MjhjNjYtMDNmOS00NDI5LWFjZDYtOTZkNzE4Zjc5ZGJj-T04=",
+            "taxonomy": "organisations"
+          }
+        },
+        {
+          "term": {
+            "name": "Apple Inc",
+            "attributes": [
+              {
+                "value": "us:AAPL",
+                "key": "wsod_key"
+              },
+              {
+                "value": "true",
+                "key": "is_company"
+              }
+            ],
+            "id": "TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0FBUEw=-T04=",
+            "taxonomy": "organisations"
+          }
+        },
+        {
+          "term": {
+            "name": "AT&T Inc",
+            "attributes": [
+              {
+                "value": "us:T",
+                "key": "wsod_key"
+              },
+              {
+                "value": "true",
+                "key": "is_company"
+              }
+            ],
+            "id": "TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X1Q=-T04=",
+            "taxonomy": "organisations"
+          }
+        },
+        {
+          "term": {
+            "name": "Verizon Communications Inc",
+            "attributes": [
+              {
+                "value": "us:VZ",
+                "key": "wsod_key"
+              },
+              {
+                "value": "true",
+                "key": "is_company"
+              }
+            ],
+            "id": "TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X1Za-T04=",
+            "taxonomy": "organisations"
+          }
+        },
+        {
+          "term": {
+            "name": "Sprint Corp",
+            "attributes": [
+              {
+                "value": "false",
+                "key": "is_company"
+              }
+            ],
+            "id": "ZWY1ZDNkZDYtYWVjNi00ZTFkLTk2OWYtZGUzYmIwNDI3NzEw-T04=",
+            "taxonomy": "organisations"
+          }
+        }
+      ],
+      "people": [],
+      "regions": [
+        {
+          "term": {
+            "name": "United States of America",
+            "attributes": [],
+            "id": "TnN0ZWluX0dMX1VT-R0w=",
+            "taxonomy": "regions"
+          }
+        }
+      ],
+      "sections": [
+        {
+          "term": {
+            "name": "Companies",
+            "attributes": [
+              {
+                "value": "companies",
+                "key": "dfpSite"
+              }
+            ],
+            "id": "Mjk=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Technology",
+            "attributes": [
+              {
+                "value": "companies",
+                "key": "dfpSite"
+              },
+              {
+                "value": "technology",
+                "key": "dfpZone"
+              }
+            ],
+            "id": "NTM=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Telecoms",
+            "attributes": [
+              {
+                "value": "companies",
+                "key": "dfpSite"
+              },
+              {
+                "value": "telecoms",
+                "key": "dfpZone"
+              }
+            ],
+            "id": "NTY=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Companies By Region",
+            "attributes": [],
+            "id": "NjI=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "US & Canadian Companies",
+            "attributes": [],
+            "id": "NjU=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        }
+      ],
+      "specialReports": [],
+      "subjects": [],
+      "topics": []
+    },
+    "images": [
+      {
+        "width": 272,
+        "mediaType": "image/jpeg",
+        "source": "Bloomberg",
+        "type": "primary",
+        "url": "http://im.ft-static.com/content/images/9f797ffd-b2f3-49bb-933b-c299faac7846.img",
+        "height": 153
+      },
+      {
+        "width": 167,
+        "mediaType": "image/jpeg",
+        "source": "Bloomberg",
+        "type": "secondary",
+        "url": "http://im.ft-static.com/content/images/5338582c-f78b-493a-88c6-f96bbf1ae84e.img",
+        "height": 94
+      },
+      {
+        "width": 600,
+        "mediaType": "image/jpeg",
+        "source": "Bloomberg",
+        "type": "article",
+        "url": "http://im.ft-static.com/content/images/a7c4ca26-12bc-4da8-a45e-ac51dd58bcd8.img",
+        "height": 338
+      },
+      {
+        "width": 414,
+        "mediaType": "image/jpeg",
+        "source": "Bloomberg",
+        "type": "leader",
+        "url": "http://im.ft-static.com/content/images/41d96c22-64c7-4d42-ba5f-4980f9298962.img",
+        "height": 233
+      },
+      {
+        "width": 972,
+        "mediaType": "image/jpeg",
+        "source": "Bloomberg",
+        "type": "wide-format",
+        "url": "http://im.ft-static.com/content/images/c28954e5-5057-41a7-aeab-2e77a0af78d1.img",
+        "height": 547
+      },
+      {
+        "width": 150,
+        "mediaType": "image/jpeg",
+        "type": "inline",
+        "url": "http://im.ft-static.com/content/images/91b39ae8-ccff-11e1-92c1-00144feabdc0.img",
+        "height": 100
+      }
+    ],
+    "package": [
+      {
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "apiUrl": "http://api.ft.com/content/items/v1/1438c26a-57d4-11e5-97e9-7f0bf5e7177b",
+        "packaging": {
+          "spHeadline": "Apple TV wants viewers to change channel"
+        },
+        "id": "1438c26a-57d4-11e5-97e9-7f0bf5e7177b"
+      },
+      {
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "apiUrl": "http://api.ft.com/content/items/v1/beee7cdc-576f-11e5-a28b-50226830d644",
+        "packaging": {
+          "spHeadline": "Apple — carried away",
+          "kicker": "Comment"
+        },
+        "id": "beee7cdc-576f-11e5-a28b-50226830d644"
+      },
+      {
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "apiUrl": "http://api.ft.com/content/items/v1/33012b18-5713-11e5-9846-de406ccb37f2",
+        "packaging": {
+          "spHeadline": "Apple TV and iPad revamp with iPhone 6S"
+        },
+        "id": "33012b18-5713-11e5-9846-de406ccb37f2"
+      },
+      {
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "apiUrl": "http://api.ft.com/content/items/v1/44022e2a-541e-3fff-9f6f-bd56d72330ff",
+        "packaging": {
+          "spHeadline": "new iPhone 6S and Apple TV launch",
+          "kicker": "As it happened"
+        },
+        "id": "44022e2a-541e-3fff-9f6f-bd56d72330ff"
+      }
+    ],
+    "assets": [
+      {
+        "name": "asset1",
+        "type": "slideshow",
+        "fields": {
+          "slides": [
+            {
+              "slideNumber": 1,
+              "width": 972,
+              "caption": "Phil Schiller, Apple’s marketing boss, shows off the new ‘rose gold’ finish on the updated iPhone 6S. Updates include a new camera, faster fingerprint reader and accelerated processor",
+              "mediaType": "image/jpeg",
+              "source": "Bloomberg",
+              "url": "http://im.ft-static.com/content/images/c28954e5-5057-41a7-aeab-2e77a0af78d1.img",
+              "height": 547
+            },
+            {
+              "slideNumber": 2,
+              "width": 972,
+              "caption": "The Bill Graham Civic Auditorium in San Francisco, where Apple on Wednesday unveiled an updated iPhone 6S, an Apple TV overhaul, new Watch features and a supersized iPad Pro",
+              "mediaType": "image/jpeg",
+              "source": "Getty",
+              "url": "http://im.ft-static.com/content/images/4f298e73-d148-4813-adfc-94d11aba9517.img",
+              "height": 547
+            },
+            {
+              "slideNumber": 3,
+              "width": 972,
+              "caption": "Apple employees outside the auditorium to hear chief executive Tim Cook and colleagues unveil the latest from Apple. ‘We are about to make some monster announcements,’ he promised",
+              "mediaType": "image/jpeg",
+              "source": "Getty",
+              "url": "http://im.ft-static.com/content/images/e54650c1-0cb0-4b96-8315-23018f83822a.img",
+              "height": 547
+            },
+            {
+              "slideNumber": 4,
+              "width": 972,
+              "caption": "‘How do you follow a success like this? I’ve got that question a few times,’ Tim Cook said. ‘No product is more about innovation than the iPhone’",
+              "mediaType": "image/jpeg",
+              "source": "Getty",
+              "url": "http://im.ft-static.com/content/images/82b753b9-33fc-430b-b6ab-2366f54150a4.img",
+              "height": 547
+            },
+            {
+              "slideNumber": 5,
+              "width": 972,
+              "caption": "Hardware improvements mean the iPhone can better distinguish the amount of pressure to the screen to create new shortcuts, such as ‘peeking’ into emails and jumping to a selfie camera",
+              "mediaType": "image/jpeg",
+              "source": "Getty",
+              "url": "http://im.ft-static.com/content/images/58ea6a25-2ebe-46c0-afcd-2b4dbc1f37c7.img",
+              "height": 547
+            },
+            {
+              "slideNumber": 6,
+              "width": 972,
+              "caption": "Some of Apple’s biggest changes were for the iPad, which has seen sales decline in the past two years. The iPad Pro has a bigger, 12.9in screen",
+              "mediaType": "image/jpeg",
+              "source": "Getty",
+              "url": "http://im.ft-static.com/content/images/ba0b8e27-5341-471d-88de-a27a5ce9683b.img",
+              "height": 547
+            },
+            {
+              "slideNumber": 7,
+              "width": 972,
+              "caption": "Falling iPad revenues prompted a rethink for the device’s capabilities — it was ‘a piece of glass that transforms into anything you want it to be,’ said Tim Cook",
+              "mediaType": "image/jpeg",
+              "source": "Getty",
+              "url": "http://im.ft-static.com/content/images/7f85f951-1a70-4aaa-b5c1-4ff53b302532.img",
+              "height": 547
+            },
+            {
+              "slideNumber": 8,
+              "width": 972,
+              "caption": "The iPad Pro makeover has turned the tablet into a product nearer to what Microsoft had planned with its Surface device",
+              "mediaType": "image/jpeg",
+              "source": "Getty",
+              "url": "http://im.ft-static.com/content/images/6c9693c6-b822-4171-b361-35b121f79eeb.img",
+              "height": 547
+            },
+            {
+              "slideNumber": 9,
+              "width": 972,
+              "caption": "Phil Schiller outlines the iPad Pro’s pricing. The Pro’s bigger screen makes it easier for workers to multitask by running two ‘windows’ next to each other",
+              "mediaType": "image/jpeg",
+              "source": "Getty",
+              "url": "http://im.ft-static.com/content/images/5f1a88b2-2e7c-4b24-b567-4cd20da071fb.img",
+              "height": 547
+            },
+            {
+              "slideNumber": 10,
+              "width": 972,
+              "caption": "The new keyboard for the iPad Pro. Apple has revamped its vision of how tablet computers should fit into working life, as it aims to revive sales",
+              "mediaType": "image/jpeg",
+              "source": "Getty",
+              "url": "http://im.ft-static.com/content/images/47507bb0-687b-4758-ab2a-31614ed02376.img",
+              "height": 547
+            },
+            {
+              "slideNumber": 11,
+              "width": 972,
+              "caption": "In a sign of how far Microsoft and Apple have moved from heated rivalry, a Microsoft executive demonstrated how the iPad software works with Microsoft’s Office",
+              "mediaType": "image/jpeg",
+              "source": "Bloomberg",
+              "url": "http://im.ft-static.com/content/images/941f02e0-523d-4477-91a4-0ade1da7b14a.img",
+              "height": 547
+            },
+            {
+              "slideNumber": 12,
+              "width": 972,
+              "caption": "Tim Cook with the larger iPad designed to attract business users and jump-start demand. Apple has sealed partnerships with IBM and Cisco to make the devices fit better into traditional corporate IT",
+              "mediaType": "image/jpeg",
+              "source": "Bloomberg",
+              "url": "http://im.ft-static.com/content/images/4126ac61-a780-4262-84d5-bbe7e0e011b5.img",
+              "height": 547
+            },
+            {
+              "slideNumber": 13,
+              "width": 972,
+              "caption": "Eddy Cue, head of internet software and services, demonstrates the new Siri-powered remote control which uses Bluetooth — no need to point it at the TV",
+              "mediaType": "image/jpeg",
+              "source": "Getty",
+              "url": "http://im.ft-static.com/content/images/f62d337a-4e60-4b94-847d-b4d19ba4065d.img",
+              "height": 547
+            },
+            {
+              "slideNumber": 14,
+              "width": 972,
+              "caption": "‘This is the future of television, coming now,’ said Tim Cook, as he unveiled Apple’s third attempt to dominate the living room since it launched its set-top box in 2007",
+              "mediaType": "image/jpeg",
+              "source": "Getty",
+              "url": "http://im.ft-static.com/content/images/b734be9e-7abb-459d-8bbd-f8b2105638fe.img",
+              "height": 547
+            },
+            {
+              "slideNumber": 15,
+              "width": 972,
+              "caption": "‘Apple has now brought back two antiquities — gold and pencils,’ one tweeter posted during the San Francisco presentation. ‘Excited to see what they do with fire and spears’",
+              "mediaType": "image/jpeg",
+              "source": "Getty",
+              "url": "http://im.ft-static.com/content/images/c72ebac6-c14d-46f4-a174-ba338cc3d8cb.img",
+              "height": 547
+            },
+            {
+              "slideNumber": 16,
+              "width": 972,
+              "caption": "The Apple Pencil and Smart Keyboard for the iPad Pro. Late chief executive Steve Jobs once said of other companies’ devices: ‘If you see a stylus, they blew it’",
+              "mediaType": "image/jpeg",
+              "source": "Getty",
+              "url": "http://im.ft-static.com/content/images/cd3f2a58-e7df-4c34-b7ad-aca5362816f9.img",
+              "height": 547
+            },
+            {
+              "slideNumber": 17,
+              "width": 972,
+              "caption": "Senior operations vice-president Jeff Williams demonstrating new features on the Apple Watch, although the company still refused to detail figures about device sales",
+              "mediaType": "image/jpeg",
+              "source": "Getty",
+              "url": "http://im.ft-static.com/content/images/43f8551d-8a7d-4a25-8906-4b142be2ea30.img",
+              "height": 547
+            }
+          ],
+          "title": "Apple revamps iPad in bid to boost sales"
+        }
+      },
+      {
+        "name": "asset2",
+        "type": "video",
+        "fields": {
+          "sourceReference": "4474074856001",
+          "source": "Brightcove"
+        }
+      },
+      {
+        "name": "asset3",
+        "type": "pullQuote",
+        "fields": {
+          "attribution": "Jonathan Chaplin, New Street Research",
+          "body": "<p>Apple would love to commoditise the carriers and be the source of the entire relationship</p>"
+        }
+      },
+      {
+        "name": "asset4",
+        "type": "pullQuote",
+        "fields": {
+          "attribution": "Michael Rollins, Citi",
+          "body": "<p>We see the move by Apple as a further affirmation that carriers will probably move to 100% device financing and leasing over the next few years</p>"
+        }
+      }
+    ],
+    "mediaAssets": [
+      {
+        "slides": [
+          {
+            "slideNumber": 1,
+            "width": 972,
+            "caption": "Phil Schiller, Apple’s marketing boss, shows off the new ‘rose gold’ finish on the updated iPhone 6S. Updates include a new camera, faster fingerprint reader and accelerated processor",
+            "mediaType": "image/jpeg",
+            "source": "Bloomberg",
+            "url": "http://im.ft-static.com/content/images/c28954e5-5057-41a7-aeab-2e77a0af78d1.img",
+            "height": 547
+          },
+          {
+            "slideNumber": 2,
+            "width": 972,
+            "caption": "The Bill Graham Civic Auditorium in San Francisco, where Apple on Wednesday unveiled an updated iPhone 6S, an Apple TV overhaul, new Watch features and a supersized iPad Pro",
+            "mediaType": "image/jpeg",
+            "source": "Getty",
+            "url": "http://im.ft-static.com/content/images/4f298e73-d148-4813-adfc-94d11aba9517.img",
+            "height": 547
+          },
+          {
+            "slideNumber": 3,
+            "width": 972,
+            "caption": "Apple employees outside the auditorium to hear chief executive Tim Cook and colleagues unveil the latest from Apple. ‘We are about to make some monster announcements,’ he promised",
+            "mediaType": "image/jpeg",
+            "source": "Getty",
+            "url": "http://im.ft-static.com/content/images/e54650c1-0cb0-4b96-8315-23018f83822a.img",
+            "height": 547
+          },
+          {
+            "slideNumber": 4,
+            "width": 972,
+            "caption": "‘How do you follow a success like this? I’ve got that question a few times,’ Tim Cook said. ‘No product is more about innovation than the iPhone’",
+            "mediaType": "image/jpeg",
+            "source": "Getty",
+            "url": "http://im.ft-static.com/content/images/82b753b9-33fc-430b-b6ab-2366f54150a4.img",
+            "height": 547
+          },
+          {
+            "slideNumber": 5,
+            "width": 972,
+            "caption": "Hardware improvements mean the iPhone can better distinguish the amount of pressure to the screen to create new shortcuts, such as ‘peeking’ into emails and jumping to a selfie camera",
+            "mediaType": "image/jpeg",
+            "source": "Getty",
+            "url": "http://im.ft-static.com/content/images/58ea6a25-2ebe-46c0-afcd-2b4dbc1f37c7.img",
+            "height": 547
+          },
+          {
+            "slideNumber": 6,
+            "width": 972,
+            "caption": "Some of Apple’s biggest changes were for the iPad, which has seen sales decline in the past two years. The iPad Pro has a bigger, 12.9in screen",
+            "mediaType": "image/jpeg",
+            "source": "Getty",
+            "url": "http://im.ft-static.com/content/images/ba0b8e27-5341-471d-88de-a27a5ce9683b.img",
+            "height": 547
+          },
+          {
+            "slideNumber": 7,
+            "width": 972,
+            "caption": "Falling iPad revenues prompted a rethink for the device’s capabilities — it was ‘a piece of glass that transforms into anything you want it to be,’ said Tim Cook",
+            "mediaType": "image/jpeg",
+            "source": "Getty",
+            "url": "http://im.ft-static.com/content/images/7f85f951-1a70-4aaa-b5c1-4ff53b302532.img",
+            "height": 547
+          },
+          {
+            "slideNumber": 8,
+            "width": 972,
+            "caption": "The iPad Pro makeover has turned the tablet into a product nearer to what Microsoft had planned with its Surface device",
+            "mediaType": "image/jpeg",
+            "source": "Getty",
+            "url": "http://im.ft-static.com/content/images/6c9693c6-b822-4171-b361-35b121f79eeb.img",
+            "height": 547
+          },
+          {
+            "slideNumber": 9,
+            "width": 972,
+            "caption": "Phil Schiller outlines the iPad Pro’s pricing. The Pro’s bigger screen makes it easier for workers to multitask by running two ‘windows’ next to each other",
+            "mediaType": "image/jpeg",
+            "source": "Getty",
+            "url": "http://im.ft-static.com/content/images/5f1a88b2-2e7c-4b24-b567-4cd20da071fb.img",
+            "height": 547
+          },
+          {
+            "slideNumber": 10,
+            "width": 972,
+            "caption": "The new keyboard for the iPad Pro. Apple has revamped its vision of how tablet computers should fit into working life, as it aims to revive sales",
+            "mediaType": "image/jpeg",
+            "source": "Getty",
+            "url": "http://im.ft-static.com/content/images/47507bb0-687b-4758-ab2a-31614ed02376.img",
+            "height": 547
+          },
+          {
+            "slideNumber": 11,
+            "width": 972,
+            "caption": "In a sign of how far Microsoft and Apple have moved from heated rivalry, a Microsoft executive demonstrated how the iPad software works with Microsoft’s Office",
+            "mediaType": "image/jpeg",
+            "source": "Bloomberg",
+            "url": "http://im.ft-static.com/content/images/941f02e0-523d-4477-91a4-0ade1da7b14a.img",
+            "height": 547
+          },
+          {
+            "slideNumber": 12,
+            "width": 972,
+            "caption": "Tim Cook with the larger iPad designed to attract business users and jump-start demand. Apple has sealed partnerships with IBM and Cisco to make the devices fit better into traditional corporate IT",
+            "mediaType": "image/jpeg",
+            "source": "Bloomberg",
+            "url": "http://im.ft-static.com/content/images/4126ac61-a780-4262-84d5-bbe7e0e011b5.img",
+            "height": 547
+          },
+          {
+            "slideNumber": 13,
+            "width": 972,
+            "caption": "Eddy Cue, head of internet software and services, demonstrates the new Siri-powered remote control which uses Bluetooth — no need to point it at the TV",
+            "mediaType": "image/jpeg",
+            "source": "Getty",
+            "url": "http://im.ft-static.com/content/images/f62d337a-4e60-4b94-847d-b4d19ba4065d.img",
+            "height": 547
+          },
+          {
+            "slideNumber": 14,
+            "width": 972,
+            "caption": "‘This is the future of television, coming now,’ said Tim Cook, as he unveiled Apple’s third attempt to dominate the living room since it launched its set-top box in 2007",
+            "mediaType": "image/jpeg",
+            "source": "Getty",
+            "url": "http://im.ft-static.com/content/images/b734be9e-7abb-459d-8bbd-f8b2105638fe.img",
+            "height": 547
+          },
+          {
+            "slideNumber": 15,
+            "width": 972,
+            "caption": "‘Apple has now brought back two antiquities — gold and pencils,’ one tweeter posted during the San Francisco presentation. ‘Excited to see what they do with fire and spears’",
+            "mediaType": "image/jpeg",
+            "source": "Getty",
+            "url": "http://im.ft-static.com/content/images/c72ebac6-c14d-46f4-a174-ba338cc3d8cb.img",
+            "height": 547
+          },
+          {
+            "slideNumber": 16,
+            "width": 972,
+            "caption": "The Apple Pencil and Smart Keyboard for the iPad Pro. Late chief executive Steve Jobs once said of other companies’ devices: ‘If you see a stylus, they blew it’",
+            "mediaType": "image/jpeg",
+            "source": "Getty",
+            "url": "http://im.ft-static.com/content/images/cd3f2a58-e7df-4c34-b7ad-aca5362816f9.img",
+            "height": 547
+          },
+          {
+            "slideNumber": 17,
+            "width": 972,
+            "caption": "Senior operations vice-president Jeff Williams demonstrating new features on the Apple Watch, although the company still refused to detail figures about device sales",
+            "mediaType": "image/jpeg",
+            "source": "Getty",
+            "url": "http://im.ft-static.com/content/images/43f8551d-8a7d-4a25-8906-4b142be2ea30.img",
+            "height": 547
+          }
+        ],
+        "name": "asset1",
+        "slideshowHeading": "Apple revamps iPad in bid to boost sales",
+        "type": "slideshow"
+      }
+    ]
+  },
+  "_lastUpdatedDateTime": "2015-09-14T13:31:19.937Z"
+}

--- a/test/fixtures/readNext/storyPackageArticle2.json
+++ b/test/fixtures/readNext/storyPackageArticle2.json
@@ -1,0 +1,637 @@
+{
+  "requestUrl": "http://api.ft.com/content/items/v1/a581b44e-5acb-11e5-a28b-50226830d644?feature.blogposts=on&h=2580380887",
+  "item": {
+    "aspectSet": "article",
+    "aspects": [
+      "assets",
+      "body",
+      "editorial",
+      "images",
+      "lifecycle",
+      "location",
+      "master",
+      "mediaAssets",
+      "metadata",
+      "package",
+      "packaging",
+      "provenance",
+      "summary",
+      "title"
+    ],
+    "modelVersion": "1",
+    "id": "a581b44e-5acb-11e5-a28b-50226830d644",
+    "apiUrl": "http://api.ft.com/content/items/v1/a581b44e-5acb-11e5-a28b-50226830d644",
+    "title": {
+      "title": "CNPC forced to sell businesses as China’s crackdown widens"
+    },
+    "body": {
+      "mediaType": "text/html",
+      "body": "<p>China National Petroleum Corp, China’s largest oil company, is shedding a raft of non-core businesses, including a chain of hotels and a taxi business, as <a title=\"China’s state-owned enterprise reform plans face compromise - FT.com\" href=\"http://www.ft.com/cms/s/0/5eeeb84a-5aaa-11e5-97e9-7f0bf5e7177b.html#axzz3ldXLAcJI\">state-owned companies </a>come under pressure from the government to dispose of lucrative but often corrupt enterprises.</p>\n<p>China’s two-year, anti-corruption drive has targeted the perks of office of government and state-owned enterprise employees, ranging from <a title=\"A bribe-free lunar new year awaits China’s public servants - FT.com\" href=\"http://www.ft.com/cms/s/0/9d8de956-80ca-11e3-95aa-00144feab7de.html#axzz3lggYgvAN\">annual New Years’ banquets</a> and gifts of mooncakes to company trips, expensive meals and privileges that allow people employed by the Chinese state to enjoy a quality of life well above their official salary levels.</p>\n<p>The result has been a sharp slowdown in demand for Swiss watches, foreign wines and other high-end products in <a title=\"China Tremors in depth - FT.com\" href=\"http://www.ft.com/indepth/china-tremors\">China</a>, previously one of the fastest growing markets for luxury consumer goods in the world.</p>\n<p>CNPC, parent of listed PetroChina, said on its website on Monday that it would trim its regional and overseas offices and shed its hotels business. The large number of offices makes it “easy for irregularities to happen and cause problems,” it said.</p>\n<p>China’s anti-corruption watchdog had said after an audit earlier this year that CNPC had “too many offices and hotels” and “chaotic management” among other issues.</p>\n<p>Beijing’s anti-corruption drive has disproportionately affected CNPC, a former power base for Zhou Yongkang, the now-disgraced energy and security tsar. A former member of the standing committee of the politburo, Mr Zhou is the highest-ranking Communist Party member to be arrested in Xi Jinping’s anti-corruption crackdown and power consolidation.</p>\n<p>His influence thrived in CNPC’s Soluxe hotel chain, where his son Zhou Bin muscled in on hotel properties including one in the Sichuan mountain resort area of Jiuzhaigou. Soluxe operates more than 30 hotels in two dozen Chinese cities, as well as a taxi company in Beijing and a travel agency.</p>\n<p>Mr Zhou’s relatives had also encroached on CNPC oil projects overseas.</p>\n<p>The anti-corruption watchdog’s report on CNPC vowed to “resolutely eradicate the malignant influence of Zhou Yongkang and others”.</p>\n<aside data-asset-type=\"promoBox\" data-asset-name=\"asset1\"></aside><p>Also over the weekend, state oil company Cnooc pledged to “dismantle all entertainment equipment” and ban official receptions, dining, and purchases of high-end liquor and cigarettes.</p>\n<p>Chinese SOEs, government ministries and provincial governments generally own a number of hotels and representative offices in Beijing as well as in other large Chinese cities, much as a US state might have a business development office in Washington DC. Many also own hotels overseas or in resort areas in China, in part to host the executive and employee trips that are a perk of working for the Chinese state. They also operate old-age homes for elderly and retired cadres or executives.</p>\n\n<p>Oil groups and mining companies first developed hotels near oilfields and mines during the planned economy, and many morphed into freewheeling side businesses after China allowed a market economy to develop. But the businesses became a channel for corruption and nepotism for officials running the enterprises.</p>\n\n<p><span class=\"ft-italic\">Additional reporting by Owen Guo in Beijing</span>\n</p>"
+    },
+    "lifecycle": {
+      "initialPublishDateTime": "2015-09-14T14:26:37Z",
+      "lastPublishDateTime": "2015-09-14T14:26:37Z"
+    },
+    "location": {
+      "uri": "http://www.ft.com/cms/s/0/a581b44e-5acb-11e5-a28b-50226830d644.html"
+    },
+    "summary": {
+      "excerpt": "Hotel chains and taxi businesses among the non-core businesses to be sold"
+    },
+    "packaging": {
+      "spHeadline": "CNPC forced to dispose of hotel chain"
+    },
+    "master": {
+      "masterSource": "Methode",
+      "masterEntityId": "a581b44e-5acb-11e5-a28b-50226830d644"
+    },
+    "editorial": {
+      "otherTitles": [
+        "CNPC forced to dispose of hotel chain"
+      ],
+      "subheading": "Non-core businesses to go as SEOs come under government pressure",
+      "standFirst": "Hotel chains and taxi businesses among the non-core businesses to be sold",
+      "byline": "Lucy Hornby in Beijing"
+    },
+    "provenance": {
+      "originatingParty": "FT"
+    },
+    "metadata": {
+      "primarySection": {
+        "term": {
+          "name": "China",
+          "attributes": [],
+          "id": "TnN0ZWluX0dMX0NO-R0w=",
+          "taxonomy": "regions"
+        }
+      },
+      "primaryTheme": {
+        "term": {
+          "name": "China",
+          "id": "TnN0ZWluX0dMX0NO-R0w=",
+          "attributes": [],
+          "taxonomy": "regions"
+        }
+      },
+      "tags": [
+        {
+          "term": {
+            "name": "China",
+            "attributes": [],
+            "id": "TnN0ZWluX0dMX0NO-R0w=",
+            "taxonomy": "regions"
+          }
+        },
+        {
+          "term": {
+            "name": "News",
+            "attributes": [],
+            "id": "Nw==-R2VucmVz",
+            "taxonomy": "genre"
+          }
+        },
+        {
+          "term": {
+            "name": "Text",
+            "attributes": [],
+            "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+            "taxonomy": "mediaType"
+          }
+        },
+        {
+          "term": {
+            "name": "Lucy Hornby",
+            "attributes": [],
+            "id": "Q0ItMDM4Njc5MQ==-QXV0aG9ycw==",
+            "taxonomy": "authors"
+          }
+        },
+        {
+          "term": {
+            "name": "02012006 - corruption",
+            "attributes": [],
+            "id": "MDIwMTIwMDY=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "04005004 - oil and gas - upstream activities",
+            "attributes": [],
+            "id": "MDQwMDUwMDQ=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "04014002 - hotel and accommodation",
+            "attributes": [],
+            "id": "MDQwMTQwMDI=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "09016000 - employee",
+            "attributes": [],
+            "id": "MDkwMTYwMDA=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "12006002 - corrupt practices",
+            "attributes": [],
+            "id": "MTIwMDYwMDI=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "China National Petroleum Corp",
+            "attributes": [
+              {
+                "value": "true",
+                "key": "is_company"
+              }
+            ],
+            "id": "TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0NOUEM=-T04=",
+            "taxonomy": "organisations"
+          }
+        },
+        {
+          "term": {
+            "name": "Zhou Yongkang",
+            "attributes": [],
+            "id": "TnN0ZWluX1BOX0FGVE1fUE5fMzI2MTAz-UE4=",
+            "taxonomy": "people"
+          }
+        },
+        {
+          "term": {
+            "name": "Beijing",
+            "attributes": [],
+            "id": "TnN0ZWluX0dMX0FGVE1fR0xfMTEyOTc=-R0w=",
+            "taxonomy": "regions"
+          }
+        },
+        {
+          "term": {
+            "name": "World",
+            "attributes": [
+              {
+                "value": "world",
+                "key": "dfpSite"
+              }
+            ],
+            "id": "MQ==-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Asia Pacific",
+            "attributes": [
+              {
+                "value": "world",
+                "key": "dfpSite"
+              },
+              {
+                "value": "asia.pacific",
+                "key": "dfpZone"
+              }
+            ],
+            "id": "MTE=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Companies",
+            "attributes": [
+              {
+                "value": "companies",
+                "key": "dfpSite"
+              }
+            ],
+            "id": "Mjk=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Energy",
+            "attributes": [
+              {
+                "value": "companies",
+                "key": "dfpSite"
+              },
+              {
+                "value": "energy",
+                "key": "dfpZone"
+              }
+            ],
+            "id": "MzA=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Oil & Gas",
+            "attributes": [],
+            "id": "MzI=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Asia-Pacific Companies",
+            "attributes": [],
+            "id": "Njc=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Business of Luxury",
+            "attributes": [],
+            "id": "NWY0ZmJlNmUtMzY2NS00NDc4LTk5MjYtOGQ4Mjk3OGE3ZTMw-VG9waWNz",
+            "taxonomy": "topics"
+          }
+        },
+        {
+          "term": {
+            "name": "Oil",
+            "attributes": [],
+            "id": "ZmFmYTUxOTItMGZjZC00YmJkLWJlZTQtMmY3ZDZiOWZkYmYw-VG9waWNz",
+            "taxonomy": "topics"
+          }
+        }
+      ],
+      "authors": [
+        {
+          "term": {
+            "name": "Lucy Hornby",
+            "attributes": [],
+            "id": "Q0ItMDM4Njc5MQ==-QXV0aG9ycw==",
+            "taxonomy": "authors"
+          }
+        }
+      ],
+      "brand": [],
+      "genre": [
+        {
+          "term": {
+            "name": "News",
+            "attributes": [],
+            "id": "Nw==-R2VucmVz",
+            "taxonomy": "genre"
+          }
+        }
+      ],
+      "icb": [],
+      "iptc": [
+        {
+          "term": {
+            "name": "02012006 - corruption",
+            "attributes": [],
+            "id": "MDIwMTIwMDY=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "04005004 - oil and gas - upstream activities",
+            "attributes": [],
+            "id": "MDQwMDUwMDQ=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "04014002 - hotel and accommodation",
+            "attributes": [],
+            "id": "MDQwMTQwMDI=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "09016000 - employee",
+            "attributes": [],
+            "id": "MDkwMTYwMDA=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        },
+        {
+          "term": {
+            "name": "12006002 - corrupt practices",
+            "attributes": [],
+            "id": "MTIwMDYwMDI=-SVBUQw==",
+            "taxonomy": "iptc"
+          }
+        }
+      ],
+      "mediaType": [
+        {
+          "term": {
+            "name": "Text",
+            "attributes": [],
+            "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+            "taxonomy": "mediaType"
+          }
+        }
+      ],
+      "organisations": [
+        {
+          "term": {
+            "name": "China National Petroleum Corp",
+            "attributes": [
+              {
+                "value": "true",
+                "key": "is_company"
+              }
+            ],
+            "id": "TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0NOUEM=-T04=",
+            "taxonomy": "organisations"
+          }
+        }
+      ],
+      "people": [
+        {
+          "term": {
+            "name": "Zhou Yongkang",
+            "attributes": [],
+            "id": "TnN0ZWluX1BOX0FGVE1fUE5fMzI2MTAz-UE4=",
+            "taxonomy": "people"
+          }
+        }
+      ],
+      "regions": [
+        {
+          "term": {
+            "name": "Beijing",
+            "attributes": [],
+            "id": "TnN0ZWluX0dMX0FGVE1fR0xfMTEyOTc=-R0w=",
+            "taxonomy": "regions"
+          }
+        },
+        {
+          "term": {
+            "name": "China",
+            "attributes": [],
+            "id": "TnN0ZWluX0dMX0NO-R0w=",
+            "taxonomy": "regions"
+          }
+        }
+      ],
+      "sections": [
+        {
+          "term": {
+            "name": "World",
+            "attributes": [
+              {
+                "value": "world",
+                "key": "dfpSite"
+              }
+            ],
+            "id": "MQ==-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Asia Pacific",
+            "attributes": [
+              {
+                "value": "world",
+                "key": "dfpSite"
+              },
+              {
+                "value": "asia.pacific",
+                "key": "dfpZone"
+              }
+            ],
+            "id": "MTE=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Companies",
+            "attributes": [
+              {
+                "value": "companies",
+                "key": "dfpSite"
+              }
+            ],
+            "id": "Mjk=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Energy",
+            "attributes": [
+              {
+                "value": "companies",
+                "key": "dfpSite"
+              },
+              {
+                "value": "energy",
+                "key": "dfpZone"
+              }
+            ],
+            "id": "MzA=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Oil & Gas",
+            "attributes": [],
+            "id": "MzI=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        },
+        {
+          "term": {
+            "name": "Asia-Pacific Companies",
+            "attributes": [],
+            "id": "Njc=-U2VjdGlvbnM=",
+            "taxonomy": "sections"
+          }
+        }
+      ],
+      "specialReports": [],
+      "subjects": [],
+      "topics": [
+        {
+          "term": {
+            "name": "Business of Luxury",
+            "attributes": [],
+            "id": "NWY0ZmJlNmUtMzY2NS00NDc4LTk5MjYtOGQ4Mjk3OGE3ZTMw-VG9waWNz",
+            "taxonomy": "topics"
+          }
+        },
+        {
+          "term": {
+            "name": "Oil",
+            "attributes": [],
+            "id": "ZmFmYTUxOTItMGZjZC00YmJkLWJlZTQtMmY3ZDZiOWZkYmYw-VG9waWNz",
+            "taxonomy": "topics"
+          }
+        }
+      ]
+    },
+    "images": [
+      {
+        "alt": "epa04793150 (FILE) A file picture dated 01 November 2010 shows Chinese Zhou Yongkang, then member of the Standing Committee of the Politburo and Secretary of Political and Legislative Affairs Committee, addressing a seminar in New Delhi, India. Zhou Yongkang has been sentenced to life in prison, it was reported 11 June 2015. He was found guilty of bribery, abuse of power and 'intentionally disclosing national secrets', Chinese media reports. EPA/ANINDITO MUKHERJEE",
+        "width": 272,
+        "caption": "Zhou Yongkang, China’s disgraced energy and security tsar, whose influence thrived in CNPC’s Soluxe hotel chain",
+        "mediaType": "image/jpeg",
+        "source": "EPA",
+        "type": "primary",
+        "url": "http://im.ft-static.com/content/images/fab1b192-b82d-4bd7-83d2-71a97970671c.img",
+        "height": 153
+      },
+      {
+        "alt": "epa04793150 (FILE) A file picture dated 01 November 2010 shows Chinese Zhou Yongkang, then member of the Standing Committee of the Politburo and Secretary of Political and Legislative Affairs Committee, addressing a seminar in New Delhi, India. Zhou Yongkang has been sentenced to life in prison, it was reported 11 June 2015. He was found guilty of bribery, abuse of power and 'intentionally disclosing national secrets', Chinese media reports. EPA/ANINDITO MUKHERJEE",
+        "width": 167,
+        "caption": "Zhou Yongkang, China’s disgraced energy and security tsar, whose influence thrived in CNPC’s Soluxe hotel chain",
+        "mediaType": "image/jpeg",
+        "source": "EPA",
+        "type": "secondary",
+        "url": "http://im.ft-static.com/content/images/ab6ed205-e36d-4c01-b803-b084c21b6382.img",
+        "height": 94
+      },
+      {
+        "alt": "epa04793150 (FILE) A file picture dated 01 November 2010 shows Chinese Zhou Yongkang, then member of the Standing Committee of the Politburo and Secretary of Political and Legislative Affairs Committee, addressing a seminar in New Delhi, India. Zhou Yongkang has been sentenced to life in prison, it was reported 11 June 2015. He was found guilty of bribery, abuse of power and 'intentionally disclosing national secrets', Chinese media reports. EPA/ANINDITO MUKHERJEE",
+        "width": 600,
+        "caption": "Zhou Yongkang, China’s disgraced energy and security tsar, whose influence thrived in CNPC’s Soluxe hotel chain",
+        "mediaType": "image/jpeg",
+        "source": "EPA",
+        "type": "article",
+        "url": "http://im.ft-static.com/content/images/2f42c338-48ad-4382-8ecd-47b1d16f0a00.img",
+        "height": 338
+      },
+      {
+        "alt": "epa04793150 (FILE) A file picture dated 01 November 2010 shows Chinese Zhou Yongkang, then member of the Standing Committee of the Politburo and Secretary of Political and Legislative Affairs Committee, addressing a seminar in New Delhi, India. Zhou Yongkang has been sentenced to life in prison, it was reported 11 June 2015. He was found guilty of bribery, abuse of power and 'intentionally disclosing national secrets', Chinese media reports. EPA/ANINDITO MUKHERJEE",
+        "width": 414,
+        "caption": "Zhou Yongkang, China’s disgraced energy and security tsar, whose influence thrived in CNPC’s Soluxe hotel chain",
+        "mediaType": "image/jpeg",
+        "source": "EPA",
+        "type": "leader",
+        "url": "http://im.ft-static.com/content/images/b42d2a68-d363-4b27-9f7a-84d42770755f.img",
+        "height": 233
+      },
+      {
+        "alt": "epa04793150 (FILE) A file picture dated 01 November 2010 shows Chinese Zhou Yongkang, then member of the Standing Committee of the Politburo and Secretary of Political and Legislative Affairs Committee, addressing a seminar in New Delhi, India. Zhou Yongkang has been sentenced to life in prison, it was reported 11 June 2015. He was found guilty of bribery, abuse of power and 'intentionally disclosing national secrets', Chinese media reports. EPA/ANINDITO MUKHERJEE",
+        "width": 972,
+        "caption": "Zhou Yongkang, China’s disgraced energy and security tsar, whose influence thrived in CNPC’s Soluxe hotel chain",
+        "mediaType": "image/jpeg",
+        "source": "EPA",
+        "type": "wide-format",
+        "url": "http://im.ft-static.com/content/images/b29be4bd-ef06-4839-984b-d21ead0c0a06.img",
+        "height": 547
+      },
+      {
+        "width": 272,
+        "mediaType": "image/jpeg",
+        "type": "promo",
+        "url": "http://im.ft-static.com/content/images/ad0d1569-2e28-47f7-a108-1558883bc6ad.img",
+        "height": 153
+      },
+      {
+        "width": 972,
+        "mediaType": "image/jpeg",
+        "type": "promo",
+        "url": "http://im.ft-static.com/content/images/f5593565-6904-466e-a1c9-1c082a347927.img",
+        "height": 547
+      }
+    ],
+    "package": [
+      {
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "apiUrl": "http://api.ft.com/content/items/v1/aff90924-5a01-11e5-9846-de406ccb37f2",
+        "packaging": {
+          "spHeadline": "China’s state-owned groups face shake-up"
+        },
+        "id": "aff90924-5a01-11e5-9846-de406ccb37f2"
+      },
+      {
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "apiUrl": "http://api.ft.com/content/items/v1/3186f3dc-5310-11e5-b029-b9d50a74fd14",
+        "packaging": {
+          "spHeadline": "Robert Zoellick – China will stumble if Xi stalls on reform",
+          "kicker": "Comment"
+        },
+        "id": "3186f3dc-5310-11e5-b029-b9d50a74fd14"
+      },
+      {
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "apiUrl": "http://api.ft.com/content/items/v1/8dfcd43e-507b-11e5-b029-b9d50a74fd14",
+        "packaging": {
+          "spHeadline": "China urges companies to shore up market"
+        },
+        "id": "8dfcd43e-507b-11e5-b029-b9d50a74fd14"
+      },
+      {
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "apiUrl": "http://api.ft.com/content/items/v1/e9b56844-4ece-11e5-b029-b9d50a74fd14",
+        "packaging": {
+          "spHeadline": "China to form top aluminium producer"
+        },
+        "id": "e9b56844-4ece-11e5-b029-b9d50a74fd14"
+      },
+      {
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "apiUrl": "http://api.ft.com/content/items/v1/066a5068-4d98-11e5-b558-8a9722977189",
+        "packaging": {
+          "spHeadline": "China’s problem its economy",
+          "kicker": "Comment"
+        },
+        "id": "066a5068-4d98-11e5-b558-8a9722977189"
+      }
+    ],
+    "assets": [
+      {
+        "name": "asset1",
+        "type": "promoBox",
+        "fields": {
+          "images": [
+            {
+              "width": 272,
+              "mediaType": "image/jpeg",
+              "type": "promo",
+              "url": "http://im.ft-static.com/content/images/ad0d1569-2e28-47f7-a108-1558883bc6ad.img",
+              "height": 153
+            },
+            {
+              "width": 972,
+              "mediaType": "image/jpeg",
+              "type": "promo",
+              "url": "http://im.ft-static.com/content/images/f5593565-6904-466e-a1c9-1c082a347927.img",
+              "height": 547
+            }
+          ],
+          "intro": "<p>China has been roiling global markets all summer as its authoritarian leaders try to stop a huge stock bubble from bursting and its slowing economy from stalling</p>",
+          "title": "<p>In depth</p>",
+          "headline": "<p><a title=\"www.ft.com\" href=\"http://www.ft.com/indepth/china-tremors\">China tremors</a>\n</p>"
+        }
+      }
+    ],
+    "mediaAssets": []
+  },
+  "_lastUpdatedDateTime": "2015-09-14T15:06:38.358Z"
+}

--- a/test/fixtures/readNext/topicArticles1.json
+++ b/test/fixtures/readNext/topicArticles1.json
@@ -1,0 +1,1143 @@
+[
+  {
+    "_index": "v1_api_v2",
+    "_type": "item",
+    "_id": "41129eec-5b9d-11e5-a28b-50226830d644",
+    "_score": null,
+    "_source": {
+      "requestUrl": "http://api.ft.com/content/items/v1/41129eec-5b9d-11e5-a28b-50226830d644?feature.blogposts=on&h=1769303635",
+      "item": {
+        "aspectSet": "article",
+        "aspects": [
+          "assets",
+          "body",
+          "editorial",
+          "images",
+          "lifecycle",
+          "location",
+          "master",
+          "mediaAssets",
+          "metadata",
+          "package",
+          "packaging",
+          "provenance",
+          "summary",
+          "title"
+        ],
+        "modelVersion": "1",
+        "id": "41129eec-5b9d-11e5-a28b-50226830d644",
+        "apiUrl": "http://api.ft.com/content/items/v1/41129eec-5b9d-11e5-a28b-50226830d644",
+        "title": {
+          "title": "Steve Jobs film will upset fans but misreads underdog mindset"
+        },
+        "body": {
+          "mediaType": "text/html",
+          "body": "<p>Film-maker Alex Gibney knows how to pick a controversial subject for his documentaries.</p>\n<p>His examination of <a title=\"Steve Jobs: The Man in the Machine trailer - youtube.com\" href=\"https://www.youtube.com/watch?v=jhWKxtsYrJE\">Apple’s co-founder</a> arrives at a time of renewed debate about Steve Jobs’ life. In March, Brent Schlender and Rick Tetzeli argued in their book, <span class=\"ft-italic\"><a title=\"‘Becoming Steve Jobs’, by Brent Schlender and Rick Tetzeli - FT.com\" href=\"http://www.ft.com/cms/s/d8363e4c-d2df-11e4-a792-00144feab7de,Authorised=false.html?siteedition=uk&amp;_i_location=http%3A%2F%2Fwww.ft.com%2Fcms%2Fs%2F0%2Fd8363e4c-d2df-11e4-a792-00144feab7de.html%3Fsiteedition%3Duk&amp;_i_referer=&amp;classification=conditional_standard&amp;iab=barrier-app\">Becoming Steve Jobs</a>\n</span>, that their subject was too harshly portrayed by his many previous biographers. </p>\n<p>Later this year, Danny Boyle and Aaron Sorkin’s drama starring Michael Fassbender as the iPhone impresario will go backstage at key product launches.</p>\n<p>Gibney’s addition to the canon points out, like so many others before him, that <a title=\"The legacy of Steve Jobs as a civil rights hero - FT.com\" href=\"http://www.ft.com/cms/s/1f0ded26-1023-11e5-bd70-00144feabdc0,Authorised=false.html?siteedition=uk&amp;_i_location=http%3A%2F%2Fwww.ft.com%2Fcms%2Fs%2F0%2F1f0ded26-1023-11e5-bd70-00144feabdc0.html%3Fsiteedition%3Duk&amp;_i_referer=&amp;classification=conditional_standard&amp;iab=barrier-app#axzz3ltLGXtaV\">Jobs was a man of contradictions</a>: the renegade who wanted to be legit, the humanist who denied paternity of his first daughter, the Wall Street idol embroiled in stock options and recruiting scandals. “He had the focus of a monk,” Gibney says as narrator, his camera lingering over Japanese zen gardens, “but none of the empathy.”</p>\n<p>The familiar stories told in this documentary are brought to life with extensive interviews with former <a title=\"Apple Inc news headlines - FT.com\" href=\"http://www.ft.com/topics/organisations/Apple_Inc\">Apple</a> employees and Jobs’ associates, as well as archive footage that includes his first screen test.</p>\n<p>Just as compelling are clips from the March 2008 video deposition, where Jobs squirms constantly in his seat as he is quizzed over allegations of backdated stock options.</p>\n<p>Absent from the screen, however, are any current Apple employees. Several members of Apple’s current management team blessed <span class=\"ft-italic\">Becoming Steve Jobs</span> as their preferred account of their former chief. Eddy Cue, who heads Apple’s services business, was rather less enthusiastic about <span class=\"ft-italic\">Man in the Machine</span>, calling it “an inaccurate and mean-spirited view of my friend”. </p>\n<p>It is not hard to see where Apple loyalists would object. </p>\n<p>Early on, the film-maker professes his love for his iPhone and Pixar movie <span class=\"ft-italic\">Wall-E</span>, but says he struggled to understand the global outpouring of grief in 2011 at the death of a man he calls “ruthless, deceitful and cruel”. He supports this argument by recalling suicides at Apple’s suppliers in China, investigations of its overseas profits and ripped-off colleagues such as Steve Wozniak and Daniel Kottke. \n</p>\n<p><img height=\"273\" alt=\"SteveJjobs Man in the Machine\" width=\"184\" class=\"ft-web-inline-picture\" src=\"http://im.ft-static.com/content/images/fff2660c-5bbc-11e5-a28b-50226830d644.img\"/>Yet by failing to include Jobs’ heirs and bring the story up to date, Gibney misses an opportunity to examine the company that survives him — at a crucial moment for the iPhone maker’s leadership. </p>\n<p>“Jobs’ genius was how he sold the iPod. It wasn’t a machine for you, it was you,” Gibney says. As Apple pushes beyond phones into watches, televisions, even cars, it is still figuring out how to sell these new categories without its master marketer. </p>\n<p>Gibney criticises Jobs for “behaving as though Apple was a start-up”, despite it becoming one of the world’s most valuable companies, yet the film-maker underestimates the energising force of playing the underdog.</p>\n<p>“This is a field in which one does one’s work and, in 10 years, it’s obsolete,” a young, bearded Jobs tells us towards the end of the film. \n</p>\n<p>Apple is about to enter its fifth year without its co-founder. All these controversies about Jobs’ life may soon give way to renewed debate about the future of the company he left behind. </p>\n\n<p><span class=\"ft-italic\">Steve Jobs: The man in the machine</span>, <span class=\"ft-bold\">directed by Alex Gibney, released by Magnolia Pictures, now in selected cinemas, on iTunes and on demand</span>\n</p>\n<p><br/>\n<span class=\"ft-italic\">The reviewer is an FT San Francisco correspondent</span>\n</p>"
+        },
+        "lifecycle": {
+          "initialPublishDateTime": "2015-09-16T11:44:13Z",
+          "lastPublishDateTime": "2015-09-16T11:44:13Z"
+        },
+        "location": {
+          "uri": "http://www.ft.com/cms/s/0/41129eec-5b9d-11e5-a28b-50226830d644.html"
+        },
+        "summary": {
+          "excerpt": "Documentary paints critical picture of Apple founder and misses opportunity to update story"
+        },
+        "packaging": {
+          "spHeadline": "Steve Jobs film misreads underdog mindset"
+        },
+        "master": {
+          "masterSource": "Methode",
+          "masterEntityId": "41129eec-5b9d-11e5-a28b-50226830d644"
+        },
+        "editorial": {
+          "otherTitles": [
+            "Steve Jobs film misreads underdog mindset"
+          ],
+          "subheading": "Documentary paints critical picture of Apple founder",
+          "standFirst": "Documentary paints critical picture of Apple founder and misses opportunity to update story",
+          "byline": "Tim Bradshaw"
+        },
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "metadata": {
+          "primarySection": {
+            "term": {
+              "name": "Work & Career",
+              "id": "MTI1-U2VjdGlvbnM=",
+              "attributes": [
+                {
+                  "value": "work.and.career",
+                  "key": "dfpSite"
+                }
+              ],
+              "taxonomy": "sections"
+            }
+          },
+          "primaryTheme": {
+            "term": {
+              "name": "Steve Jobs",
+              "id": "TnN0ZWluX1BOX0VudGVydGFpbm1lbnRfMjAwOV8xMF85XzQ1MDQ3-UE4=",
+              "attributes": [],
+              "taxonomy": "people"
+            }
+          },
+          "tags": [
+            {
+              "term": {
+                "name": "Steve Jobs",
+                "attributes": [],
+                "id": "TnN0ZWluX1BOX0VudGVydGFpbm1lbnRfMjAwOV8xMF85XzQ1MDQ3-UE4=",
+                "taxonomy": "people"
+              }
+            },
+            {
+              "term": {
+                "name": "Work & Career",
+                "attributes": [
+                  {
+                    "value": "work.and.career",
+                    "key": "dfpSite"
+                  }
+                ],
+                "id": "MTI1-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Review",
+                "attributes": [],
+                "id": "NA==-R2VucmVz",
+                "taxonomy": "genre"
+              }
+            },
+            {
+              "term": {
+                "name": "Text",
+                "attributes": [],
+                "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+                "taxonomy": "mediaType"
+              }
+            },
+            {
+              "term": {
+                "name": "01005000 - cinema",
+                "attributes": [],
+                "id": "MDEwMDUwMDA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04008026 - stocks",
+                "attributes": [],
+                "id": "MDQwMDgwMjY=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04010003 - cinema industry",
+                "attributes": [],
+                "id": "MDQwMTAwMDM=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04016052 - stock options",
+                "attributes": [],
+                "id": "MDQwMTYwNTI=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "Apple Inc",
+                "attributes": [
+                  {
+                    "value": "us:AAPL",
+                    "key": "wsod_key"
+                  },
+                  {
+                    "value": "true",
+                    "key": "is_company"
+                  }
+                ],
+                "id": "TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0FBUEw=-T04=",
+                "taxonomy": "organisations"
+              }
+            },
+            {
+              "term": {
+                "name": "Eddy Cue",
+                "attributes": [],
+                "id": "M2NmZTE5NzctODc5Ny00YzE1LWFlYWUtNWJlMjAyZjE5MDlm-UE4=",
+                "taxonomy": "people"
+              }
+            },
+            {
+              "term": {
+                "name": "Rick Tetzeli",
+                "attributes": [],
+                "id": "NmQ0MmI5ZGEtNmY1MS00MDA3LWJjNGMtZjcxNzJhMzUzNDE2-UE4=",
+                "taxonomy": "people"
+              }
+            },
+            {
+              "term": {
+                "name": "Steve Wozniak",
+                "attributes": [],
+                "id": "TnN0ZWluX1BOX0VudGVydGFpbm1lbnRfMjAwOV8xMF85XzEwMTk1OQ==-UE4=",
+                "taxonomy": "people"
+              }
+            },
+            {
+              "term": {
+                "name": "Alex Gibney",
+                "attributes": [],
+                "id": "TnN0ZWluX1BOX0VudGVydGFpbm1lbnRfMjAwOV8xMF85XzUxMTcz-UE4=",
+                "taxonomy": "people"
+              }
+            },
+            {
+              "term": {
+                "name": "Michael Fassbender",
+                "attributes": [],
+                "id": "TnN0ZWluX1BOX0VudGVydGFpbm1lbnRfMjAwOV8xMF85Xzk5MDI4-UE4=",
+                "taxonomy": "people"
+              }
+            },
+            {
+              "term": {
+                "name": "Danny Boyle",
+                "attributes": [],
+                "id": "UE5fY2VsZWJzLXBsdXNfZmV2LTIwMDhfMjU1-UE4=",
+                "taxonomy": "people"
+              }
+            },
+            {
+              "term": {
+                "name": "Brent Schlender",
+                "attributes": [],
+                "id": "ZTE4NWY0MGYtOThmNy00NjE1LWI3OWUtNzRlNDY4N2FhMzA3-UE4=",
+                "taxonomy": "people"
+              }
+            },
+            {
+              "term": {
+                "name": "Film & Television",
+                "attributes": [
+                  {
+                    "value": "life.and.arts",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "film.and.television",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "MTUy-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Technology",
+                "attributes": [
+                  {
+                    "value": "companies",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "technology",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "NTM=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "US & Canadian Companies",
+                "attributes": [],
+                "id": "NjU=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "General News",
+                "attributes": [],
+                "id": "MTE4-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            },
+            {
+              "term": {
+                "name": "Leadership",
+                "attributes": [],
+                "id": "NDhkMTE0NjEtNGMzYS00OTEzLTg1MGEtNjViM2UzYzNmZTlk-VG9waWNz",
+                "taxonomy": "topics"
+              }
+            }
+          ],
+          "authors": [],
+          "brand": [],
+          "genre": [
+            {
+              "term": {
+                "name": "Review",
+                "attributes": [],
+                "id": "NA==-R2VucmVz",
+                "taxonomy": "genre"
+              }
+            }
+          ],
+          "icb": [],
+          "iptc": [
+            {
+              "term": {
+                "name": "01005000 - cinema",
+                "attributes": [],
+                "id": "MDEwMDUwMDA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04008026 - stocks",
+                "attributes": [],
+                "id": "MDQwMDgwMjY=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04010003 - cinema industry",
+                "attributes": [],
+                "id": "MDQwMTAwMDM=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04016052 - stock options",
+                "attributes": [],
+                "id": "MDQwMTYwNTI=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            }
+          ],
+          "mediaType": [
+            {
+              "term": {
+                "name": "Text",
+                "attributes": [],
+                "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+                "taxonomy": "mediaType"
+              }
+            }
+          ],
+          "organisations": [
+            {
+              "term": {
+                "name": "Apple Inc",
+                "attributes": [
+                  {
+                    "value": "us:AAPL",
+                    "key": "wsod_key"
+                  },
+                  {
+                    "value": "true",
+                    "key": "is_company"
+                  }
+                ],
+                "id": "TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0FBUEw=-T04=",
+                "taxonomy": "organisations"
+              }
+            }
+          ],
+          "people": [
+            {
+              "term": {
+                "name": "Eddy Cue",
+                "attributes": [],
+                "id": "M2NmZTE5NzctODc5Ny00YzE1LWFlYWUtNWJlMjAyZjE5MDlm-UE4=",
+                "taxonomy": "people"
+              }
+            },
+            {
+              "term": {
+                "name": "Rick Tetzeli",
+                "attributes": [],
+                "id": "NmQ0MmI5ZGEtNmY1MS00MDA3LWJjNGMtZjcxNzJhMzUzNDE2-UE4=",
+                "taxonomy": "people"
+              }
+            },
+            {
+              "term": {
+                "name": "Steve Wozniak",
+                "attributes": [],
+                "id": "TnN0ZWluX1BOX0VudGVydGFpbm1lbnRfMjAwOV8xMF85XzEwMTk1OQ==-UE4=",
+                "taxonomy": "people"
+              }
+            },
+            {
+              "term": {
+                "name": "Steve Jobs",
+                "attributes": [],
+                "id": "TnN0ZWluX1BOX0VudGVydGFpbm1lbnRfMjAwOV8xMF85XzQ1MDQ3-UE4=",
+                "taxonomy": "people"
+              }
+            },
+            {
+              "term": {
+                "name": "Alex Gibney",
+                "attributes": [],
+                "id": "TnN0ZWluX1BOX0VudGVydGFpbm1lbnRfMjAwOV8xMF85XzUxMTcz-UE4=",
+                "taxonomy": "people"
+              }
+            },
+            {
+              "term": {
+                "name": "Michael Fassbender",
+                "attributes": [],
+                "id": "TnN0ZWluX1BOX0VudGVydGFpbm1lbnRfMjAwOV8xMF85Xzk5MDI4-UE4=",
+                "taxonomy": "people"
+              }
+            },
+            {
+              "term": {
+                "name": "Danny Boyle",
+                "attributes": [],
+                "id": "UE5fY2VsZWJzLXBsdXNfZmV2LTIwMDhfMjU1-UE4=",
+                "taxonomy": "people"
+              }
+            },
+            {
+              "term": {
+                "name": "Brent Schlender",
+                "attributes": [],
+                "id": "ZTE4NWY0MGYtOThmNy00NjE1LWI3OWUtNzRlNDY4N2FhMzA3-UE4=",
+                "taxonomy": "people"
+              }
+            }
+          ],
+          "regions": [],
+          "sections": [
+            {
+              "term": {
+                "name": "Work & Career",
+                "attributes": [
+                  {
+                    "value": "work.and.career",
+                    "key": "dfpSite"
+                  }
+                ],
+                "id": "MTI1-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Film & Television",
+                "attributes": [
+                  {
+                    "value": "life.and.arts",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "film.and.television",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "MTUy-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Technology",
+                "attributes": [
+                  {
+                    "value": "companies",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "technology",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "NTM=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "US & Canadian Companies",
+                "attributes": [],
+                "id": "NjU=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            }
+          ],
+          "specialReports": [],
+          "subjects": [
+            {
+              "term": {
+                "name": "General News",
+                "attributes": [],
+                "id": "MTE4-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            }
+          ],
+          "topics": [
+            {
+              "term": {
+                "name": "Leadership",
+                "attributes": [],
+                "id": "NDhkMTE0NjEtNGMzYS00OTEzLTg1MGEtNjViM2UzYzNmZTlk-VG9waWNz",
+                "taxonomy": "topics"
+              }
+            }
+          ]
+        },
+        "images": [
+          {
+            "alt": "Steve Jobs",
+            "width": 272,
+            "mediaType": "image/jpeg",
+            "source": "FT",
+            "type": "primary",
+            "url": "http://im.ft-static.com/content/images/75e15193-4ffb-43b6-bd1b-e43c3aaa7fe0.img",
+            "height": 153
+          },
+          {
+            "alt": "Steve Jobs",
+            "width": 167,
+            "mediaType": "image/jpeg",
+            "source": "FT",
+            "type": "secondary",
+            "url": "http://im.ft-static.com/content/images/d3199b0d-e098-4cd1-9e79-ccdaf008e8f7.img",
+            "height": 94
+          },
+          {
+            "alt": "Steve Jobs",
+            "width": 600,
+            "mediaType": "image/jpeg",
+            "source": "FT",
+            "type": "article",
+            "url": "http://im.ft-static.com/content/images/cfc3a509-9484-4a55-a547-1b6ae55c9069.img",
+            "height": 338
+          },
+          {
+            "alt": "Steve Jobs",
+            "width": 414,
+            "mediaType": "image/jpeg",
+            "source": "FT",
+            "type": "leader",
+            "url": "http://im.ft-static.com/content/images/f8021d7f-5679-4b5c-8efd-21f06b58760f.img",
+            "height": 233
+          },
+          {
+            "alt": "Steve Jobs",
+            "width": 972,
+            "mediaType": "image/jpeg",
+            "source": "FT",
+            "type": "wide-format",
+            "url": "http://im.ft-static.com/content/images/abda36f3-8afa-48a8-9bc8-58d7a6cfdd4f.img",
+            "height": 547
+          },
+          {
+            "alt": "SteveJjobs Man in the Machine",
+            "width": 184,
+            "mediaType": "image/jpeg",
+            "source": "FT",
+            "type": "inline",
+            "url": "http://im.ft-static.com/content/images/fff2660c-5bbc-11e5-a28b-50226830d644.img",
+            "height": 273
+          }
+        ],
+        "package": [],
+        "assets": [],
+        "mediaAssets": []
+      },
+      "_lastUpdatedDateTime": "2015-09-16T11:45:54.472Z"
+    },
+    "sort": [
+      1442403853000
+    ]
+  },
+  {
+    "_index": "v1_api_v2",
+    "_type": "item",
+    "_id": "71468994-5c41-11e5-9846-de406ccb37f2",
+    "_score": null,
+    "_source": {
+      "requestUrl": "http://api.ft.com/content/items/v1/71468994-5c41-11e5-9846-de406ccb37f2?feature.blogposts=on&h=7730785147",
+      "item": {
+        "aspectSet": "article",
+        "aspects": [
+          "assets",
+          "body",
+          "editorial",
+          "images",
+          "lifecycle",
+          "location",
+          "master",
+          "mediaAssets",
+          "metadata",
+          "package",
+          "packaging",
+          "provenance",
+          "summary",
+          "title"
+        ],
+        "modelVersion": "1",
+        "id": "71468994-5c41-11e5-9846-de406ccb37f2",
+        "apiUrl": "http://api.ft.com/content/items/v1/71468994-5c41-11e5-9846-de406ccb37f2",
+        "title": {
+          "title": "iOS 9 release: Apple opts for subtlety over revolutionary changes"
+        },
+        "body": {
+          "mediaType": "text/html",
+          "body": "<p><span class=\"ft-bold\">iPhone and iPad owners will immediately notice a small but satisfying change after updating to the latest version of iOS this week. As you enter your password to sign into iCloud after installing iOS 9, the letters on that tiny keyboard will be in a lower-case font, only switching back to the familiar capitals when you press the shift key.</span>\n</p>\n<p>Other smartphone keyboards have used this technique for years, but the iPhone’s previous all-caps approach made it confusing to tell when you were actually typing in lower case or upper case.</p>\n<p>This kind of change is iOS 9 all over: incremental yet worthwhile, if overdue.</p>\n<p>Unlike the iOS launches of years gone by that prompted outcry for removing Google Maps, “flattening” the design, swallowing up gigabytes of memory or — in some cases — briefly taking away wireless connectivity, iOS 9 is all about making the iPhone’s annual software update as smooth as possible. While Apple billed last year’s update as its <a title=\"Apple opens up with iOS 8 and targets the privacy high ground - FT.com\" href=\"http://www.ft.com/cms/s/0/e21fc14c-3e6c-11e4-a620-00144feabdc0.html?siteedition=uk#axzz3lsrUBBwW\">“biggest iOS release ever”</a>, its latest is full of smaller, everyday improvements.</p>\n<p><span class=\"ft-bold\">Features</span>\n</p>\n<p>The headline-grabbing features of iOS 9 when it was announced in June were a new News app, replacing the little-loved Newsstand; a smarter, pre-emptive Siri that volunteers apps and information before you realise you need them; and for recent iPads, a split-screen mode that lets you use two apps side-by-side.</p>\n<p>Judging by tumbling iPad sales figures, I am one of many people clinging on to an ageing Apple tablet that lacks the processing power to run iOS 9’s new multitasking capabilities, which ape those already offered by Microsoft’s Surface. So I will test those in a future review. (If you have an iPad Air, iPad Mini 2 or later, you should have more luck.)</p>\n<p>Over the past week, I have been browsing stories on News, swiping right on my home screen to access Siri’s “Proactive” recommendations and even checking bus routes in Apple Maps (yes, it is still catching up with Google Maps, three years on from that bungled launch).</p>\n<p>I have enjoyed reading emails and text messages in Apple’s new San Francisco font, first used on the Apple Watch and now replacing Helvetica Neue across all its devices. Apple has used distinctive typefaces to differentiate its products in the past — Susan Kare’s fonts helped to define the onscreen look of the Macintosh in the 1980s — and the curvier, well-spaced San Francisco is designed to be easy on the eye on small displays.</p>\n<p>Another subtle change is to the Notification Center that appears when you swipe down from the top of the iPhone’s screen. Posts and updates are now ordered chronologically rather than by app, making it easier to dismiss a full day’s worth of interruptions in a couple of taps. This is one of several day-to-day frustrations that Apple has tried to fix. Searching in the inbuilt Mail app actually works now. </p>\n<p><span class=\"ft-bold\">Battery life</span>\n</p>\n<p>Nips and tucks to power consumption across the operating system give battery life a small bump — up to an hour, Apple says, although I still have to recharge my iPhone 6 before the end of most days. When the battery does run low, a new power-saving option turns off background downloading of apps and email, among other tweaks which squeeze the most out of the charge you have left. </p>\n<p>Another way to save power for web surfers is the option to download adblocking extensions for the inbuilt Safari browser. This move has caused controversy among publishers but is the latest manifestation of Apple’s broader privacy push. </p>\n<p>Siri’s new “Proactive” mode also attempts to marry privacy improvements with Google-style predictive functionality. While virtual assistants Google Now and <a title=\"What happened when I let Microsoft’s Cortana into my Android life - FT.com\" href=\"http://www.ft.com/cms/s/0/712dc8ca-39ee-11e5-bbd1-b37bc06f590c.html#axzz3lsrUBBwW\">Microsoft Cortana</a> (as well as <a title=\"Amazon Echo’s virtual helper Alexa has designs on your home - FT.com\" href=\"http://www.ft.com/cms/s/0/1d1228e6-56fc-11e5-9846-de406ccb37f2.html#axzz3lsrUBBwW\">Amazon’s standalone Echo device </a>I reviewed last week) rely on the cloud to make helpful, unprompted suggestions and recommendations, Apple is trying to do more of that processing on the iPhone itself, which it says better protects personal information. </p>\n<p>The software does a decent job of remembering which apps you use or people you contact in a particular location or time of day, with recommendations improving over time. Siri suggests adding emailed restaurant or flight bookings to your calendar. Suggested news headlines, however, were hit and miss. </p>\n<p>It is early days for Proactive Siri and it will be a test of Apple’s technical capabilities if it can eventually create an assistant that matches its rivals without throwing our personal information far and wide. For now, Google Now’s more advanced suggestions make a persuasive case for entrusting it with our data. </p>\n<p><span class=\"ft-bold\">The verdict</span>\n</p>\n<p>With its biggest new feature still a work-in-progress, iOS 9 may not be revolutionary. But at a mere 1.3GB download — compared with iOS 8’s huge 4.5GB — it is worth finding the space on your iPhone for. </p>\n<aside data-asset-type=\"dataTable\" data-asset-name=\"asset1\"></aside><p>\n</p>"
+        },
+        "lifecycle": {
+          "initialPublishDateTime": "2015-09-16T08:44:41Z",
+          "lastPublishDateTime": "2015-09-16T08:44:41Z"
+        },
+        "location": {
+          "uri": "http://www.ft.com/cms/s/0/71468994-5c41-11e5-9846-de406ccb37f2.html"
+        },
+        "summary": {
+          "excerpt": "Operating system’s update focuses on move to fix day-to-day frustrations"
+        },
+        "packaging": {
+          "spHeadline": "Apple opts for subtlety",
+          "kicker": "iOS 9 release"
+        },
+        "master": {
+          "masterSource": "Methode",
+          "masterEntityId": "71468994-5c41-11e5-9846-de406ccb37f2"
+        },
+        "editorial": {
+          "otherTitles": [
+            "iOS 9 release: Apple opts for subtlety"
+          ],
+          "subheading": "Operating system update focuses on incremental improvements",
+          "standFirst": "Operating system’s update focuses on move to fix day-to-day frustrations",
+          "byline": "By Tim Bradshaw in San Francisco"
+        },
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "metadata": {
+          "primarySection": {
+            "term": {
+              "name": "Work & Career",
+              "id": "MTI1-U2VjdGlvbnM=",
+              "attributes": [
+                {
+                  "value": "work.and.career",
+                  "key": "dfpSite"
+                }
+              ],
+              "taxonomy": "sections"
+            }
+          },
+          "primaryTheme": {
+            "term": {
+              "name": "Apple Inc",
+              "id": "TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0FBUEw=-T04=",
+              "attributes": [
+                {
+                  "value": "us:AAPL",
+                  "key": "wsod_key"
+                },
+                {
+                  "value": "true",
+                  "key": "is_company"
+                }
+              ],
+              "taxonomy": "organisations"
+            }
+          },
+          "tags": [
+            {
+              "term": {
+                "name": "Apple Inc",
+                "attributes": [
+                  {
+                    "value": "us:AAPL",
+                    "key": "wsod_key"
+                  },
+                  {
+                    "value": "true",
+                    "key": "is_company"
+                  }
+                ],
+                "id": "TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0FBUEw=-T04=",
+                "taxonomy": "organisations"
+              }
+            },
+            {
+              "term": {
+                "name": "Work & Career",
+                "attributes": [
+                  {
+                    "value": "work.and.career",
+                    "key": "dfpSite"
+                  }
+                ],
+                "id": "MTI1-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Review",
+                "attributes": [],
+                "id": "NA==-R2VucmVz",
+                "taxonomy": "genre"
+              }
+            },
+            {
+              "term": {
+                "name": "Text",
+                "attributes": [],
+                "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+                "taxonomy": "mediaType"
+              }
+            },
+            {
+              "term": {
+                "name": "Tim Bradshaw",
+                "attributes": [],
+                "id": "Q0ItMDAwMDY4OA==-QXV0aG9ycw==",
+                "taxonomy": "authors"
+              }
+            },
+            {
+              "term": {
+                "name": "9530 Software & Computer Services",
+                "attributes": [],
+                "id": "MTc2-SUNC",
+                "taxonomy": "icb"
+              }
+            },
+            {
+              "term": {
+                "name": "9535 Internet",
+                "attributes": [],
+                "id": "MTc4-SUNC",
+                "taxonomy": "icb"
+              }
+            },
+            {
+              "term": {
+                "name": "9537 Software",
+                "attributes": [],
+                "id": "MTc5-SUNC",
+                "taxonomy": "icb"
+              }
+            },
+            {
+              "term": {
+                "name": "01027000 - internet",
+                "attributes": [],
+                "id": "MDEwMjcwMDA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04003005 - software",
+                "attributes": [],
+                "id": "MDQwMDMwMDU=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "Tim Cook (Executive)",
+                "attributes": [],
+                "id": "MzJmYWJlNDAtOWY4NS00ZWMzLTg2OTItZjMxODdiY2RiNzYz-UE4=",
+                "taxonomy": "people"
+              }
+            },
+            {
+              "term": {
+                "name": "San Francisco",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX1VTX0NBX011bmljaXBhbGl0eV8yNzc1OTM=-R0w=",
+                "taxonomy": "regions"
+              }
+            },
+            {
+              "term": {
+                "name": "Companies",
+                "attributes": [
+                  {
+                    "value": "companies",
+                    "key": "dfpSite"
+                  }
+                ],
+                "id": "Mjk=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Technology",
+                "attributes": [
+                  {
+                    "value": "companies",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "technology",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "NTM=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "US & Canadian Companies",
+                "attributes": [],
+                "id": "NjU=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Personal Technology",
+                "attributes": [
+                  {
+                    "value": "life.and.arts",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "personal.technology",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "OTM5ZWYwODQtMGVhYS00MzBlLWE0NjctODNmMmUwYWIxOGJl-QnJhbmRz",
+                "taxonomy": "sections"
+              }
+            }
+          ],
+          "authors": [
+            {
+              "term": {
+                "name": "Tim Bradshaw",
+                "attributes": [],
+                "id": "Q0ItMDAwMDY4OA==-QXV0aG9ycw==",
+                "taxonomy": "authors"
+              }
+            }
+          ],
+          "brand": [],
+          "genre": [
+            {
+              "term": {
+                "name": "Review",
+                "attributes": [],
+                "id": "NA==-R2VucmVz",
+                "taxonomy": "genre"
+              }
+            }
+          ],
+          "icb": [
+            {
+              "term": {
+                "name": "9530 Software & Computer Services",
+                "attributes": [],
+                "id": "MTc2-SUNC",
+                "taxonomy": "icb"
+              }
+            },
+            {
+              "term": {
+                "name": "9535 Internet",
+                "attributes": [],
+                "id": "MTc4-SUNC",
+                "taxonomy": "icb"
+              }
+            },
+            {
+              "term": {
+                "name": "9537 Software",
+                "attributes": [],
+                "id": "MTc5-SUNC",
+                "taxonomy": "icb"
+              }
+            }
+          ],
+          "iptc": [
+            {
+              "term": {
+                "name": "01027000 - internet",
+                "attributes": [],
+                "id": "MDEwMjcwMDA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04003005 - software",
+                "attributes": [],
+                "id": "MDQwMDMwMDU=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            }
+          ],
+          "mediaType": [
+            {
+              "term": {
+                "name": "Text",
+                "attributes": [],
+                "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+                "taxonomy": "mediaType"
+              }
+            }
+          ],
+          "organisations": [
+            {
+              "term": {
+                "name": "Apple Inc",
+                "attributes": [
+                  {
+                    "value": "us:AAPL",
+                    "key": "wsod_key"
+                  },
+                  {
+                    "value": "true",
+                    "key": "is_company"
+                  }
+                ],
+                "id": "TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0FBUEw=-T04=",
+                "taxonomy": "organisations"
+              }
+            }
+          ],
+          "people": [
+            {
+              "term": {
+                "name": "Tim Cook (Executive)",
+                "attributes": [],
+                "id": "MzJmYWJlNDAtOWY4NS00ZWMzLTg2OTItZjMxODdiY2RiNzYz-UE4=",
+                "taxonomy": "people"
+              }
+            }
+          ],
+          "regions": [
+            {
+              "term": {
+                "name": "San Francisco",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX1VTX0NBX011bmljaXBhbGl0eV8yNzc1OTM=-R0w=",
+                "taxonomy": "regions"
+              }
+            }
+          ],
+          "sections": [
+            {
+              "term": {
+                "name": "Work & Career",
+                "attributes": [
+                  {
+                    "value": "work.and.career",
+                    "key": "dfpSite"
+                  }
+                ],
+                "id": "MTI1-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Companies",
+                "attributes": [
+                  {
+                    "value": "companies",
+                    "key": "dfpSite"
+                  }
+                ],
+                "id": "Mjk=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Technology",
+                "attributes": [
+                  {
+                    "value": "companies",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "technology",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "NTM=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "US & Canadian Companies",
+                "attributes": [],
+                "id": "NjU=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Personal Technology",
+                "attributes": [
+                  {
+                    "value": "life.and.arts",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "personal.technology",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "OTM5ZWYwODQtMGVhYS00MzBlLWE0NjctODNmMmUwYWIxOGJl-QnJhbmRz",
+                "taxonomy": "sections"
+              }
+            }
+          ],
+          "specialReports": [],
+          "subjects": [],
+          "topics": []
+        },
+        "images": [
+          {
+            "alt": "User screens from the Apple iOS9 operating system update",
+            "width": 272,
+            "mediaType": "image/jpeg",
+            "type": "primary",
+            "url": "http://im.ft-static.com/content/images/9cc62dd8-0dc1-4db6-b0c4-ea7db7c58da4.img",
+            "height": 153
+          },
+          {
+            "alt": "User screens from the Apple iOS9 operating system update",
+            "width": 167,
+            "mediaType": "image/jpeg",
+            "type": "secondary",
+            "url": "http://im.ft-static.com/content/images/19110459-b270-4a58-a3f3-447ba84bba0f.img",
+            "height": 94
+          },
+          {
+            "alt": "User screens from the Apple iOS9 operating system update",
+            "width": 600,
+            "mediaType": "image/jpeg",
+            "type": "article",
+            "url": "http://im.ft-static.com/content/images/95b4b9ee-bbea-434b-97d3-a806c9b8084b.img",
+            "height": 338
+          },
+          {
+            "alt": "User screens from the Apple iOS9 operating system update",
+            "width": 414,
+            "mediaType": "image/jpeg",
+            "type": "leader",
+            "url": "http://im.ft-static.com/content/images/c1445bb3-01cb-43df-8d62-143c5e35e51e.img",
+            "height": 233
+          },
+          {
+            "alt": "User screens from the Apple iOS9 operating system update",
+            "width": 972,
+            "mediaType": "image/jpeg",
+            "type": "wide-format",
+            "url": "http://im.ft-static.com/content/images/5d18050f-3a19-4d7e-a776-d7bd5d08e399.img",
+            "height": 547
+          }
+        ],
+        "package": [
+          {
+            "provenance": {
+              "originatingParty": "FT"
+            },
+            "apiUrl": "http://api.ft.com/content/items/v1/9f7b25d8-39ee-11e5-bbd1-b37bc06f590c",
+            "packaging": {
+              "spHeadline": "what to pack",
+              "kicker": "Vacation gadgets"
+            },
+            "id": "9f7b25d8-39ee-11e5-bbd1-b37bc06f590c"
+          },
+          {
+            "provenance": {
+              "originatingParty": "FT"
+            },
+            "apiUrl": "http://api.ft.com/content/items/v1/7b2ea402-3601-11e5-b05b-b01debd57852",
+            "packaging": {
+              "spHeadline": "A marriage of old and new",
+              "kicker": "Windows 10"
+            },
+            "id": "7b2ea402-3601-11e5-b05b-b01debd57852"
+          },
+          {
+            "provenance": {
+              "originatingParty": "FT"
+            },
+            "apiUrl": "http://api.ft.com/content/items/v1/0d4a3880-3470-11e5-bdbb-35e55cbae175",
+            "packaging": {
+              "spHeadline": "Microsoft aims to woo with Windows 10",
+              "kicker": "Analysis"
+            },
+            "id": "0d4a3880-3470-11e5-bdbb-35e55cbae175"
+          },
+          {
+            "provenance": {
+              "originatingParty": "FT"
+            },
+            "apiUrl": "http://api.ft.com/content/items/v1/217f1998-3064-11e5-91ac-a5e17d9b4cff",
+            "packaging": {
+              "spHeadline": "Electric skateboard thrill",
+              "kicker": "Boosted Board"
+            },
+            "id": "217f1998-3064-11e5-91ac-a5e17d9b4cff"
+          },
+          {
+            "provenance": {
+              "originatingParty": "FT"
+            },
+            "apiUrl": "http://api.ft.com/content/items/v1/261124bc-2aef-11e5-acfb-cbd2e1c81cca",
+            "packaging": {
+              "spHeadline": "Pebble Time feels like smartwatch of past",
+              "kicker": "Personal Technology"
+            },
+            "id": "261124bc-2aef-11e5-acfb-cbd2e1c81cca"
+          }
+        ],
+        "assets": [
+          {
+            "name": "asset1",
+            "type": "dataTable",
+            "fields": {
+              "body": "<table><caption>Planet of the apps</caption>\n<tr><td colspan=\"2\"><p><span class=\"ft-bold\">What is it</span>\n<span class=\"ft-bold\"></span> <br/>Apple News (free with iOS 9)</p>\n<p>Apple chief executive Tim Cook recently said that it would consider letting iPhone users remove the company’s own apps which it automatically installs on their homescreens. In the meantime, though, it just added another: News, Apple’s take on a Flipboard-style newsreader. </p>\n<p><span class=\"ft-bold\">Why you should try it</span>\n<br/>Start by selecting your favourite publications and topics (“Food and drink”, “Economy”, “Space exploration”) and Apple News will offer a range of semi-personalised articles. Like the internet, Apple News is a great leveller — newspaper stories sit side by side with blogposts, but unlike the web, they all have the same smooth design. Much like Apple Music’s playlists, its added value is in editorial recommendations that unearth hidden gems of stories. </p>\n</td>\n</tr>\n</table>"
+            }
+          }
+        ],
+        "mediaAssets": []
+      },
+      "_lastUpdatedDateTime": "2015-09-16T13:36:54.687Z"
+    },
+    "sort": [
+      1442393081000
+    ]
+  }
+]

--- a/test/fixtures/readNext/topicArticles2.json
+++ b/test/fixtures/readNext/topicArticles2.json
@@ -1,0 +1,1128 @@
+[
+  {
+    "_index": "v1_api_v2",
+    "_type": "item",
+    "_id": "921d8c8e-5c47-11e5-a28b-50226830d644",
+    "_score": null,
+    "_source": {
+      "requestUrl": "http://api.ft.com/content/items/v1/921d8c8e-5c47-11e5-a28b-50226830d644?feature.blogposts=on&h=2568569686",
+      "item": {
+        "aspectSet": "article",
+        "aspects": [
+          "assets",
+          "body",
+          "editorial",
+          "images",
+          "lifecycle",
+          "location",
+          "master",
+          "mediaAssets",
+          "metadata",
+          "package",
+          "packaging",
+          "provenance",
+          "summary",
+          "title"
+        ],
+        "modelVersion": "1",
+        "id": "921d8c8e-5c47-11e5-a28b-50226830d644",
+        "apiUrl": "http://api.ft.com/content/items/v1/921d8c8e-5c47-11e5-a28b-50226830d644",
+        "title": {
+          "title": "China eases limits on overseas debt"
+        },
+        "body": {
+          "mediaType": "text/html",
+          "body": "<p>Beijing has eased restrictions on Chinese companies seeking to raise funds overseas, after a record monthly decline in China’s foreign exchange reserves in August. </p>\n<p>The decision to loosen capital controls on inbound funds stands to boost capital inflows at a time when big domestic stock market losses and the slowing Chinese economy are heightening concerns about <a title=\"Capital outflows reignite debate between China bulls and bears - FT.com\" href=\"http://www.ft.com/intl/cms/s/0/5c615290-3737-11e5-b05b-b01debd57852.html\">capital outflows</a>. </p>\n<p>China’s top planning agency, the National Development and Reform Commission, has made it easier for Chinese companies to obtain foreign currency bank loans or issue renminbi bonds with a term of more than one year, according to a statement on its website dated Tuesday.</p>\n<p>“The new policy will simplify the process for Chinese entities to issue offshore bonds. It will give Chinese companies flexibility in terms of timing and the amount of bonds issued as long as it is within the approved foreign debt quota,” said Ivan Chung, head of greater China credit research at Moody’s in Hong Kong. </p>\n<p>Previously, companies needed approval on a deal-by-deal basis but now they are only required to register with the regulator. “Like Shanghai-HK Stock Connect, it is another step forward in integrating the Chinese financial market with the world,” Mr Chung said. </p>\n\n<p>China’s foreign exchange reserves fell 2.6 per cent to $3.557tn in August, a monthly <a title=\"China’s foreign exchange reserves fall by record $94bn - FT.com\" href=\"http://www.ft.com/intl/cms/s/0/2d3eb83e-554d-11e5-8642-453585f2cfcd.html#axzz3lsE9hDZv\">$94bn</a> drop that was the sharpest on record, as the People’s Bank of China sold down some of its stockpile to support the renminbi. </p>\n<p>​Data from the Bank of International Settlements show that foreign bank claims on China shrank by $77bn in the first three months of 2015, reflecting their reluctance to lend and Chinese borrowers’ increasing wariness of taking on foreign currency debt. </p>\n<p>“On one level it’s encouraging to see that China has not lost its appetite for pro-market liberalisation, even as volatility and uncertainty have risen. It suggests the leadership understands that problems revealed by market forces can be addressed by market forces as well,” says Michael Kurtz, chief Asia equity strategist at Nomura in Hong Kong.</p>\n<p>However, he said it was not clear that Chinese firms would immediately embrace the more open overseas borrowing environment, “given expectations for both a depreciating renminbi and for rising US dollar borrowing costs vs falling domestic borrowing costs”. Markets are awaiting a decision from the US Federal Reserve on Thursday on whether to raise interest rates for the first time in nearly a decade. </p>\n<p>The NDRC also said it would encourage companies with good credit quality and strong debt repayment ability to raise money overseas for high-priority construction and investment projects such as the “One Belt, One Road” campaign to develop ties along the old Silk Road trading route. </p>\n<p>Meanwhile, China is considering implementing restrictions on automated trading in its commodity markets, according to market participants who spoke to the FT.</p>\n<p>The new regulations would define automated traders, require their identity and source of funds to be disclosed and limit the number of trades they could place in the futures markets. </p>\n<p>“A few years ago the exchanges began researching this type of unified management because programme trading is different from other trading behaviour and can cause shocks,” said one exchange official who did not want to be named. “After the August 16 crash, this discussion has sprung up again.”</p>\n<p><span class=\"ft-italic\">Additional reporting by Jackie Cai and Lucy Hornby</span>\n</p>"
+        },
+        "lifecycle": {
+          "initialPublishDateTime": "2015-08-16T09:07:26Z",
+          "lastPublishDateTime": "2015-08-16T09:07:26Z"
+        },
+        "location": {
+          "uri": "http://www.ft.com/cms/s/0/921d8c8e-5c47-11e5-a28b-50226830d644.html"
+        },
+        "summary": {
+          "excerpt": "Loosening of controls on inbound funds comes amid rising concerns over capital outflows"
+        },
+        "packaging": {
+          "spHeadline": "China eases limits on overseas debt"
+        },
+        "master": {
+          "masterSource": "Methode",
+          "masterEntityId": "921d8c8e-5c47-11e5-a28b-50226830d644"
+        },
+        "editorial": {
+          "subheading": "Inbound fund controls loosened amid fears over capital outflows",
+          "standFirst": "Loosening of controls on inbound funds comes amid rising concerns over capital outflows",
+          "byline": "Patti Waldmeir in Shanghai"
+        },
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "metadata": {
+          "primarySection": {
+            "term": {
+              "name": "Chinese Economy",
+              "id": "MTEx-U2VjdGlvbnM=",
+              "attributes": [],
+              "taxonomy": "sections"
+            }
+          },
+          "primaryTheme": {
+            "term": {
+              "name": "China Economic Slowdown",
+              "id": "NWIwYzgxZTgtZjc3MC00ODNkLWI1YjYtYTVhNGQ2OTNjYjVi-VG9waWNz",
+              "attributes": [],
+              "taxonomy": "topics"
+            }
+          },
+          "tags": [
+            {
+              "term": {
+                "name": "China Economic Slowdown",
+                "attributes": [],
+                "id": "NWIwYzgxZTgtZjc3MC00ODNkLWI1YjYtYTVhNGQ2OTNjYjVi-VG9waWNz",
+                "taxonomy": "topics"
+              }
+            },
+            {
+              "term": {
+                "name": "Chinese Economy",
+                "attributes": [],
+                "id": "MTEx-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "News",
+                "attributes": [],
+                "id": "Nw==-R2VucmVz",
+                "taxonomy": "genre"
+              }
+            },
+            {
+              "term": {
+                "name": "Text",
+                "attributes": [],
+                "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+                "taxonomy": "mediaType"
+              }
+            },
+            {
+              "term": {
+                "name": "Patti Waldmeir",
+                "attributes": [],
+                "id": "Q0ItMDAwMDg4Ng==-QXV0aG9ycw==",
+                "taxonomy": "authors"
+              }
+            },
+            {
+              "term": {
+                "name": "8355 Banks",
+                "attributes": [],
+                "id": "MTQy-SUNC",
+                "taxonomy": "icb"
+              }
+            },
+            {
+              "term": {
+                "name": "04006000 - financial and business service",
+                "attributes": [],
+                "id": "MDQwMDYwMDA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04006002 - banking",
+                "attributes": [],
+                "id": "MDQwMDYwMDI=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04008020 - credit and debt",
+                "attributes": [],
+                "id": "MDQwMDgwMjA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04008023 - financial markets",
+                "attributes": [],
+                "id": "MDQwMDgwMjM=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04008026 - stocks",
+                "attributes": [],
+                "id": "MDQwMDgwMjY=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04009000 - market and exchange",
+                "attributes": [],
+                "id": "MDQwMDkwMDA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "11013000 - state budget and tax",
+                "attributes": [],
+                "id": "MTEwMTMwMDA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "Beijing",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0FGVE1fR0xfMTEyOTc=-R0w=",
+                "taxonomy": "regions"
+              }
+            },
+            {
+              "term": {
+                "name": "Hong Kong",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0FGVE1fR0xfNTc0NjY=-R0w=",
+                "taxonomy": "regions"
+              }
+            },
+            {
+              "term": {
+                "name": "China",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0NO-R0w=",
+                "taxonomy": "regions"
+              }
+            },
+            {
+              "term": {
+                "name": "World Economy",
+                "attributes": [
+                  {
+                    "value": "world",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "world.economy",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "MTA3-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Currencies",
+                "attributes": [
+                  {
+                    "value": "markets",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "currencies",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "MTAz-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Markets",
+                "attributes": [
+                  {
+                    "value": "markets",
+                    "key": "dfpSite"
+                  }
+                ],
+                "id": "NzE=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Corporate Finance",
+                "attributes": [],
+                "id": "Ng==-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            },
+            {
+              "term": {
+                "name": "Economic Indicators",
+                "attributes": [],
+                "id": "NjU=-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            },
+            {
+              "term": {
+                "name": "China Business",
+                "attributes": [],
+                "id": "NjM3ZTU3MDUtMmY1ZS00ZGExLThkNjYtYWY4YWUzY2U1YWVm-VG9waWNz",
+                "taxonomy": "topics"
+              }
+            }
+          ],
+          "authors": [
+            {
+              "term": {
+                "name": "Patti Waldmeir",
+                "attributes": [],
+                "id": "Q0ItMDAwMDg4Ng==-QXV0aG9ycw==",
+                "taxonomy": "authors"
+              }
+            }
+          ],
+          "brand": [],
+          "genre": [
+            {
+              "term": {
+                "name": "News",
+                "attributes": [],
+                "id": "Nw==-R2VucmVz",
+                "taxonomy": "genre"
+              }
+            }
+          ],
+          "icb": [
+            {
+              "term": {
+                "name": "8355 Banks",
+                "attributes": [],
+                "id": "MTQy-SUNC",
+                "taxonomy": "icb"
+              }
+            }
+          ],
+          "iptc": [
+            {
+              "term": {
+                "name": "04006000 - financial and business service",
+                "attributes": [],
+                "id": "MDQwMDYwMDA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04006002 - banking",
+                "attributes": [],
+                "id": "MDQwMDYwMDI=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04008020 - credit and debt",
+                "attributes": [],
+                "id": "MDQwMDgwMjA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04008023 - financial markets",
+                "attributes": [],
+                "id": "MDQwMDgwMjM=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04008026 - stocks",
+                "attributes": [],
+                "id": "MDQwMDgwMjY=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04009000 - market and exchange",
+                "attributes": [],
+                "id": "MDQwMDkwMDA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "11013000 - state budget and tax",
+                "attributes": [],
+                "id": "MTEwMTMwMDA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            }
+          ],
+          "mediaType": [
+            {
+              "term": {
+                "name": "Text",
+                "attributes": [],
+                "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+                "taxonomy": "mediaType"
+              }
+            }
+          ],
+          "organisations": [],
+          "people": [],
+          "regions": [
+            {
+              "term": {
+                "name": "Beijing",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0FGVE1fR0xfMTEyOTc=-R0w=",
+                "taxonomy": "regions"
+              }
+            },
+            {
+              "term": {
+                "name": "Hong Kong",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0FGVE1fR0xfNTc0NjY=-R0w=",
+                "taxonomy": "regions"
+              }
+            },
+            {
+              "term": {
+                "name": "China",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0NO-R0w=",
+                "taxonomy": "regions"
+              }
+            }
+          ],
+          "sections": [
+            {
+              "term": {
+                "name": "World Economy",
+                "attributes": [
+                  {
+                    "value": "world",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "world.economy",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "MTA3-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Currencies",
+                "attributes": [
+                  {
+                    "value": "markets",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "currencies",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "MTAz-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Chinese Economy",
+                "attributes": [],
+                "id": "MTEx-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Markets",
+                "attributes": [
+                  {
+                    "value": "markets",
+                    "key": "dfpSite"
+                  }
+                ],
+                "id": "NzE=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            }
+          ],
+          "specialReports": [],
+          "subjects": [
+            {
+              "term": {
+                "name": "Corporate Finance",
+                "attributes": [],
+                "id": "Ng==-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            },
+            {
+              "term": {
+                "name": "Economic Indicators",
+                "attributes": [],
+                "id": "NjU=-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            }
+          ],
+          "topics": [
+            {
+              "term": {
+                "name": "China Economic Slowdown",
+                "attributes": [],
+                "id": "NWIwYzgxZTgtZjc3MC00ODNkLWI1YjYtYTVhNGQ2OTNjYjVi-VG9waWNz",
+                "taxonomy": "topics"
+              }
+            },
+            {
+              "term": {
+                "name": "China Business",
+                "attributes": [],
+                "id": "NjM3ZTU3MDUtMmY1ZS00ZGExLThkNjYtYWY4YWUzY2U1YWVm-VG9waWNz",
+                "taxonomy": "topics"
+              }
+            }
+          ]
+        },
+        "images": [
+          {
+            "width": 272,
+            "mediaType": "image/jpeg",
+            "source": "AFP",
+            "type": "primary",
+            "url": "http://im.ft-static.com/content/images/9ec9fe0e-146c-4930-92c7-53949e4e00b7.img",
+            "height": 153
+          },
+          {
+            "width": 167,
+            "mediaType": "image/jpeg",
+            "source": "AFP",
+            "type": "secondary",
+            "url": "http://im.ft-static.com/content/images/3f32e634-042b-49f1-b4c1-7562f3ec667a.img",
+            "height": 94
+          },
+          {
+            "width": 600,
+            "mediaType": "image/jpeg",
+            "source": "AFP",
+            "type": "article",
+            "url": "http://im.ft-static.com/content/images/b29ba0c9-c059-49ad-a3ea-afc9ce552f5e.img",
+            "height": 338
+          },
+          {
+            "width": 414,
+            "mediaType": "image/jpeg",
+            "source": "AFP",
+            "type": "leader",
+            "url": "http://im.ft-static.com/content/images/37dabf00-bb83-4a0d-a5cf-7b8aad6226bc.img",
+            "height": 233
+          },
+          {
+            "width": 972,
+            "mediaType": "image/jpeg",
+            "source": "AFP",
+            "type": "wide-format",
+            "url": "http://im.ft-static.com/content/images/0521f258-e325-4d8e-8cac-29e67523f43d.img",
+            "height": 547
+          }
+        ],
+        "package": [],
+        "assets": [],
+        "mediaAssets": []
+      },
+      "_lastUpdatedDateTime": "2015-09-16T11:49:54.509Z"
+    },
+    "sort": [
+      1442394446000
+    ]
+  },
+  {
+    "_index": "v1_api_v2",
+    "_type": "item",
+    "_id": "1ae0b140-5bc6-11e5-97e9-7f0bf5e7177b",
+    "_score": null,
+    "_source": {
+      "requestUrl": "http://api.ft.com/content/items/v1/1ae0b140-5bc6-11e5-97e9-7f0bf5e7177b?feature.blogposts=on&h=5217011441",
+      "item": {
+        "aspectSet": "article",
+        "aspects": [
+          "assets",
+          "body",
+          "editorial",
+          "images",
+          "lifecycle",
+          "location",
+          "master",
+          "mediaAssets",
+          "metadata",
+          "package",
+          "packaging",
+          "provenance",
+          "summary",
+          "title"
+        ],
+        "modelVersion": "1",
+        "id": "1ae0b140-5bc6-11e5-97e9-7f0bf5e7177b",
+        "apiUrl": "http://api.ft.com/content/items/v1/1ae0b140-5bc6-11e5-97e9-7f0bf5e7177b",
+        "title": {
+          "title": "China probes top Citic Securities executives over insider trading"
+        },
+        "body": {
+          "mediaType": "text/html",
+          "body": "<p>The general manager and two other executives from Citic Securities, China's largest investment bank, have been arrested as part of an insider trading probe, the latest casualties of the country's <a title=\"China tremors in depth - FT.com\" href=\"http://www.ft.com/intl/indepth/china-tremors\">ailing stock market</a>.</p>\n<p>State-owned Citic Securities, controlled by industrial and financial conglomerate Citic Group, has been on the front line of government efforts to rescue the country's tumbling stock market. The so-called \"national team\" of state financial institutions directed many trades through the brokerage's flagship trading hall in Beijing.</p>\n<p>Police are investigating Chen Boming, Citic’s general manager, Yu Xinli, operations management head, and Wang Jinling, vice director of information technology, on allegations in connection with insider trading and the leak of inside information, the official Xinhua news agency said late on Tuesday.</p>\n<p>In late August, eight Citic executives and board members were <a title=\"China launches probes into top brokerages - FT.com\" href=\"http://www.ft.com/intl/cms/s/0/ada9ca96-4bab-11e5-b558-8a9722977189.html\">taken into custody</a>. Four of them were later punished for insider trading. The three latest arrests deal a further blow to the company, whose stock price has fallen 61 per cent since the height of China's broader market rally in early June.</p>\n<p>In mid-July, as the government was deploying trillions of renminbi in state rescue funds to stem the panic in the Shanghai and Shenzhen markets, Mr. Chen gave an interview to Caijing, a respected financial magazine in which he pledged the broker would do its part to stabilise the market. </p>\n<p>Detailed allegations against Mr Chen and other Citic executives are not public, but the company is the government's favoured brokerage and may have had information about which stocks state institutions were buying. </p>\n<p>Traders say <a title=\"FT Explainer: What is China Securities Finance Corporation? - FT.com\" href=\"http://www.ft.com/intl/cms/s/0/c1666694-248b-11e5-9c4e-a775d2b173ca.html\">China Securities Finance Corp</a>, the state-owned margin lending agency that became the government's main conduit for injecting rescue funds into the market, was known to route trades through Citic. Indeed, picking stocks thought to be favoured by CSF emerged as a <a title=\"China targets high-frequency traders in ‘spoofing’ probe - FT.com\" href=\"http://www.ft.com/intl/cms/s/0/1f4751f4-3758-11e5-b05b-b01debd57852.html\">popular investment strategy</a> in July, when the agency was conducting daily market interventions.</p>\n<p>Goldman Sachs estimates that the national team has spent Rmb1.5tn ($236bn) since late June to <a title=\"Goldman estimates China’s ‘national team’ stock rescue at $144bn - FT.com\" href=\"http://www.ft.com/intl/cms/s/0/ec29a8b2-3bf8-11e5-8613-07d16aad2152.html\">stabilise the market</a>. That includes cash injections from CSF as well as a Rmb120bn fund comprising funds from 21 leading brokerages led by Citic, China's largest by assets. </p>\n<p>The Shanghai Composite Index is down 41 per cent from its peak on June 9 and has fallen 6 per cent this week.</p>\n<p>The Citic arrests are the latest in a series of regulatory and police actions in response to the market tumble. Police have investigated so-called <a title=\"China’s hunt for short-sellers tests legal boundaries - FT.com\" href=\"http://www.ft.com/intl/cms/s/0/88280be8-2b85-11e5-8613-e7aedbb7bdb7.html\">\"malicious\" short selling</a> and placed new limits on futures trading. Regulators also targeted <a title=\"China targets high-frequency traders in ‘spoofing’ probe - FT.com\" href=\"http://www.ft.com/intl/cms/s/0/1f4751f4-3758-11e5-b05b-b01debd57852.html\">high-frequency traders</a> in a probe focused on the practice known as \"spoofing\".</p>\n<p>A reporter for Caijing confessed on state television to stoking '<a title=\"China reporter confesses to stoking market ‘panic and disorder’ - FT.com\" href=\"http://www.ft.com/intl/cms/s/0/41fed0a6-4f9e-11e5-8642-453585f2cfcd.html\">panic and disorder</a>' for a story saying that the national team was looking for a way to scale back interventions.</p>"
+        },
+        "lifecycle": {
+          "initialPublishDateTime": "2015-08-15T18:21:13Z",
+          "lastPublishDateTime": "2015-08-15T18:21:13Z"
+        },
+        "location": {
+          "uri": "http://www.ft.com/cms/s/0/1ae0b140-5bc6-11e5-97e9-7f0bf5e7177b.html"
+        },
+        "summary": {
+          "excerpt": "Country’s largest brokerage was on front line of Beijing drive to rescue stock market"
+        },
+        "packaging": {
+          "spHeadline": "China holds Citic chiefs in trading probe"
+        },
+        "master": {
+          "masterSource": "Methode",
+          "masterEntityId": "1ae0b140-5bc6-11e5-97e9-7f0bf5e7177b"
+        },
+        "editorial": {
+          "otherTitles": [
+            "China holds Citic chiefs in trading probe"
+          ],
+          "subheading": "Country’s largest broker was on front line of stock market rescue",
+          "standFirst": "Country’s largest brokerage was on front line of Beijing drive to rescue stock market",
+          "byline": "Gabriel Wildau in Shanghai"
+        },
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "metadata": {
+          "primarySection": {
+            "term": {
+              "name": "Financials",
+              "id": "NTc=-U2VjdGlvbnM=",
+              "attributes": [
+                {
+                  "value": "companies",
+                  "key": "dfpSite"
+                },
+                {
+                  "value": "financials",
+                  "key": "dfpZone"
+                }
+              ],
+              "taxonomy": "sections"
+            }
+          },
+          "primaryTheme": {
+            "term": {
+              "name": "CITIC Securities Co Ltd",
+              "id": "ZWMzYzNkYTUtZTE2My00Yjk3LTliZWMtNzhjY2VlMzhkMGZl-T04=",
+              "attributes": [
+                {
+                  "value": "cn:600030",
+                  "key": "wsod_key"
+                },
+                {
+                  "value": "true",
+                  "key": "is_company"
+                }
+              ],
+              "taxonomy": "organisations"
+            }
+          },
+          "tags": [
+            {
+              "term": {
+                "name": "CITIC Securities Co Ltd",
+                "attributes": [
+                  {
+                    "value": "cn:600030",
+                    "key": "wsod_key"
+                  },
+                  {
+                    "value": "true",
+                    "key": "is_company"
+                  }
+                ],
+                "id": "ZWMzYzNkYTUtZTE2My00Yjk3LTliZWMtNzhjY2VlMzhkMGZl-T04=",
+                "taxonomy": "organisations"
+              }
+            },
+            {
+              "term": {
+                "name": "Financials",
+                "attributes": [
+                  {
+                    "value": "companies",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "financials",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "NTc=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Market Report",
+                "attributes": [],
+                "id": "Mg==-R2VucmVz",
+                "taxonomy": "genre"
+              }
+            },
+            {
+              "term": {
+                "name": "Text",
+                "attributes": [],
+                "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+                "taxonomy": "mediaType"
+              }
+            },
+            {
+              "term": {
+                "name": "Gabriel Wildau",
+                "attributes": [],
+                "id": "Q0ItMDUwNjY4NA==-QXV0aG9ycw==",
+                "taxonomy": "authors"
+              }
+            },
+            {
+              "term": {
+                "name": "8770 Financial Services",
+                "attributes": [],
+                "id": "MTY0-SUNC",
+                "taxonomy": "icb"
+              }
+            },
+            {
+              "term": {
+                "name": "04006000 - financial and business service",
+                "attributes": [],
+                "id": "MDQwMDYwMDA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04009000 - market and exchange",
+                "attributes": [],
+                "id": "MDQwMDkwMDA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04009003 - securities",
+                "attributes": [],
+                "id": "MDQwMDkwMDM=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04016022 - insider trading",
+                "attributes": [],
+                "id": "MDQwMTYwMjI=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "CITIC Group",
+                "attributes": [
+                  {
+                    "value": "true",
+                    "key": "is_company"
+                  }
+                ],
+                "id": "TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0NJVElD-T04=",
+                "taxonomy": "organisations"
+              }
+            },
+            {
+              "term": {
+                "name": "Beijing",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0FGVE1fR0xfMTEyOTc=-R0w=",
+                "taxonomy": "regions"
+              }
+            },
+            {
+              "term": {
+                "name": "Shanghai",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0FGVE1fR0xfNjg2MDc=-R0w=",
+                "taxonomy": "regions"
+              }
+            },
+            {
+              "term": {
+                "name": "China",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0NO-R0w=",
+                "taxonomy": "regions"
+              }
+            },
+            {
+              "term": {
+                "name": "Emerging Markets",
+                "attributes": [
+                  {
+                    "value": "markets",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "emerging.markets",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "MTA2-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Companies",
+                "attributes": [
+                  {
+                    "value": "companies",
+                    "key": "dfpSite"
+                  }
+                ],
+                "id": "Mjk=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Asia-Pacific Companies",
+                "attributes": [],
+                "id": "Njc=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Regulation & Governance",
+                "attributes": [],
+                "id": "ODA=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "China Business",
+                "attributes": [],
+                "id": "NjM3ZTU3MDUtMmY1ZS00ZGExLThkNjYtYWY4YWUzY2U1YWVm-VG9waWNz",
+                "taxonomy": "topics"
+              }
+            },
+            {
+              "term": {
+                "name": "China corruption",
+                "attributes": [],
+                "id": "ZDZjMDlhOTMtZWJlOS00ZDViLThlYjktMTE4NmM3NjZmNWMw-VG9waWNz",
+                "taxonomy": "topics"
+              }
+            }
+          ],
+          "authors": [
+            {
+              "term": {
+                "name": "Gabriel Wildau",
+                "attributes": [],
+                "id": "Q0ItMDUwNjY4NA==-QXV0aG9ycw==",
+                "taxonomy": "authors"
+              }
+            }
+          ],
+          "brand": [],
+          "genre": [
+            {
+              "term": {
+                "name": "Market Report",
+                "attributes": [],
+                "id": "Mg==-R2VucmVz",
+                "taxonomy": "genre"
+              }
+            }
+          ],
+          "icb": [
+            {
+              "term": {
+                "name": "8770 Financial Services",
+                "attributes": [],
+                "id": "MTY0-SUNC",
+                "taxonomy": "icb"
+              }
+            }
+          ],
+          "iptc": [
+            {
+              "term": {
+                "name": "04006000 - financial and business service",
+                "attributes": [],
+                "id": "MDQwMDYwMDA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04009000 - market and exchange",
+                "attributes": [],
+                "id": "MDQwMDkwMDA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04009003 - securities",
+                "attributes": [],
+                "id": "MDQwMDkwMDM=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04016022 - insider trading",
+                "attributes": [],
+                "id": "MDQwMTYwMjI=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            }
+          ],
+          "mediaType": [
+            {
+              "term": {
+                "name": "Text",
+                "attributes": [],
+                "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+                "taxonomy": "mediaType"
+              }
+            }
+          ],
+          "organisations": [
+            {
+              "term": {
+                "name": "CITIC Group",
+                "attributes": [
+                  {
+                    "value": "true",
+                    "key": "is_company"
+                  }
+                ],
+                "id": "TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0NJVElD-T04=",
+                "taxonomy": "organisations"
+              }
+            },
+            {
+              "term": {
+                "name": "CITIC Securities Co Ltd",
+                "attributes": [
+                  {
+                    "value": "cn:600030",
+                    "key": "wsod_key"
+                  },
+                  {
+                    "value": "true",
+                    "key": "is_company"
+                  }
+                ],
+                "id": "ZWMzYzNkYTUtZTE2My00Yjk3LTliZWMtNzhjY2VlMzhkMGZl-T04=",
+                "taxonomy": "organisations"
+              }
+            }
+          ],
+          "people": [],
+          "regions": [
+            {
+              "term": {
+                "name": "Beijing",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0FGVE1fR0xfMTEyOTc=-R0w=",
+                "taxonomy": "regions"
+              }
+            },
+            {
+              "term": {
+                "name": "Shanghai",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0FGVE1fR0xfNjg2MDc=-R0w=",
+                "taxonomy": "regions"
+              }
+            },
+            {
+              "term": {
+                "name": "China",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0NO-R0w=",
+                "taxonomy": "regions"
+              }
+            }
+          ],
+          "sections": [
+            {
+              "term": {
+                "name": "Emerging Markets",
+                "attributes": [
+                  {
+                    "value": "markets",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "emerging.markets",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "MTA2-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Companies",
+                "attributes": [
+                  {
+                    "value": "companies",
+                    "key": "dfpSite"
+                  }
+                ],
+                "id": "Mjk=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Financials",
+                "attributes": [
+                  {
+                    "value": "companies",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "financials",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "NTc=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Asia-Pacific Companies",
+                "attributes": [],
+                "id": "Njc=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Regulation & Governance",
+                "attributes": [],
+                "id": "ODA=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            }
+          ],
+          "specialReports": [],
+          "subjects": [],
+          "topics": [
+            {
+              "term": {
+                "name": "China Business",
+                "attributes": [],
+                "id": "NjM3ZTU3MDUtMmY1ZS00ZGExLThkNjYtYWY4YWUzY2U1YWVm-VG9waWNz",
+                "taxonomy": "topics"
+              }
+            },
+            {
+              "term": {
+                "name": "China corruption",
+                "attributes": [],
+                "id": "ZDZjMDlhOTMtZWJlOS00ZDViLThlYjktMTE4NmM3NjZmNWMw-VG9waWNz",
+                "taxonomy": "topics"
+              }
+            }
+          ]
+        },
+        "images": [
+          {
+            "alt": "An employee of Citic Securities Co. works in an office branch in Beijing, China, on Thursday, April 13, 2006. China's 167 percent stock rally this year has made Citic Securities Co., its largest brokerage with a market capitalization of $39.4 billion, bigger than all but three counterparts on Wall Street. Photographer: Danfung Dennis/Bloomberg News",
+            "width": 272,
+            "mediaType": "image/jpeg",
+            "source": "Bloomberg",
+            "type": "primary",
+            "url": "http://im.ft-static.com/content/images/2272651b-f5e4-4c29-92ce-162ee3a38418.img",
+            "height": 153
+          },
+          {
+            "alt": "An employee of Citic Securities Co. works in an office branch in Beijing, China, on Thursday, April 13, 2006. China's 167 percent stock rally this year has made Citic Securities Co., its largest brokerage with a market capitalization of $39.4 billion, bigger than all but three counterparts on Wall Street. Photographer: Danfung Dennis/Bloomberg News",
+            "width": 167,
+            "mediaType": "image/jpeg",
+            "source": "Bloomberg",
+            "type": "secondary",
+            "url": "http://im.ft-static.com/content/images/807dc374-b4fa-4654-b69e-0eab5f5d6c7b.img",
+            "height": 94
+          },
+          {
+            "alt": "An employee of Citic Securities Co. works in an office branch in Beijing, China, on Thursday, April 13, 2006. China's 167 percent stock rally this year has made Citic Securities Co., its largest brokerage with a market capitalization of $39.4 billion, bigger than all but three counterparts on Wall Street. Photographer: Danfung Dennis/Bloomberg News",
+            "width": 600,
+            "mediaType": "image/jpeg",
+            "source": "Bloomberg",
+            "type": "article",
+            "url": "http://im.ft-static.com/content/images/53459d82-02fe-44be-9989-538a52d79241.img",
+            "height": 338
+          },
+          {
+            "alt": "An employee of Citic Securities Co. works in an office branch in Beijing, China, on Thursday, April 13, 2006. China's 167 percent stock rally this year has made Citic Securities Co., its largest brokerage with a market capitalization of $39.4 billion, bigger than all but three counterparts on Wall Street. Photographer: Danfung Dennis/Bloomberg News",
+            "width": 414,
+            "mediaType": "image/jpeg",
+            "source": "Bloomberg",
+            "type": "leader",
+            "url": "http://im.ft-static.com/content/images/9ecb3a1c-7d2b-41c2-a0cb-489a82bfe8d0.img",
+            "height": 233
+          },
+          {
+            "alt": "An employee of Citic Securities Co. works in an office branch in Beijing, China, on Thursday, April 13, 2006. China's 167 percent stock rally this year has made Citic Securities Co., its largest brokerage with a market capitalization of $39.4 billion, bigger than all but three counterparts on Wall Street. Photographer: Danfung Dennis/Bloomberg News",
+            "width": 972,
+            "mediaType": "image/jpeg",
+            "source": "Bloomberg",
+            "type": "wide-format",
+            "url": "http://im.ft-static.com/content/images/84138b09-f1f1-4e30-bd2e-3b805d8e3f60.img",
+            "height": 547
+          }
+        ],
+        "package": [],
+        "assets": [],
+        "mediaAssets": []
+      },
+      "_lastUpdatedDateTime": "2015-09-16T03:06:53.737Z"
+    },
+    "sort": [
+      1442341273000
+    ]
+  }
+]

--- a/test/fixtures/readNext/topicArticles3.json
+++ b/test/fixtures/readNext/topicArticles3.json
@@ -1,0 +1,1077 @@
+[
+  {
+    "_index": "v1_api_v2",
+    "_type": "item",
+    "_id": "eaa2adf0-5bb4-11e5-9846-de406ccb37f2",
+    "_score": null,
+    "_source": {
+      "requestUrl": "http://api.ft.com/content/items/v1/eaa2adf0-5bb4-11e5-9846-de406ccb37f2?feature.blogposts=on&h=1258877739",
+      "item": {
+        "aspectSet": "article",
+        "aspects": [
+          "assets",
+          "body",
+          "editorial",
+          "images",
+          "lifecycle",
+          "location",
+          "master",
+          "mediaAssets",
+          "metadata",
+          "package",
+          "packaging",
+          "provenance",
+          "summary",
+          "title"
+        ],
+        "modelVersion": "1",
+        "id": "eaa2adf0-5bb4-11e5-9846-de406ccb37f2",
+        "apiUrl": "http://api.ft.com/content/items/v1/eaa2adf0-5bb4-11e5-9846-de406ccb37f2",
+        "title": {
+          "title": "Free Lunch: Lessons from Greece"
+        },
+        "body": {
+          "mediaType": "text/html",
+          "body": "<p><span class=\"ft-bold\">Still more to learn</span>\n</p>\n<p>Greece has mostly drifted off the international media radar in recent weeks – not just because of the bigger refugee crisis, but because it is hard to see why this Sunday’s election is going to make any difference. The mood, among Greeks as well as those who follow the country from outside, is one of resignation.</p>\n<p>Notwithstanding this, the process of learning the lessons of the Greek debt crisis is fortunately continuing apace, the latest instalment being a <a title=\"Fall 2015 Brookings Panel on Economic Activity - brookings.edu\" href=\"http://www.brookings.edu/about/projects/bpea/latest-conference\">series of papers</a> presented at last week’s Brookings Panel on Economic Activity conference.</p>\n<p>The most captivating of these papers is a <a title=\"The pitfalls of external independence: Greece, 1829-2015 - brookings.edu\" href=\"http://www.brookings.edu/about/projects/bpea/papers/2015/reinhart-trebesch-greek-debt-crisis\">historical study of Greece’s history</a> with external debt. There is nothing new about the country’s current debt travails, write Carmen Reinhart and Christoph Trebesch. It took on huge foreign loans in order to fund its war for independence and thus started its existence as a modern state with a large debt burden. Brutal episodes of external indebtedness followed by debilitating debt overhangs and default happened in the 1820s, 1880s, 1920s and again today.</p>\n<p><img alt=\"\" width=\"600\" src=\"http://im.ft-static.com/content/images/2d739d5c-5c68-11e5-a28b-50226830d644.png\"/>\n</p>\n<p>The fascinating study illustrates how <a title=\"Eurozone: The case against ‘cash for reform’ - FT.com\" href=\"http://www.ft.com/cms/s/0/9ef2a034-458b-11e5-af2f-4d6e0e5eda22.html\">the euro has taken too much blame for the current misery</a>: experience suggests Greece would easily have incurred excessive debt in the 2000s boom whether or not it was a member of the single currency. And the problems that followed echo those of past debt disasters and the responses to them:</p>\n<p>“Against this backdrop, the most recent round of Greek sovereign bailouts and the associated conditionality by the ‘Troika’ of IMF, ECB and European Commission look familiar as to the timing, the process and the associated political disputes. As debt migrated from private sector balance sheets to official sector balance sheets, Greece was pushed to give up parts of its sovereignty and to implement adjustment programmes to which it did not fully agree. The success of these interventions was often limited.”</p>\n<p>That limited success is the topic of some of the other papers. Yannis Ioannides and Christopher Pissarides ask “Is the Greek debt crisis one of supply or demand?” <a title=\"Is the Greek debt crisis one of supply or demand? - brookings.edu\" href=\"http://www.brookings.edu/about/projects/bpea/papers/2015/ioannides-pissarides-greek-debt-crisis\">Their answer is that it is both</a>, and that the policy programme often made things worse by missing the complexity of the economic challenge. They are particularly critical of pushing so hard on socially disruptive labour market liberalisation instead of prioritising product markets:</p>\n<p>“The Greek economy is subject to more frictions and is less open than other EZ economies in crisis, such as Ireland and Portugal. In such an economy prices do not fall and the decrease in aggregate demand that is brought about by wage decreases translates into a contraction of aggregate activity and unemployment . . . Wage reductions were reflected in greater increases in profit margins rather than reductions in prices [and] have contributed to the recession instead of reversing it. In such circumstances it makes much more sense to target first product market reforms . . . Labour markets reforms were given greater priority, mistakenly in our view.”</p>\n<p>Ioannides and Pissarides, additionally, point out that product market reforms carry better prospects for higher productivity growth in the long run, Greece’s deepest economic need. This echoes the IMF research we have written about earlier, which shows that <a title=\"The good, the bad, and the ugly in structural reform - Free Lunch - FT.com\" href=\"http://www.ft.com/cms/s/0/e9c6e16e-e349-11e4-9a82-00144feab7de.html\">not all structural reforms are created equal</a> — and indeed that the IMF’s own teams on the ground do not always press for the best ones.</p>\n<p><img alt=\"\" width=\"600\" src=\"http://im.ft-static.com/content/images/20bee9f2-4653-11e5-b3b2-1672f710807b.img\"/>\n</p>\n<p><span class=\"ft-bold\">Will she or won’t she?</span>\n</p>\n<p>The Federal Reserve’s interest-rate-setting committee meets today and will announce tomorrow whether it is indeed going to start lifting rates now. Arguments for or against a rise — mostly against — have been piling up and it may be a good time to quiet down and just wait to see what happens. But two recent contributions in the FT are well worth reading. One is from Larry Summers, who seems to have appointed himself dovish-commentators-in-chief. In a short note, he says that apart from the big substantial reasons why it would be wrong to lift the rate, <a title=\"Monetary policy should seek to avoid major surprises - blogs.ft.com\" href=\"http://blogs.ft.com/larry-summers/2015/09/15/75/\">there is also a tactical reason to wait</a>: by now markets only expect a rise with a 28 per cent probability, so even if the Fed wants to increase rates, it has not guided investors to expect this outcome. The last time it started a tightening cycle against expectations was 1994, and what followed has been called the “bond market massacre”.</p>\n<p>Also read Gavyn Davies’s <a title=\"Janet Yellen's fateful decision - blogs.ft.com\" href=\"http://blogs.ft.com/gavyndavies/2015/09/15/janet-yellens-fateful-decision/\">more strategic observations</a> on Fed chair Janet Yellen’s decision (for it largely comes down to her now). “From where I sit, it is hard to say that these key criteria [that Yellen has publicly announced] have been met today, unless they were already met in July, when the Fed decided not to raise rates,” he writes. It emerges that a key strategic mistake was for Yellen to have introduced “calendar-based” guidance when she said in July she expected a rate rise “later this year”. She may have been throwing a bone to the hawks on her committee. But it has not made Fed policy thinking any clearer.</p>\n<p><span class=\"ft-bold\">Numbers news</span>\n</p>\n<ul><li>The Economist reports on a study showing that annoying as they may have been, <a title=\"Why tube strikes help Londoners - economist.com\" href=\"http://www.economist.com/blogs/freeexchange/2015/09/economics-commuting\">London tube strikes helped commuters</a> find travel routes that were better than before. The average gain in time spent in transit: 20 seconds per one-way journey.</li>\n</ul>\n<p>To receive Martin Sandbu's <a title=\"Martin Sandbu's Free Lunch\" href=\"http://www.ft.com/martin-sandbu-free-lunch\">Free Lunch</a> by email every workday, <a title=\"nbe.ft.com\" href=\"http://nbe.ft.com/nbe/profile.cfm\">sign up here</a>.</p>"
+        },
+        "lifecycle": {
+          "initialPublishDateTime": "2015-09-16T11:58:53Z",
+          "lastPublishDateTime": "2015-09-16T11:58:53Z"
+        },
+        "location": {
+          "uri": "http://www.ft.com/cms/s/3/eaa2adf0-5bb4-11e5-9846-de406ccb37f2.html"
+        },
+        "summary": {
+          "excerpt": "A long and tragic history of external debt crises"
+        },
+        "packaging": {
+          "spHeadline": "Lessons from Greece"
+        },
+        "master": {
+          "masterSource": "Methode",
+          "masterEntityId": "eaa2adf0-5bb4-11e5-9846-de406ccb37f2"
+        },
+        "editorial": {
+          "otherTitles": [
+            "Lessons from Greece"
+          ],
+          "subheading": "A long and tragic history of external debt crises",
+          "standFirst": "A long and tragic history of external debt crises",
+          "byline": "Martin Sandbu"
+        },
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "metadata": {
+          "primarySection": {
+            "term": {
+              "name": "Columnists",
+              "id": "MTE3-U2VjdGlvbnM=",
+              "attributes": [
+                {
+                  "value": "opinion",
+                  "key": "dfpSite"
+                },
+                {
+                  "value": "columnists",
+                  "key": "dfpZone"
+                }
+              ],
+              "taxonomy": "sections"
+            }
+          },
+          "primaryTheme": {
+            "term": {
+              "name": "Euro in crisis",
+              "id": "OTZhMTRiZDItYjI2ZS00NGMzLTg1MjAtNjlkNzVmZjk2NTI1-VG9waWNz",
+              "attributes": [],
+              "taxonomy": "topics"
+            }
+          },
+          "tags": [
+            {
+              "term": {
+                "name": "Euro in crisis",
+                "attributes": [],
+                "id": "OTZhMTRiZDItYjI2ZS00NGMzLTg1MjAtNjlkNzVmZjk2NTI1-VG9waWNz",
+                "taxonomy": "topics"
+              }
+            },
+            {
+              "term": {
+                "name": "Columnists",
+                "attributes": [
+                  {
+                    "value": "opinion",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "columnists",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "MTE3-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Martin Sandbu's Free Lunch",
+                "attributes": [],
+                "id": "YmQ4Y2VlMjQtOGY0OS00NmZjLWE1NWItYjgxNzJiMjhlMTRh-QnJhbmRz",
+                "taxonomy": "brand"
+              }
+            },
+            {
+              "term": {
+                "name": "Comment",
+                "attributes": [],
+                "id": "OA==-R2VucmVz",
+                "taxonomy": "genre"
+              }
+            },
+            {
+              "term": {
+                "name": "Text",
+                "attributes": [],
+                "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+                "taxonomy": "mediaType"
+              }
+            },
+            {
+              "term": {
+                "name": "Martin Sandbu",
+                "attributes": [],
+                "id": "Q0ItMDAwMTAzOA==-QXV0aG9ycw==",
+                "taxonomy": "authors"
+              }
+            },
+            {
+              "term": {
+                "name": "04008010 - international economic institution",
+                "attributes": [],
+                "id": "MDQwMDgwMTA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04008017 - prices",
+                "attributes": [],
+                "id": "MDQwMDgwMTc=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "Greece",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0dS-R0w=",
+                "taxonomy": "regions"
+              }
+            },
+            {
+              "term": {
+                "name": "World",
+                "attributes": [
+                  {
+                    "value": "world",
+                    "key": "dfpSite"
+                  }
+                ],
+                "id": "MQ==-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "World Economy",
+                "attributes": [
+                  {
+                    "value": "world",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "world.economy",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "MTA3-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "EU Economy",
+                "attributes": [],
+                "id": "MTA4-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Opinion",
+                "attributes": [
+                  {
+                    "value": "opinion",
+                    "key": "dfpSite"
+                  }
+                ],
+                "id": "MTE2-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Euro",
+                "attributes": [],
+                "id": "M2NhYzFmYjctNDkwOS00YjJiLTk4MjQtY2UzNzM2NDdhY2Ri-VG9waWNz",
+                "taxonomy": "topics"
+              }
+            },
+            {
+              "term": {
+                "name": "Greece Debt Crisis",
+                "attributes": [],
+                "id": "ZmEzMmRmNDAtNDc0Zi00ODk3LWE2ZmQtZWFmYzJlZTRjZTVk-VG9waWNz",
+                "taxonomy": "topics"
+              }
+            }
+          ],
+          "authors": [
+            {
+              "term": {
+                "name": "Martin Sandbu",
+                "attributes": [],
+                "id": "Q0ItMDAwMTAzOA==-QXV0aG9ycw==",
+                "taxonomy": "authors"
+              }
+            }
+          ],
+          "brand": [
+            {
+              "term": {
+                "name": "Martin Sandbu's Free Lunch",
+                "attributes": [],
+                "id": "YmQ4Y2VlMjQtOGY0OS00NmZjLWE1NWItYjgxNzJiMjhlMTRh-QnJhbmRz",
+                "taxonomy": "brand"
+              }
+            }
+          ],
+          "genre": [
+            {
+              "term": {
+                "name": "Comment",
+                "attributes": [],
+                "id": "OA==-R2VucmVz",
+                "taxonomy": "genre"
+              }
+            }
+          ],
+          "icb": [],
+          "iptc": [
+            {
+              "term": {
+                "name": "04008010 - international economic institution",
+                "attributes": [],
+                "id": "MDQwMDgwMTA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04008017 - prices",
+                "attributes": [],
+                "id": "MDQwMDgwMTc=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            }
+          ],
+          "mediaType": [
+            {
+              "term": {
+                "name": "Text",
+                "attributes": [],
+                "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+                "taxonomy": "mediaType"
+              }
+            }
+          ],
+          "organisations": [],
+          "people": [],
+          "regions": [
+            {
+              "term": {
+                "name": "Greece",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0dS-R0w=",
+                "taxonomy": "regions"
+              }
+            }
+          ],
+          "sections": [
+            {
+              "term": {
+                "name": "World",
+                "attributes": [
+                  {
+                    "value": "world",
+                    "key": "dfpSite"
+                  }
+                ],
+                "id": "MQ==-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "World Economy",
+                "attributes": [
+                  {
+                    "value": "world",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "world.economy",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "MTA3-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "EU Economy",
+                "attributes": [],
+                "id": "MTA4-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Opinion",
+                "attributes": [
+                  {
+                    "value": "opinion",
+                    "key": "dfpSite"
+                  }
+                ],
+                "id": "MTE2-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Columnists",
+                "attributes": [
+                  {
+                    "value": "opinion",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "columnists",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "MTE3-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            }
+          ],
+          "specialReports": [],
+          "subjects": [],
+          "topics": [
+            {
+              "term": {
+                "name": "Euro",
+                "attributes": [],
+                "id": "M2NhYzFmYjctNDkwOS00YjJiLTk4MjQtY2UzNzM2NDdhY2Ri-VG9waWNz",
+                "taxonomy": "topics"
+              }
+            },
+            {
+              "term": {
+                "name": "Euro in crisis",
+                "attributes": [],
+                "id": "OTZhMTRiZDItYjI2ZS00NGMzLTg1MjAtNjlkNzVmZjk2NTI1-VG9waWNz",
+                "taxonomy": "topics"
+              }
+            },
+            {
+              "term": {
+                "name": "Greece Debt Crisis",
+                "attributes": [],
+                "id": "ZmEzMmRmNDAtNDc0Zi00ODk3LWE2ZmQtZWFmYzJlZTRjZTVk-VG9waWNz",
+                "taxonomy": "topics"
+              }
+            }
+          ]
+        },
+        "images": [
+          {
+            "width": 600,
+            "type": "inline-external",
+            "url": "http://im.ft-static.com/content/images/2d739d5c-5c68-11e5-a28b-50226830d644.png"
+          },
+          {
+            "width": 600,
+            "type": "inline-external",
+            "url": "http://im.ft-static.com/content/images/20bee9f2-4653-11e5-b3b2-1672f710807b.img"
+          }
+        ],
+        "package": [],
+        "assets": [],
+        "mediaAssets": []
+      },
+      "_lastUpdatedDateTime": "2015-09-16T12:00:54.476Z"
+    },
+    "sort": [
+      1442404733000
+    ]
+  },
+  {
+    "_index": "v1_api_v2",
+    "_type": "item",
+    "_id": "a54b8836-5b90-11e5-a28b-50226830d644",
+    "_score": null,
+    "_source": {
+      "requestUrl": "http://api.ft.com/content/items/v1/a54b8836-5b90-11e5-a28b-50226830d644?feature.blogposts=on&h=7043589200",
+      "item": {
+        "aspectSet": "article",
+        "aspects": [
+          "assets",
+          "body",
+          "editorial",
+          "images",
+          "lifecycle",
+          "location",
+          "master",
+          "mediaAssets",
+          "metadata",
+          "package",
+          "packaging",
+          "provenance",
+          "summary",
+          "title"
+        ],
+        "modelVersion": "1",
+        "id": "a54b8836-5b90-11e5-a28b-50226830d644",
+        "apiUrl": "http://api.ft.com/content/items/v1/a54b8836-5b90-11e5-a28b-50226830d644",
+        "title": {
+          "title": "Tsipras and Meimarakis go head-to-head in TV debate"
+        },
+        "body": {
+          "mediaType": "text/html",
+          "body": "<p>A final pre-election debate between the leaders of Greece’s biggest parties failed to break the deadlock between them, polls suggested, raising expectations that Sunday’s vote will yield a hung parliament or bipartisan coalition.</p>\n<p>Monday night’s debate featured sharp exchanges between former prime minister Alexis Tsipras, who last month triggered the snap election amid a rebellion in his leftwing Syriza party over a new EU bailout, and the centre-right New Democracy leader Evangelos Meimarakis.</p>\n<p>Mr Tsipras repeatedly put his conservative opponent on the defensive, attacking Mr Meimarakis’ party as responsible for “40 years of financial scandals while in power” that had benefited the country’s business and political elite.</p>\n<p>Mr Meimarakis countered the Syriza-led government had managed to <a title=\"Greece Debt Crisis - FT.com\" href=\"http://www.ft.com/indepth/greece-debt-crisis\">bankrupt Greece</a> in just seven months — to which a smiling Mr Tsipras hit back that this was like “someone who drank three bottles of whisky and a shot of vodka then claiming it was the vodka that had given him a hangover”. </p>\n\n\n\n\n<p>One pollster said on Tuesday the centre-right New Democracy party had picked up “between 0.2 and 0.5 per cent”, suggesting the two parties were still neck and neck.</p>\n<p>“You can see a trend that might be meaningful if it continues,” said the pollster who declined to be identified. “But this vote is still looking too close to call.”</p>\n<p>Syriza and New Democracy, with about 26 per cent of the vote each, according to forecasts, are well ahead of other rivals, but whomever wins will fall short of a parliamentary majority.</p>\n<p>The predictions come as a senior New Democracy official called on Mr Tsipras to form a cross-party alliance after the ballot, arguing that the scale of the challenges facing the next government was too large for one party or a coalition with a small majority to achieve. Chief among them will be implementing a tough reform package Athens committed to as part of an €86bn bailout agreed in July to stave of bankruptcy.</p>\n<aside data-asset-type=\"promoBox\" data-asset-name=\"asset1\"></aside><p>“The next government needs more than just enough seats. It needs the legitimacy from the vast majority of voters in order to have the security and certainty of three or four years that Greece needs to move forward,” said George Koumoutsakos, the party’s foreign policy head.</p>\n<p>“It makes sense for us to work together. You can only meet these challenges with national unity. We need to do whatever we can to put the country back on track,” Mr Koumoutsakos told the FT.</p>\n<p>Mr Tsipras has repeatedly rebuffed such offers, and in a televised debate on Monday evening told Mr Meimarakis that any deal between the two parties after the election would be “unnatural”. </p>\n\n\n\n<p>Thanos Veremis, a Greek historian and political commentator, said of the debate: “It was entertaining and interesting but it is unlikely to decide the election outcome. Meimarakis had a better grasp of arguments and policy details but Tsipras was able to put him on the defensive.”</p>\n<p>The final few days of campaigning will see both parties target a large proportion of undecided voters, while Mr Tsipras faces a battle to convince his party faithful that he can still be trusted, despite seemingly reneging on his promise to end austerity by signing up to the bailout and reform programme.</p>\n<p>Ilias, a stockbroker who followed the debate from a café in the upmarket Kolonaki neighbourhood, said: “You have to admire his [Tsipras’s] chutzpah even if his policies didn’t work.”<a title=\"Canadian miner and Greek minister clash over projects - FT.com\" href=\"http://www.ft.com/cms/s/0/d2ba2702-d853-11e4-ba53-00144feab7de.htmlaxzz3lhwmT7bi\"></a>\n</p>\n<p>One subject that figured into the debate was the investment by Eldorado Gold of Canada in a depressed region of northern Greece, which leftwingers oppose even though the country’s supreme court has ruled that environmental permits are in line with international standards. </p>\n\n<p>Mr Meimarakis made a point of bringing up the gold mining controversy in the debate, saying: “Syriza claims it wants investments to create jobs but you put thousands of jobs at risk just to score electoral points. You are driving away growth, not creating it”.</p>\n<p>An unruffled Mr Tsipras replied: “We only want investment that won’t damage the environment.”</p>\n"
+        },
+        "lifecycle": {
+          "initialPublishDateTime": "2015-09-15T11:49:43Z",
+          "lastPublishDateTime": "2015-09-15T11:49:43Z"
+        },
+        "location": {
+          "uri": "http://www.ft.com/cms/s/0/a54b8836-5b90-11e5-a28b-50226830d644.html"
+        },
+        "summary": {
+          "excerpt": "Greece’s former prime minister puts opponent on the defensive in battle ahead of September 20 vote"
+        },
+        "packaging": {
+          "spHeadline": "Tsipras takes on Meimarakis in TV debate"
+        },
+        "master": {
+          "masterSource": "Methode",
+          "masterEntityId": "a54b8836-5b90-11e5-a28b-50226830d644"
+        },
+        "editorial": {
+          "otherTitles": [
+            "Tsipras takes on Meimarakis in TV debate"
+          ],
+          "subheading": "Greece’s former PM puts opponent on the defensive",
+          "standFirst": "Greece’s former prime minister puts opponent on the defensive in battle ahead of September 20 vote",
+          "byline": "Kerin Hope and Henry Foy in Athens"
+        },
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "metadata": {
+          "primarySection": {
+            "term": {
+              "name": "Europe",
+              "id": "OQ==-U2VjdGlvbnM=",
+              "attributes": [
+                {
+                  "value": "world",
+                  "key": "dfpSite"
+                },
+                {
+                  "value": "europe",
+                  "key": "dfpZone"
+                }
+              ],
+              "taxonomy": "sections"
+            }
+          },
+          "primaryTheme": {
+            "term": {
+              "name": "Greece",
+              "id": "TnN0ZWluX0dMX0dS-R0w=",
+              "attributes": [],
+              "taxonomy": "regions"
+            }
+          },
+          "tags": [
+            {
+              "term": {
+                "name": "Greece",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0dS-R0w=",
+                "taxonomy": "regions"
+              }
+            },
+            {
+              "term": {
+                "name": "Europe",
+                "attributes": [
+                  {
+                    "value": "world",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "europe",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "OQ==-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "News",
+                "attributes": [],
+                "id": "Nw==-R2VucmVz",
+                "taxonomy": "genre"
+              }
+            },
+            {
+              "term": {
+                "name": "Text",
+                "attributes": [],
+                "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+                "taxonomy": "mediaType"
+              }
+            },
+            {
+              "term": {
+                "name": "Kerin Hope",
+                "attributes": [],
+                "id": "Q0ItMDAwMDYzNQ==-QXV0aG9ycw==",
+                "taxonomy": "authors"
+              }
+            },
+            {
+              "term": {
+                "name": "Henry Foy",
+                "attributes": [],
+                "id": "Q0ItMDMzNDMwOA==-QXV0aG9ycw==",
+                "taxonomy": "authors"
+              }
+            },
+            {
+              "term": {
+                "name": "1777 Gold Mining",
+                "attributes": [],
+                "id": "Mjk=-SUNC",
+                "taxonomy": "icb"
+              }
+            },
+            {
+              "term": {
+                "name": "04008025 - investments",
+                "attributes": [],
+                "id": "MDQwMDgwMjU=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "11003000 - election",
+                "attributes": [],
+                "id": "MTEwMDMwMDA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "11009002 - lower house",
+                "attributes": [],
+                "id": "MTEwMDkwMDI=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "11010000 - parties and movements",
+                "attributes": [],
+                "id": "MTEwMTAwMDA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "Syriza",
+                "attributes": [
+                  {
+                    "value": "false",
+                    "key": "is_company"
+                  }
+                ],
+                "id": "ZjczODAyMzItMzdiNy00N2NlLThjNWQtODNjNDAzNTdmNmQ2-T04=",
+                "taxonomy": "organisations"
+              }
+            },
+            {
+              "term": {
+                "name": "Evangelos Meimarakis",
+                "attributes": [],
+                "id": "NjAzNWFlNDQtNTAzMi00OGUzLThiOGEtMDFlODdlZDc1Mjli-UE4=",
+                "taxonomy": "people"
+              }
+            },
+            {
+              "term": {
+                "name": "Alexis Tsipras",
+                "attributes": [],
+                "id": "TnN0ZWluX1BOX1BvbGl0aWNpYW5zXzIwMDlfMTBfMl81NTEzNA==-UE4=",
+                "taxonomy": "people"
+              }
+            },
+            {
+              "term": {
+                "name": "Athens",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0FGVE1fR0xfZGVjLTIwMDdfMjI=-R0w=",
+                "taxonomy": "regions"
+              }
+            },
+            {
+              "term": {
+                "name": "World",
+                "attributes": [
+                  {
+                    "value": "world",
+                    "key": "dfpSite"
+                  }
+                ],
+                "id": "MQ==-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Mining",
+                "attributes": [],
+                "id": "MzE=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Politics",
+                "attributes": [],
+                "id": "MTAx-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            },
+            {
+              "term": {
+                "name": "Political Parties",
+                "attributes": [],
+                "id": "MTAy-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            },
+            {
+              "term": {
+                "name": "General News",
+                "attributes": [],
+                "id": "MTE4-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            },
+            {
+              "term": {
+                "name": "Environment",
+                "attributes": [],
+                "id": "MTMz-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            },
+            {
+              "term": {
+                "name": "Government News",
+                "attributes": [],
+                "id": "ODk=-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            },
+            {
+              "term": {
+                "name": "Elections",
+                "attributes": [],
+                "id": "OTA=-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            },
+            {
+              "term": {
+                "name": "European Union Government",
+                "attributes": [],
+                "id": "OTE=-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            },
+            {
+              "term": {
+                "name": "Greece Debt Crisis",
+                "attributes": [],
+                "id": "ZmEzMmRmNDAtNDc0Zi00ODk3LWE2ZmQtZWFmYzJlZTRjZTVk-VG9waWNz",
+                "taxonomy": "topics"
+              }
+            }
+          ],
+          "authors": [
+            {
+              "term": {
+                "name": "Kerin Hope",
+                "attributes": [],
+                "id": "Q0ItMDAwMDYzNQ==-QXV0aG9ycw==",
+                "taxonomy": "authors"
+              }
+            },
+            {
+              "term": {
+                "name": "Henry Foy",
+                "attributes": [],
+                "id": "Q0ItMDMzNDMwOA==-QXV0aG9ycw==",
+                "taxonomy": "authors"
+              }
+            }
+          ],
+          "brand": [],
+          "genre": [
+            {
+              "term": {
+                "name": "News",
+                "attributes": [],
+                "id": "Nw==-R2VucmVz",
+                "taxonomy": "genre"
+              }
+            }
+          ],
+          "icb": [
+            {
+              "term": {
+                "name": "1777 Gold Mining",
+                "attributes": [],
+                "id": "Mjk=-SUNC",
+                "taxonomy": "icb"
+              }
+            }
+          ],
+          "iptc": [
+            {
+              "term": {
+                "name": "04008025 - investments",
+                "attributes": [],
+                "id": "MDQwMDgwMjU=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "11003000 - election",
+                "attributes": [],
+                "id": "MTEwMDMwMDA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "11009002 - lower house",
+                "attributes": [],
+                "id": "MTEwMDkwMDI=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "11010000 - parties and movements",
+                "attributes": [],
+                "id": "MTEwMTAwMDA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            }
+          ],
+          "mediaType": [
+            {
+              "term": {
+                "name": "Text",
+                "attributes": [],
+                "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+                "taxonomy": "mediaType"
+              }
+            }
+          ],
+          "organisations": [
+            {
+              "term": {
+                "name": "Syriza",
+                "attributes": [
+                  {
+                    "value": "false",
+                    "key": "is_company"
+                  }
+                ],
+                "id": "ZjczODAyMzItMzdiNy00N2NlLThjNWQtODNjNDAzNTdmNmQ2-T04=",
+                "taxonomy": "organisations"
+              }
+            }
+          ],
+          "people": [
+            {
+              "term": {
+                "name": "Evangelos Meimarakis",
+                "attributes": [],
+                "id": "NjAzNWFlNDQtNTAzMi00OGUzLThiOGEtMDFlODdlZDc1Mjli-UE4=",
+                "taxonomy": "people"
+              }
+            },
+            {
+              "term": {
+                "name": "Alexis Tsipras",
+                "attributes": [],
+                "id": "TnN0ZWluX1BOX1BvbGl0aWNpYW5zXzIwMDlfMTBfMl81NTEzNA==-UE4=",
+                "taxonomy": "people"
+              }
+            }
+          ],
+          "regions": [
+            {
+              "term": {
+                "name": "Athens",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0FGVE1fR0xfZGVjLTIwMDdfMjI=-R0w=",
+                "taxonomy": "regions"
+              }
+            },
+            {
+              "term": {
+                "name": "Greece",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0dS-R0w=",
+                "taxonomy": "regions"
+              }
+            }
+          ],
+          "sections": [
+            {
+              "term": {
+                "name": "World",
+                "attributes": [
+                  {
+                    "value": "world",
+                    "key": "dfpSite"
+                  }
+                ],
+                "id": "MQ==-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Mining",
+                "attributes": [],
+                "id": "MzE=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Europe",
+                "attributes": [
+                  {
+                    "value": "world",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "europe",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "OQ==-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            }
+          ],
+          "specialReports": [],
+          "subjects": [
+            {
+              "term": {
+                "name": "Politics",
+                "attributes": [],
+                "id": "MTAx-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            },
+            {
+              "term": {
+                "name": "Political Parties",
+                "attributes": [],
+                "id": "MTAy-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            },
+            {
+              "term": {
+                "name": "General News",
+                "attributes": [],
+                "id": "MTE4-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            },
+            {
+              "term": {
+                "name": "Environment",
+                "attributes": [],
+                "id": "MTMz-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            },
+            {
+              "term": {
+                "name": "Government News",
+                "attributes": [],
+                "id": "ODk=-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            },
+            {
+              "term": {
+                "name": "Elections",
+                "attributes": [],
+                "id": "OTA=-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            },
+            {
+              "term": {
+                "name": "European Union Government",
+                "attributes": [],
+                "id": "OTE=-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            }
+          ],
+          "topics": [
+            {
+              "term": {
+                "name": "Greece Debt Crisis",
+                "attributes": [],
+                "id": "ZmEzMmRmNDAtNDc0Zi00ODk3LWE2ZmQtZWFmYzJlZTRjZTVk-VG9waWNz",
+                "taxonomy": "topics"
+              }
+            }
+          ]
+        },
+        "images": [
+          {
+            "alt": "epa04930516 Former Greek Prime Minister and President of radical left party 'SYRIZA' Alexis Tsipras (L) stands next to the leader of the main Greek conservative opposition 'New Democracy' party, Evangelos Meimarakis (R), prior to a pre-election debate of political leaders at the studios of Greek state TV in Athens, Greece, 14 September 2015. Elections will be held on 20 September 2015. EPA/YANNIS KOLESIDIS",
+            "width": 272,
+            "caption": "Former Greek prime minister Alexis Tsipras and New Democracy's Evangelos Meimarakis ahead of the televised debate",
+            "mediaType": "image/jpeg",
+            "source": "EPA",
+            "type": "primary",
+            "url": "http://im.ft-static.com/content/images/7f6f4ae9-f56a-4b77-af26-3f3a102a07a3.img",
+            "height": 153
+          },
+          {
+            "alt": "epa04930516 Former Greek Prime Minister and President of radical left party 'SYRIZA' Alexis Tsipras (L) stands next to the leader of the main Greek conservative opposition 'New Democracy' party, Evangelos Meimarakis (R), prior to a pre-election debate of political leaders at the studios of Greek state TV in Athens, Greece, 14 September 2015. Elections will be held on 20 September 2015. EPA/YANNIS KOLESIDIS",
+            "width": 167,
+            "caption": "Former Greek prime minister Alexis Tsipras and New Democracy's Evangelos Meimarakis ahead of the televised debate",
+            "mediaType": "image/jpeg",
+            "source": "EPA",
+            "type": "secondary",
+            "url": "http://im.ft-static.com/content/images/c27e7f80-2067-476e-8c17-6701b156ce50.img",
+            "height": 94
+          },
+          {
+            "alt": "epa04930516 Former Greek Prime Minister and President of radical left party 'SYRIZA' Alexis Tsipras (L) stands next to the leader of the main Greek conservative opposition 'New Democracy' party, Evangelos Meimarakis (R), prior to a pre-election debate of political leaders at the studios of Greek state TV in Athens, Greece, 14 September 2015. Elections will be held on 20 September 2015. EPA/YANNIS KOLESIDIS",
+            "width": 600,
+            "caption": "Former Greek prime minister Alexis Tsipras and New Democracy's Evangelos Meimarakis ahead of the televised debate",
+            "mediaType": "image/jpeg",
+            "source": "EPA",
+            "type": "article",
+            "url": "http://im.ft-static.com/content/images/b53779d2-2f77-477d-b416-a208558bcd44.img",
+            "height": 338
+          },
+          {
+            "alt": "epa04930516 Former Greek Prime Minister and President of radical left party 'SYRIZA' Alexis Tsipras (L) stands next to the leader of the main Greek conservative opposition 'New Democracy' party, Evangelos Meimarakis (R), prior to a pre-election debate of political leaders at the studios of Greek state TV in Athens, Greece, 14 September 2015. Elections will be held on 20 September 2015. EPA/YANNIS KOLESIDIS",
+            "width": 414,
+            "caption": "Former Greek prime minister Alexis Tsipras and New Democracy's Evangelos Meimarakis ahead of the televised debate",
+            "mediaType": "image/jpeg",
+            "source": "EPA",
+            "type": "leader",
+            "url": "http://im.ft-static.com/content/images/429a2cdc-7330-41ef-9202-848c86eab711.img",
+            "height": 233
+          },
+          {
+            "alt": "epa04930516 Former Greek Prime Minister and President of radical left party 'SYRIZA' Alexis Tsipras (L) stands next to the leader of the main Greek conservative opposition 'New Democracy' party, Evangelos Meimarakis (R), prior to a pre-election debate of political leaders at the studios of Greek state TV in Athens, Greece, 14 September 2015. Elections will be held on 20 September 2015. EPA/YANNIS KOLESIDIS",
+            "width": 972,
+            "caption": "Former Greek prime minister Alexis Tsipras and New Democracy's Evangelos Meimarakis ahead of the televised debate",
+            "mediaType": "image/jpeg",
+            "source": "EPA",
+            "type": "wide-format",
+            "url": "http://im.ft-static.com/content/images/e5047c16-2adf-436f-a7ed-9b5b12f922d0.img",
+            "height": 547
+          },
+          {
+            "alt": "Greece debt crisis",
+            "width": 167,
+            "mediaType": "image/jpeg",
+            "type": "promo",
+            "url": "http://im.ft-static.com/content/images/e1ce46ac-ac83-11e4-9aaa-00144feab7de.img",
+            "height": 96
+          }
+        ],
+        "package": [],
+        "assets": [
+          {
+            "name": "asset1",
+            "type": "promoBox",
+            "fields": {
+              "images": [
+                {
+                  "alt": "Greece debt crisis",
+                  "width": 167,
+                  "mediaType": "image/jpeg",
+                  "type": "promo",
+                  "url": "http://im.ft-static.com/content/images/e1ce46ac-ac83-11e4-9aaa-00144feab7de.img",
+                  "height": 96
+                }
+              ],
+              "intro": "<p>Athens has caved in to an ultimatum from its creditors and agreed to rush through long-resisted economic reforms in return for a third bailout</p>\n<p><a title=\"www.ft.com\" href=\"http://www.ft.com/indepth/greece-debt-crisis\">Further reading</a>\n</p>",
+              "title": "<p>In depth</p>",
+              "headline": "<p><a title=\"Greece debt crisis in depth - FT.com\" href=\"http://www.ft.com/indepth/greece-debt-crisis\">Greece debt crisis</a>\n</p>"
+            }
+          }
+        ],
+        "mediaAssets": []
+      },
+      "_lastUpdatedDateTime": "2015-09-15T16:54:38.647Z"
+    },
+    "sort": [
+      1442317783000
+    ]
+  }
+]

--- a/test/fixtures/readNext/topicArticles4.json
+++ b/test/fixtures/readNext/topicArticles4.json
@@ -1,0 +1,1003 @@
+[
+  {
+    "_index": "v1_api_v2",
+    "_type": "item",
+    "_id": "921d8c8e-5c47-11e5-a28b-50226830d644",
+    "_score": null,
+    "_source": {
+      "requestUrl": "http://api.ft.com/content/items/v1/921d8c8e-5c47-11e5-a28b-50226830d644?feature.blogposts=on&h=2568569686",
+      "item": {
+        "aspectSet": "article",
+        "aspects": [
+          "assets",
+          "body",
+          "editorial",
+          "images",
+          "lifecycle",
+          "location",
+          "master",
+          "mediaAssets",
+          "metadata",
+          "package",
+          "packaging",
+          "provenance",
+          "summary",
+          "title"
+        ],
+        "modelVersion": "1",
+        "id": "921d8c8e-5c47-11e5-a28b-50226830d644",
+        "apiUrl": "http://api.ft.com/content/items/v1/921d8c8e-5c47-11e5-a28b-50226830d644",
+        "title": {
+          "title": "China eases limits on overseas debt"
+        },
+        "body": {
+          "mediaType": "text/html",
+          "body": "<p>Beijing has eased restrictions on Chinese companies seeking to raise funds overseas, after a record monthly decline in China’s foreign exchange reserves in August. </p>\n<p>The decision to loosen capital controls on inbound funds stands to boost capital inflows at a time when big domestic stock market losses and the slowing Chinese economy are heightening concerns about <a title=\"Capital outflows reignite debate between China bulls and bears - FT.com\" href=\"http://www.ft.com/intl/cms/s/0/5c615290-3737-11e5-b05b-b01debd57852.html\">capital outflows</a>. </p>\n<p>China’s top planning agency, the National Development and Reform Commission, has made it easier for Chinese companies to obtain foreign currency bank loans or issue renminbi bonds with a term of more than one year, according to a statement on its website dated Tuesday.</p>\n<p>“The new policy will simplify the process for Chinese entities to issue offshore bonds. It will give Chinese companies flexibility in terms of timing and the amount of bonds issued as long as it is within the approved foreign debt quota,” said Ivan Chung, head of greater China credit research at Moody’s in Hong Kong. </p>\n<p>Previously, companies needed approval on a deal-by-deal basis but now they are only required to register with the regulator. “Like Shanghai-HK Stock Connect, it is another step forward in integrating the Chinese financial market with the world,” Mr Chung said. </p>\n\n<p>China’s foreign exchange reserves fell 2.6 per cent to $3.557tn in August, a monthly <a title=\"China’s foreign exchange reserves fall by record $94bn - FT.com\" href=\"http://www.ft.com/intl/cms/s/0/2d3eb83e-554d-11e5-8642-453585f2cfcd.html#axzz3lsE9hDZv\">$94bn</a> drop that was the sharpest on record, as the People’s Bank of China sold down some of its stockpile to support the renminbi. </p>\n<p>​Data from the Bank of International Settlements show that foreign bank claims on China shrank by $77bn in the first three months of 2015, reflecting their reluctance to lend and Chinese borrowers’ increasing wariness of taking on foreign currency debt. </p>\n<p>“On one level it’s encouraging to see that China has not lost its appetite for pro-market liberalisation, even as volatility and uncertainty have risen. It suggests the leadership understands that problems revealed by market forces can be addressed by market forces as well,” says Michael Kurtz, chief Asia equity strategist at Nomura in Hong Kong.</p>\n<p>However, he said it was not clear that Chinese firms would immediately embrace the more open overseas borrowing environment, “given expectations for both a depreciating renminbi and for rising US dollar borrowing costs vs falling domestic borrowing costs”. Markets are awaiting a decision from the US Federal Reserve on Thursday on whether to raise interest rates for the first time in nearly a decade. </p>\n<p>The NDRC also said it would encourage companies with good credit quality and strong debt repayment ability to raise money overseas for high-priority construction and investment projects such as the “One Belt, One Road” campaign to develop ties along the old Silk Road trading route. </p>\n<p>Meanwhile, China is considering implementing restrictions on automated trading in its commodity markets, according to market participants who spoke to the FT.</p>\n<p>The new regulations would define automated traders, require their identity and source of funds to be disclosed and limit the number of trades they could place in the futures markets. </p>\n<p>“A few years ago the exchanges began researching this type of unified management because programme trading is different from other trading behaviour and can cause shocks,” said one exchange official who did not want to be named. “After the August 16 crash, this discussion has sprung up again.”</p>\n<p><span class=\"ft-italic\">Additional reporting by Jackie Cai and Lucy Hornby</span>\n</p>"
+        },
+        "lifecycle": {
+          "initialPublishDateTime": "2015-08-16T09:07:26Z",
+          "lastPublishDateTime": "2015-08-16T09:07:26Z"
+        },
+        "location": {
+          "uri": "http://www.ft.com/cms/s/0/921d8c8e-5c47-11e5-a28b-50226830d644.html"
+        },
+        "summary": {
+          "excerpt": "Loosening of controls on inbound funds comes amid rising concerns over capital outflows"
+        },
+        "packaging": {
+          "spHeadline": "China eases limits on overseas debt"
+        },
+        "master": {
+          "masterSource": "Methode",
+          "masterEntityId": "921d8c8e-5c47-11e5-a28b-50226830d644"
+        },
+        "editorial": {
+          "subheading": "Inbound fund controls loosened amid fears over capital outflows",
+          "standFirst": "Loosening of controls on inbound funds comes amid rising concerns over capital outflows",
+          "byline": "Patti Waldmeir in Shanghai"
+        },
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "metadata": {
+          "primarySection": {
+            "term": {
+              "name": "Chinese Economy",
+              "id": "MTEx-U2VjdGlvbnM=",
+              "attributes": [],
+              "taxonomy": "sections"
+            }
+          },
+          "primaryTheme": {
+            "term": {
+              "name": "China Economic Slowdown",
+              "id": "NWIwYzgxZTgtZjc3MC00ODNkLWI1YjYtYTVhNGQ2OTNjYjVi-VG9waWNz",
+              "attributes": [],
+              "taxonomy": "topics"
+            }
+          },
+          "tags": [
+            {
+              "term": {
+                "name": "China Economic Slowdown",
+                "attributes": [],
+                "id": "NWIwYzgxZTgtZjc3MC00ODNkLWI1YjYtYTVhNGQ2OTNjYjVi-VG9waWNz",
+                "taxonomy": "topics"
+              }
+            },
+            {
+              "term": {
+                "name": "Chinese Economy",
+                "attributes": [],
+                "id": "MTEx-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "News",
+                "attributes": [],
+                "id": "Nw==-R2VucmVz",
+                "taxonomy": "genre"
+              }
+            },
+            {
+              "term": {
+                "name": "Text",
+                "attributes": [],
+                "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+                "taxonomy": "mediaType"
+              }
+            },
+            {
+              "term": {
+                "name": "Patti Waldmeir",
+                "attributes": [],
+                "id": "Q0ItMDAwMDg4Ng==-QXV0aG9ycw==",
+                "taxonomy": "authors"
+              }
+            },
+            {
+              "term": {
+                "name": "8355 Banks",
+                "attributes": [],
+                "id": "MTQy-SUNC",
+                "taxonomy": "icb"
+              }
+            },
+            {
+              "term": {
+                "name": "04006000 - financial and business service",
+                "attributes": [],
+                "id": "MDQwMDYwMDA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04006002 - banking",
+                "attributes": [],
+                "id": "MDQwMDYwMDI=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04008020 - credit and debt",
+                "attributes": [],
+                "id": "MDQwMDgwMjA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04008023 - financial markets",
+                "attributes": [],
+                "id": "MDQwMDgwMjM=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04008026 - stocks",
+                "attributes": [],
+                "id": "MDQwMDgwMjY=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04009000 - market and exchange",
+                "attributes": [],
+                "id": "MDQwMDkwMDA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "11013000 - state budget and tax",
+                "attributes": [],
+                "id": "MTEwMTMwMDA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "Beijing",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0FGVE1fR0xfMTEyOTc=-R0w=",
+                "taxonomy": "regions"
+              }
+            },
+            {
+              "term": {
+                "name": "Hong Kong",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0FGVE1fR0xfNTc0NjY=-R0w=",
+                "taxonomy": "regions"
+              }
+            },
+            {
+              "term": {
+                "name": "China",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0NO-R0w=",
+                "taxonomy": "regions"
+              }
+            },
+            {
+              "term": {
+                "name": "World Economy",
+                "attributes": [
+                  {
+                    "value": "world",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "world.economy",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "MTA3-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Currencies",
+                "attributes": [
+                  {
+                    "value": "markets",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "currencies",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "MTAz-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Markets",
+                "attributes": [
+                  {
+                    "value": "markets",
+                    "key": "dfpSite"
+                  }
+                ],
+                "id": "NzE=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Corporate Finance",
+                "attributes": [],
+                "id": "Ng==-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            },
+            {
+              "term": {
+                "name": "Economic Indicators",
+                "attributes": [],
+                "id": "NjU=-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            },
+            {
+              "term": {
+                "name": "China Business",
+                "attributes": [],
+                "id": "NjM3ZTU3MDUtMmY1ZS00ZGExLThkNjYtYWY4YWUzY2U1YWVm-VG9waWNz",
+                "taxonomy": "topics"
+              }
+            }
+          ],
+          "authors": [
+            {
+              "term": {
+                "name": "Patti Waldmeir",
+                "attributes": [],
+                "id": "Q0ItMDAwMDg4Ng==-QXV0aG9ycw==",
+                "taxonomy": "authors"
+              }
+            }
+          ],
+          "brand": [],
+          "genre": [
+            {
+              "term": {
+                "name": "News",
+                "attributes": [],
+                "id": "Nw==-R2VucmVz",
+                "taxonomy": "genre"
+              }
+            }
+          ],
+          "icb": [
+            {
+              "term": {
+                "name": "8355 Banks",
+                "attributes": [],
+                "id": "MTQy-SUNC",
+                "taxonomy": "icb"
+              }
+            }
+          ],
+          "iptc": [
+            {
+              "term": {
+                "name": "04006000 - financial and business service",
+                "attributes": [],
+                "id": "MDQwMDYwMDA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04006002 - banking",
+                "attributes": [],
+                "id": "MDQwMDYwMDI=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04008020 - credit and debt",
+                "attributes": [],
+                "id": "MDQwMDgwMjA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04008023 - financial markets",
+                "attributes": [],
+                "id": "MDQwMDgwMjM=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04008026 - stocks",
+                "attributes": [],
+                "id": "MDQwMDgwMjY=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "04009000 - market and exchange",
+                "attributes": [],
+                "id": "MDQwMDkwMDA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            },
+            {
+              "term": {
+                "name": "11013000 - state budget and tax",
+                "attributes": [],
+                "id": "MTEwMTMwMDA=-SVBUQw==",
+                "taxonomy": "iptc"
+              }
+            }
+          ],
+          "mediaType": [
+            {
+              "term": {
+                "name": "Text",
+                "attributes": [],
+                "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+                "taxonomy": "mediaType"
+              }
+            }
+          ],
+          "organisations": [],
+          "people": [],
+          "regions": [
+            {
+              "term": {
+                "name": "Beijing",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0FGVE1fR0xfMTEyOTc=-R0w=",
+                "taxonomy": "regions"
+              }
+            },
+            {
+              "term": {
+                "name": "Hong Kong",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0FGVE1fR0xfNTc0NjY=-R0w=",
+                "taxonomy": "regions"
+              }
+            },
+            {
+              "term": {
+                "name": "China",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0NO-R0w=",
+                "taxonomy": "regions"
+              }
+            }
+          ],
+          "sections": [
+            {
+              "term": {
+                "name": "World Economy",
+                "attributes": [
+                  {
+                    "value": "world",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "world.economy",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "MTA3-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Currencies",
+                "attributes": [
+                  {
+                    "value": "markets",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "currencies",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "MTAz-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Chinese Economy",
+                "attributes": [],
+                "id": "MTEx-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Markets",
+                "attributes": [
+                  {
+                    "value": "markets",
+                    "key": "dfpSite"
+                  }
+                ],
+                "id": "NzE=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            }
+          ],
+          "specialReports": [],
+          "subjects": [
+            {
+              "term": {
+                "name": "Corporate Finance",
+                "attributes": [],
+                "id": "Ng==-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            },
+            {
+              "term": {
+                "name": "Economic Indicators",
+                "attributes": [],
+                "id": "NjU=-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            }
+          ],
+          "topics": [
+            {
+              "term": {
+                "name": "China Economic Slowdown",
+                "attributes": [],
+                "id": "NWIwYzgxZTgtZjc3MC00ODNkLWI1YjYtYTVhNGQ2OTNjYjVi-VG9waWNz",
+                "taxonomy": "topics"
+              }
+            },
+            {
+              "term": {
+                "name": "China Business",
+                "attributes": [],
+                "id": "NjM3ZTU3MDUtMmY1ZS00ZGExLThkNjYtYWY4YWUzY2U1YWVm-VG9waWNz",
+                "taxonomy": "topics"
+              }
+            }
+          ]
+        },
+        "images": [
+          {
+            "width": 272,
+            "mediaType": "image/jpeg",
+            "source": "AFP",
+            "type": "primary",
+            "url": "http://im.ft-static.com/content/images/9ec9fe0e-146c-4930-92c7-53949e4e00b7.img",
+            "height": 153
+          },
+          {
+            "width": 167,
+            "mediaType": "image/jpeg",
+            "source": "AFP",
+            "type": "secondary",
+            "url": "http://im.ft-static.com/content/images/3f32e634-042b-49f1-b4c1-7562f3ec667a.img",
+            "height": 94
+          },
+          {
+            "width": 600,
+            "mediaType": "image/jpeg",
+            "source": "AFP",
+            "type": "article",
+            "url": "http://im.ft-static.com/content/images/b29ba0c9-c059-49ad-a3ea-afc9ce552f5e.img",
+            "height": 338
+          },
+          {
+            "width": 414,
+            "mediaType": "image/jpeg",
+            "source": "AFP",
+            "type": "leader",
+            "url": "http://im.ft-static.com/content/images/37dabf00-bb83-4a0d-a5cf-7b8aad6226bc.img",
+            "height": 233
+          },
+          {
+            "width": 972,
+            "mediaType": "image/jpeg",
+            "source": "AFP",
+            "type": "wide-format",
+            "url": "http://im.ft-static.com/content/images/0521f258-e325-4d8e-8cac-29e67523f43d.img",
+            "height": 547
+          }
+        ],
+        "package": [],
+        "assets": [],
+        "mediaAssets": []
+      },
+      "_lastUpdatedDateTime": "2015-09-16T11:49:54.509Z"
+    },
+    "sort": [
+      1442394446000
+    ]
+  },
+  {
+    "_index": "v1_api_v2",
+    "_type": "item",
+    "_id": "d77bba14-5899-11e5-a28b-50226830d644",
+    "_score": null,
+    "_source": {
+      "requestUrl": "http://api.ft.com/content/items/v1/d77bba14-5899-11e5-a28b-50226830d644?feature.blogposts=on&h=4568213955",
+      "item": {
+        "aspectSet": "article",
+        "aspects": [
+          "assets",
+          "body",
+          "editorial",
+          "images",
+          "lifecycle",
+          "location",
+          "master",
+          "mediaAssets",
+          "metadata",
+          "package",
+          "packaging",
+          "provenance",
+          "summary",
+          "title"
+        ],
+        "modelVersion": "1",
+        "id": "d77bba14-5899-11e5-a28b-50226830d644",
+        "apiUrl": "http://api.ft.com/content/items/v1/d77bba14-5899-11e5-a28b-50226830d644",
+        "title": {
+          "title": "Craft beers and palate patriotism"
+        },
+        "body": {
+          "mediaType": "text/html",
+          "body": "<p>Chinese nationalism comes in many flavours. There’s the tanks-in-the-street, I-hate-the-Japanese variety that was on display earlier this month when Beijing closed many of its streets and factories to parade killing machines through <a title=\"China cuts troops but parades its military might - ft.com\" href=\"http://www.ft.com/intl/cms/s/0/d4dda3a6-51de-11e5-8642-453585f2cfcd.html#slide0\">Tiananmen Square</a>. </p>\n<aside data-asset-type=\"promoBox\" data-asset-name=\"asset1\"></aside><p>But there is also the altogether more palatable Sichuan-peppercorn-beer kind of nationalism, which involves brewing beer from local ingredients, for local palates, and seasoning it with a bit of Chinese philosophy, a dash of middle kingdom history — everything short of an actual Chinese flag. It sure beats that watered down, German-inspired brew that they sell for almost nothing, down at my local convenience store.</p>\n<p>These days, there’s more and more “palate patriotism” around in the country — foods, drinks, even coffees made by Chinese people, with Chinese ingredients for Chinese taste buds. I’m betting on that second kind of nationalism to power the mainland through to a “new normal” of growth based on something other than just copycatting what everyone else already does better.</p>\n<p>And yes, I have noticed that the rest of the world is worried that the country’s economy is imploding. But the middle class doesn’t seem to have got that memo. So they’re still happy to spend 10, 20 or even 40 times as much on a craft beer with Chinese characteristics as on a bottle of Snow or Tsingtao. And it’s not just so they can drown their economic sorrows either: they still feel pretty flush. Sales of iPhones are booming — rising 75 per cent on the mainland year on year, Apple’s <a title=\"Apple TV and iPad revamp with new iPhone 6S - ft.com\" href=\"http://www.ft.com/intl/cms/s/0/33012b18-5713-11e5-9846-de406ccb37f2.html#slide0\">Tim Cook said last week</a>. </p>\n<p>“Demand is slowing, but there’s an underlying shift from mainstream to more specialised and niche consumption,” says Torsten Stocker, greater China retail partner at AT Kearney.</p>\n<p>Case in point: traditional beers had a bad year in 2014, with domestic production falling for the first time in two decades. This was partly due to competition from wine and other drinks, and partly due to the slowdown. But craft brewers can sell as much as they can make in China — which admittedly is not a huge amount yet, since the government treats craft breweries as basically illegal.</p>\n<p>Most of the beer that is drunk in China today was not originally Chinese. Even Tsingtao, which the west thinks of as that most Chinese of beers, was set up by Germans in Qingdao, which was then a German colony: think alcoholic imperialism. Wikipedia says that China has been drinking beer, in one form or another, for 9,000 years — and since nobody really knows what the Chinese were doing 9,000 years ago, Wikipedia is as likely to be right about that as anyone else.</p>\n<p>Fermentation was — and still is — used in many primitive societies to help purify water. My first Financial Times job, back in 1980, involved drinking home-brewed sorghum beer in northern Ghana, which at the time had no reliable source of clean water. It was drunk all day long, like coffee or Diet Coke in other cultures — except that it got stronger as the day progressed. The same was once true in China. But what’s drunk here today, in the main, is not at all indigenous.</p>\n<aside data-asset-type=\"pullQuote\" data-asset-name=\"asset2\"></aside><p>But now that’s changing. The country has a new generation of indigenous brewmasters (or foreigners who are well integrated into the society), and most of their customers are Chinese. Gao Yan — who prefers to be known as Master Gao, because of his US masters degree in chemistry — brews craft beers infused with the know-how of traditional Chinese medicine, in the second-tier Chinese city of Nanjing.</p>\n<p>He says his best-seller is jasmine tea lager, but his sweet potato beer — his first made from Chinese-inspired ingredients — did darned well too. He has brewed with purple rice, chilli peppers and sweet osmanthus flowers, while rival brewers use Sichuan peppercorns and Iron Buddha tea. Master Gao, whose first brewery was shut down by the government, says that most of his ingredients are western, “but the way we brew it, we build beer according to Chinese culture and customs”. </p>\n<p>And he’s happy to admit that that patriotic backstory has helped him sell four times as much beer this year as last. Sure beats missiles.</p>\n\n<p><span class=\"ft-italic\"><a title=\"Email the writer\" href=\"mailto:patti.waldmeir@ft.com\">patti.waldmeir@ft.com</a>\n</span>\n</p>"
+        },
+        "lifecycle": {
+          "initialPublishDateTime": "2015-08-14T12:27:09Z",
+          "lastPublishDateTime": "2015-08-14T12:27:09Z"
+        },
+        "location": {
+          "uri": "http://www.ft.com/cms/s/0/d77bba14-5899-11e5-a28b-50226830d644.html"
+        },
+        "summary": {
+          "excerpt": "Brews from local ingredients, infused with Chinese philosophy, are quenching a thirst"
+        },
+        "packaging": {
+          "spHeadline": "China’s new palate patriotism"
+        },
+        "master": {
+          "masterSource": "Methode",
+          "masterEntityId": "d77bba14-5899-11e5-a28b-50226830d644"
+        },
+        "editorial": {
+          "subheading": "Brews from local ingredients, infused with Chinese philosophy, are quenching a thirst",
+          "standFirst": "Brews from local ingredients, infused with Chinese philosophy, are quenching a thirst",
+          "byline": "Patti Waldmeir – Shanghai"
+        },
+        "provenance": {
+          "originatingParty": "FT"
+        },
+        "metadata": {
+          "primarySection": {
+            "term": {
+              "name": "Columnists",
+              "id": "MTE3-U2VjdGlvbnM=",
+              "attributes": [
+                {
+                  "value": "opinion",
+                  "key": "dfpSite"
+                },
+                {
+                  "value": "columnists",
+                  "key": "dfpZone"
+                }
+              ],
+              "taxonomy": "sections"
+            }
+          },
+          "primaryTheme": {
+            "term": {
+              "name": "Patti Waldmeir",
+              "id": "Q0ItMDAwMDg4Ng==-QXV0aG9ycw==",
+              "attributes": [],
+              "taxonomy": "authors"
+            }
+          },
+          "tags": [
+            {
+              "term": {
+                "name": "Patti Waldmeir",
+                "attributes": [],
+                "id": "Q0ItMDAwMDg4Ng==-QXV0aG9ycw==",
+                "taxonomy": "authors"
+              }
+            },
+            {
+              "term": {
+                "name": "Columnists",
+                "attributes": [
+                  {
+                    "value": "opinion",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "columnists",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "MTE3-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "China Society",
+                "attributes": [],
+                "id": "MmFlY2ExNzQtYmM4Ni00ZjRkLWI4NmItNjgxOTBhMDNkMjY5-VG9waWNz",
+                "taxonomy": "topics"
+              }
+            },
+            {
+              "term": {
+                "name": "Comment",
+                "attributes": [],
+                "id": "OA==-R2VucmVz",
+                "taxonomy": "genre"
+              }
+            },
+            {
+              "term": {
+                "name": "Text",
+                "attributes": [],
+                "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+                "taxonomy": "mediaType"
+              }
+            },
+            {
+              "term": {
+                "name": "Shanghai",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0FGVE1fR0xfNjg2MDc=-R0w=",
+                "taxonomy": "regions"
+              }
+            },
+            {
+              "term": {
+                "name": "China",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0NO-R0w=",
+                "taxonomy": "regions"
+              }
+            },
+            {
+              "term": {
+                "name": "World",
+                "attributes": [
+                  {
+                    "value": "world",
+                    "key": "dfpSite"
+                  }
+                ],
+                "id": "MQ==-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Opinion",
+                "attributes": [
+                  {
+                    "value": "opinion",
+                    "key": "dfpSite"
+                  }
+                ],
+                "id": "MTE2-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Asia Pacific",
+                "attributes": [
+                  {
+                    "value": "world",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "asia.pacific",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "MTE=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "General News",
+                "attributes": [],
+                "id": "MTE4-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            },
+            {
+              "term": {
+                "name": "Comment & Analysis",
+                "attributes": [],
+                "id": "MTIz-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            }
+          ],
+          "authors": [
+            {
+              "term": {
+                "name": "Patti Waldmeir",
+                "attributes": [],
+                "id": "Q0ItMDAwMDg4Ng==-QXV0aG9ycw==",
+                "taxonomy": "authors"
+              }
+            }
+          ],
+          "brand": [],
+          "genre": [
+            {
+              "term": {
+                "name": "Comment",
+                "attributes": [],
+                "id": "OA==-R2VucmVz",
+                "taxonomy": "genre"
+              }
+            }
+          ],
+          "icb": [],
+          "iptc": [],
+          "mediaType": [
+            {
+              "term": {
+                "name": "Text",
+                "attributes": [],
+                "id": "ZjMwY2E2NjctMDA1Ni00ZTk4LWI0MWUtZjk5MTk2ZTMyNGVm-TWVkaWFUeXBlcw==",
+                "taxonomy": "mediaType"
+              }
+            }
+          ],
+          "organisations": [],
+          "people": [],
+          "regions": [
+            {
+              "term": {
+                "name": "Shanghai",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0FGVE1fR0xfNjg2MDc=-R0w=",
+                "taxonomy": "regions"
+              }
+            },
+            {
+              "term": {
+                "name": "China",
+                "attributes": [],
+                "id": "TnN0ZWluX0dMX0NO-R0w=",
+                "taxonomy": "regions"
+              }
+            }
+          ],
+          "sections": [
+            {
+              "term": {
+                "name": "World",
+                "attributes": [
+                  {
+                    "value": "world",
+                    "key": "dfpSite"
+                  }
+                ],
+                "id": "MQ==-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Opinion",
+                "attributes": [
+                  {
+                    "value": "opinion",
+                    "key": "dfpSite"
+                  }
+                ],
+                "id": "MTE2-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Columnists",
+                "attributes": [
+                  {
+                    "value": "opinion",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "columnists",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "MTE3-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            },
+            {
+              "term": {
+                "name": "Asia Pacific",
+                "attributes": [
+                  {
+                    "value": "world",
+                    "key": "dfpSite"
+                  },
+                  {
+                    "value": "asia.pacific",
+                    "key": "dfpZone"
+                  }
+                ],
+                "id": "MTE=-U2VjdGlvbnM=",
+                "taxonomy": "sections"
+              }
+            }
+          ],
+          "specialReports": [],
+          "subjects": [
+            {
+              "term": {
+                "name": "General News",
+                "attributes": [],
+                "id": "MTE4-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            },
+            {
+              "term": {
+                "name": "Comment & Analysis",
+                "attributes": [],
+                "id": "MTIz-U3ViamVjdHM=",
+                "taxonomy": "subjects"
+              }
+            }
+          ],
+          "topics": [
+            {
+              "term": {
+                "name": "China Society",
+                "attributes": [],
+                "id": "MmFlY2ExNzQtYmM4Ni00ZjRkLWI4NmItNjgxOTBhMDNkMjY5-VG9waWNz",
+                "taxonomy": "topics"
+              }
+            }
+          ]
+        },
+        "images": [
+          {
+            "alt": "Guests mingle at the opening of Diageo Plc's Johnnie Walker brand store in Shanghai, China, on Thursday, May 19, 2011. In a converted villa in the fashionable French Concession in Shanghai, Diageo Plc is trying to wean wealthy Chinese drinkers from their love of cognac. Photographer: Kevin Lee/Bloomberg",
+            "width": 272,
+            "mediaType": "image/jpeg",
+            "source": "Bloomberg",
+            "type": "primary",
+            "url": "http://im.ft-static.com/content/images/5e69e49b-7a62-4b2e-a974-d3ca7c4b5bc5.img",
+            "height": 153
+          },
+          {
+            "alt": "Guests mingle at the opening of Diageo Plc's Johnnie Walker brand store in Shanghai, China, on Thursday, May 19, 2011. In a converted villa in the fashionable French Concession in Shanghai, Diageo Plc is trying to wean wealthy Chinese drinkers from their love of cognac. Photographer: Kevin Lee/Bloomberg",
+            "width": 167,
+            "mediaType": "image/jpeg",
+            "source": "Bloomberg",
+            "type": "secondary",
+            "url": "http://im.ft-static.com/content/images/aaf127e4-51aa-4ab5-b2e6-3ab9a8038931.img",
+            "height": 94
+          },
+          {
+            "alt": "Guests mingle at the opening of Diageo Plc's Johnnie Walker brand store in Shanghai, China, on Thursday, May 19, 2011. In a converted villa in the fashionable French Concession in Shanghai, Diageo Plc is trying to wean wealthy Chinese drinkers from their love of cognac. Photographer: Kevin Lee/Bloomberg",
+            "width": 600,
+            "mediaType": "image/jpeg",
+            "source": "Bloomberg",
+            "type": "article",
+            "url": "http://im.ft-static.com/content/images/18d3068e-3bc5-451f-a78d-41ec9d74d59f.img",
+            "height": 338
+          },
+          {
+            "alt": "Guests mingle at the opening of Diageo Plc's Johnnie Walker brand store in Shanghai, China, on Thursday, May 19, 2011. In a converted villa in the fashionable French Concession in Shanghai, Diageo Plc is trying to wean wealthy Chinese drinkers from their love of cognac. Photographer: Kevin Lee/Bloomberg",
+            "width": 414,
+            "mediaType": "image/jpeg",
+            "source": "Bloomberg",
+            "type": "leader",
+            "url": "http://im.ft-static.com/content/images/21d1c731-5890-41f2-aeff-8e262cf5fcbf.img",
+            "height": 233
+          },
+          {
+            "alt": "Guests mingle at the opening of Diageo Plc's Johnnie Walker brand store in Shanghai, China, on Thursday, May 19, 2011. In a converted villa in the fashionable French Concession in Shanghai, Diageo Plc is trying to wean wealthy Chinese drinkers from their love of cognac. Photographer: Kevin Lee/Bloomberg",
+            "width": 972,
+            "mediaType": "image/jpeg",
+            "source": "Bloomberg",
+            "type": "wide-format",
+            "url": "http://im.ft-static.com/content/images/b9cb7364-e2f9-4f56-8a0b-7ddc96973c16.img",
+            "height": 547
+          },
+          {
+            "alt": "FT podcast",
+            "width": 325,
+            "mediaType": "image/jpeg",
+            "type": "promo",
+            "url": "http://im.ft-static.com/content/images/f94345c4-f807-11e4-962b-00144feab7de.img",
+            "height": 217
+          }
+        ],
+        "package": [],
+        "assets": [
+          {
+            "name": "asset1",
+            "type": "promoBox",
+            "fields": {
+              "images": [
+                {
+                  "alt": "FT podcast",
+                  "width": 325,
+                  "mediaType": "image/jpeg",
+                  "type": "promo",
+                  "url": "http://im.ft-static.com/content/images/f94345c4-f807-11e4-962b-00144feab7de.img",
+                  "height": 217
+                }
+              ],
+              "intro": "<p>Even as the Chinese economy slows, many sectors are still pounding ahead - like craft beers with Chinese characteristics. Patti Waldmeir and Jackie Cai talk to brewer Master Gao about the importance of social media in spreading their popularity.</p>",
+              "title": "<p><a href=\"http://ig.ft.com/audio/craftbeer.mp3\">Podcast</a>\n</p>",
+              "headline": "<p><a href=\"http://ig.ft.com/audio/craftbeer.mp3\">Master Gao and jasmine tea beer</a>\n</p>"
+            }
+          },
+          {
+            "name": "asset2",
+            "type": "pullQuote",
+            "fields": {
+              "body": "<p>The country has a new generation of indigenous brewmasters, and most of their customers are Chinese</p>"
+            }
+          }
+        ],
+        "mediaAssets": []
+      },
+      "_lastUpdatedDateTime": "2015-09-15T08:03:16.921Z"
+    },
+    "sort": [
+      1442233629000
+    ]
+  }
+]

--- a/test/server/lib/read-next.test.js
+++ b/test/server/lib/read-next.test.js
@@ -1,0 +1,164 @@
+/*global describe, it, before*/
+'use strict';
+
+var sinon = require('sinon');
+require('chai').should();
+var rewire = require('rewire');
+var readNext = rewire('../../../server/lib/read-next');
+var useElasticSearch = true;
+
+var parentArticle1 = require('../../fixtures/readNext/parentArticle1');
+var parentArticle2 = require('../../fixtures/readNext/parentArticle2');
+var parentArticle3 = require('../../fixtures/readNext/parentArticle3');
+var parentArticle4 = require('../../fixtures/readNext/parentArticle4');
+
+var storyPackageId1 = '9a2b7608-5746-11e5-9846-de406ccb37f2';
+var storyPackageId2 = 'a581b44e-5acb-11e5-a28b-50226830d644';
+
+var storyPackageArticle1 = require('../../fixtures/readNext/storyPackageArticle1');
+var storyPackageArticle2 = require('../../fixtures/readNext/storyPackageArticle2');
+
+var topicArticles1 = require('../../fixtures/readNext/topicArticles1');
+var topicArticles2 = require('../../fixtures/readNext/topicArticles2');
+var topicArticles3 = require('../../fixtures/readNext/topicArticles3');
+var topicArticles4 = require('../../fixtures/readNext/topicArticles4');
+
+var readNextArticle1 = require('../../fixtures/readNext/readNextArticle1');
+var readNextArticle2 = require('../../fixtures/readNext/readNextArticle2');
+var readNextArticle3 = require('../../fixtures/readNext/readNextArticle3');
+var readNextArticle4 = require('../../fixtures/readNext/readNextArticle4');
+
+var topicQuery1 = 'organisationsId:"TnN0ZWluX09OX0ZvcnR1bmVDb21wYW55X0FBUEw=-T04="';
+var topicQuery2 = 'topicsId:"NjM3ZTU3MDUtMmY1ZS00ZGExLThkNjYtYWY4YWUzY2U1YWVm-VG9waWNz"';
+var topicQuery3 = 'topicsId:"ZmEzMmRmNDAtNDc0Zi00ODk3LWE2ZmQtZWFmYzJlZTRjZTVk-VG9waWNz"';
+var topicQuery4 = 'authorsId:"Q0ItMDAwMDg4Ng==-QXV0aG9ycw=="';
+
+describe('Suggested Read Model', function() {
+
+	var stubContentLegacy, stubSearchLegacy, api, results;
+
+	before(function() {
+		api = readNext.__get__('api');
+		stubContentLegacy = sinon.stub(api, "contentLegacy");
+		stubSearchLegacy = sinon.stub(api, "searchLegacy");
+	});
+
+	describe('Parent has a story package, but Topic article more recent than parent', function() {
+
+		before(function() {
+			stubContentLegacy.withArgs({
+				uuid: storyPackageId1,
+				useElasticSearch: true
+			}).returns(Promise.resolve(storyPackageArticle1));
+			stubSearchLegacy.withArgs({
+				query: topicQuery1,
+				count: 2,
+        fields: true,
+				useElasticSearch: true
+			}).returns(Promise.resolve(topicArticles1));
+
+			return readNext(parentArticle1, useElasticSearch)
+				.then(function(result) {
+					results = result;
+				});
+		});
+
+		it('read next should be based on topic as more recent', function() {
+			JSON.stringify(results).should.equal(JSON.stringify(readNextArticle1));
+      results.source.should.equal('topic');
+		});
+
+    it('should flag the read next article as more recent than the parent', function() {
+      results.should.have.property('moreRecent');
+      results.moreRecent.should.be.true;
+    });
+
+	});
+
+  describe('Parent has a story package, Topic articles older than parent', function() {
+
+    before(function() {
+      stubContentLegacy.withArgs({
+        uuid: storyPackageId2,
+        useElasticSearch: true
+      }).returns(Promise.resolve(storyPackageArticle2));
+      stubSearchLegacy.withArgs({
+        query: topicQuery2,
+        count: 2,
+        fields: true,
+        useElasticSearch: true
+      }).returns(Promise.resolve(topicArticles2));
+
+      return readNext(parentArticle2, useElasticSearch)
+        .then(function(result) {
+          results = result;
+        });
+    });
+
+    it('read next should be based on story package as topic not more recent than parent', function() {
+      JSON.stringify(results).should.equal(JSON.stringify(readNextArticle2));
+      results.source.should.equal('package');
+    });
+
+    it('should not flag the read next article as more recent than the parent', function() {
+      results.should.not.have.property('moreRecent');
+    });
+
+  });
+
+  describe('Parent has no story package, Topic article more recent than parent', function() {
+
+    before(function() {
+      stubSearchLegacy.withArgs({
+        query: topicQuery3,
+        count: 2,
+        fields: true,
+        useElasticSearch: true
+      }).returns(Promise.resolve(topicArticles3));
+
+      return readNext(parentArticle3, useElasticSearch)
+        .then(function(result) {
+          results = result;
+        });
+    });
+
+    it('read next should be based on topic as no story package', function() {
+      JSON.stringify(results).should.equal(JSON.stringify(readNextArticle3));
+      results.source.should.equal('topic');
+    });
+
+    it('should flag the read next article as more recent than the parent', function() {
+      results.should.have.property('moreRecent');
+      results.moreRecent.should.be.true;
+    });
+
+  });
+
+  describe('Parent has no story package, Topic articles older than parent', function() {
+
+    before(function() {
+      stubSearchLegacy.withArgs({
+        query: topicQuery4,
+        count: 2,
+        fields: true,
+        useElasticSearch: true
+      }).returns(Promise.resolve(topicArticles4));
+
+      return readNext(parentArticle4, useElasticSearch)
+        .then(function(result) {
+          results = result;
+        });
+    });
+
+    it('read next should be based on topic as no story package', function() {
+      JSON.stringify(results).should.equal(JSON.stringify(readNextArticle4));
+      results.source.should.equal('topic');
+    });
+
+    it('should not flag the read next article as more recent than the parent', function() {
+      results.should.not.have.property('moreRecent');
+    });
+
+  });
+
+});

--- a/test/server/mappings/article-pod-mapping.test.js
+++ b/test/server/mappings/article-pod-mapping.test.js
@@ -1,0 +1,17 @@
+/*global describe, it*/
+'use strict';
+
+require('chai').should();
+
+var articlePodMapping = require('../../../server/mappings/article-pod-mapping');
+var suggestedReadStoryPackageArticle = require('../../fixtures/articlePodMapping/suggestedReadStoryPackageArticle');
+var articlePodMappingStoryPackage = require('../../fixtures/articlePodMapping/articlePodMappingStoryPackage');
+
+describe('Map Article Pod Model', function() {
+
+	it('should create an array of articles with necessary data from elastic search results', function() {
+		articlePodMapping(suggestedReadStoryPackageArticle)
+			.should.eql(articlePodMappingStoryPackage);
+	});
+
+});

--- a/test/server/mappings/article-topic-mapping.test.js
+++ b/test/server/mappings/article-topic-mapping.test.js
@@ -1,0 +1,30 @@
+/*global describe, it*/
+"use strict";
+
+var expect = require('chai').expect;
+
+var articleTopicMapping = require('../../../server/mappings/article-topic-mapping');
+var metadataHasPrimaryTheme = require('../../fixtures/articleTopicMapping/metadata-has-primary-theme');
+var metadataHasPrimarySection = require('../../fixtures/articleTopicMapping/metadata-has-primary-section');
+var metadataHasNoPrimaries = require('../../fixtures/articleTopicMapping/metadata-has-no-primaries');
+
+
+describe('Article Topic Mapping', function() {
+
+	it('should return topic based on Primary Theme if available', function() {
+		articleTopicMapping(metadataHasPrimaryTheme).name.should.equal("US presidential election");
+	});
+
+	it('should return topic based on Primary Section if no Primary Theme', function() {
+		articleTopicMapping(metadataHasPrimarySection).name.should.equal("US Politics & Policy");
+	});
+
+	it('should return nothing if no Primary Section or Theme', function() {
+		expect(articleTopicMapping(metadataHasNoPrimaries)).to.be.undefined;
+	});
+
+	it('should add a url to the topic', function() {
+		articleTopicMapping(metadataHasPrimaryTheme).url.should.exist;
+	});
+
+});

--- a/test/server/stylesheets/paragraph-one.test.js
+++ b/test/server/stylesheets/paragraph-one.test.js
@@ -1,0 +1,50 @@
+/* global describe, it */
+"use strict";
+
+var transform = require('./transform-helper');
+require('chai').should();
+
+describe('Paragraph One', function() {
+
+  it('should have the standfirst before the first paragraph if suggested read is on', function() {
+    return transform(
+      '<body>' +
+        '<p>This is the first paragraph</p>' +
+        '<p>This is the second paragraph</p>' +
+      '</body>',
+      {
+        suggestedRead: 1,
+        standFirst: "This is an example standfirst"
+      }
+    ).then(function(transformedXml) {
+      transformedXml.should.equal(
+        '<body>' +
+          '<p class="article__standfirst">This is an example standfirst</p>' +
+          '<p>This is the first paragraph</p>' +
+          '<p>This is the second paragraph</p>' +
+        '</body>\n'
+      );
+    });
+  });
+
+  it('should not have the standfirst before the first paragraph if suggested read is off', function() {
+    return transform(
+      '<body>' +
+        '<p>This is the first paragraph</p>' +
+        '<p>This is the second paragraph</p>' +
+      '</body>',
+      {
+        suggestedRead: 0,
+        standFirst: "This is an example standfirst"
+      }
+    ).then(function(transformedXml) {
+      transformedXml.should.equal(
+        '<body>' +
+          '<p>This is the first paragraph</p>' +
+          '<p>This is the second paragraph</p>' +
+        '</body>\n'
+      );
+    });
+  });
+
+});

--- a/test/server/stylesheets/transform-helper.js
+++ b/test/server/stylesheets/transform-helper.js
@@ -9,7 +9,9 @@ module.exports = function(xml, params) {
 		renderSlideshows: 0,
 		renderTOC: 0,
 		fullWidthMainImages: 0,
-		reserveSpaceForMasterImage: 1
+		reserveSpaceForMasterImage: 1,
+		suggestedRead: 0,
+		standFirst: ""
 	};
 
 	var xsltParams = {};

--- a/views/article-v2.html
+++ b/views/article-v2.html
@@ -42,7 +42,9 @@
 					{{! TODO: Update to CAPI v2 when this is available ~end of Q1 }}
 					{{! Probably something like article.summaries[0] }}
 					{{#if articleV1.editorial.standFirst}}
-						<p class="article__stand-first">{{{articleV1.editorial.standFirst}}}</p>
+						{{#unless @root.flags.articleSuggestedRead}}
+							<p class="article__stand-first">{{{articleV1.editorial.standFirst}}}</p>
+						{{/unless}}
 					{{/if}}
 						<div class="article__header-time-byline">
 						{{#if article.publishedDate}}
@@ -66,17 +68,21 @@
 					</div>
 				</header>
 			</div>
-			{{#if tags}}
-				<aside class="article__tags" data-o-grid-colspan="hide L3 Loffset1" role="complementary">
-					<h3 class="article__tags__title">Topics mentioned in this article</h3>
-					<ul class="article__tags-list" data-trackable="tags">
-						{{#each tags}}
-							<li class="article__tag">
-								<a class="article__tag__link" href="{{url}}" data-trackable="tag"{{#if id}} data-concept-id="{{id}}"{{/if}}>{{name}}</a>
-							</li>
-						{{/each}}
-					</ul>
-				</aside>
+			{{#if readNextArticle}}
+				{{>read-next-header readNext=readNextArticle}}
+			{{else}}
+				{{#if tags}}
+					<aside class="article__tags" data-o-grid-colspan="hide L3 Loffset1" role="complementary">
+						<h3 class="article__tags__title">Topics mentioned in this article</h3>
+						<ul class="article__tags-list" data-trackable="tags">
+							{{#each tags}}
+								<li class="article__tag">
+									<a class="article__tag__link" href="{{url}}" data-trackable="tag"{{#if id}} data-concept-id="{{id}}"{{/if}}>{{name}}</a>
+								</li>
+							{{/each}}
+						</ul>
+					</aside>
+				{{/if}}
 			{{/if}}
 		</div>
 	</div>
@@ -137,10 +143,13 @@
 	{{>share}}
 {{/if}}
 
-<div class="o-grid-row">
+<div class="o-grid-row {{#if readNextArticle}}read-next__container{{/if}}">
 	{{#if isSpecialReport}}
 			<div class="js-special-report" data-trackable="special-report" data-o-grid-colspan="12 XL11 XLoffset1"></div>
 	{{else}}
+		{{#if readNextArticle}}
+			{{>read-next-bottom readNext=readNextArticle}}
+		{{/if}}
 		{{#if relatedContent}}
 			<div class="js-story-package" data-trackable="story-package" data-o-grid-colspan="12 XL11 XLoffset1"></div>
 		{{/if}}

--- a/views/partials/read-next-bottom.html
+++ b/views/partials/read-next-bottom.html
@@ -1,0 +1,7 @@
+{{#with readNext}}
+	<div class="next-up next-up__bottom" data-trackable="next-up-bottom" data-o-grid-colspan="12 L8 XL7 XLoffset1">
+		<p><span class="next-up__intro">Read next:</span>
+			<span><a href="{{headline.url}}" class="next-up__headline" data-trackable="headline-link--{{source}}{{#if moreRecent}}--moreRecent{{/if}}">{{headline.text}}</a></span>
+		</p>
+	</div>
+{{/with}}

--- a/views/partials/read-next-header.html
+++ b/views/partials/read-next-header.html
@@ -1,0 +1,9 @@
+{{#with readNext}}
+	<aside class="next-up next-up__header" data-o-grid-colspan="hide L3 Loffset1" data-trackable="next-up-header" role="complementary" aria-hidden="true">
+		<p class="next-up__intro next-up__intro__header">{{#if moreRecent}}Newer content available{{else}}Read next{{/if}}</p>
+			<a href="{{headline.url}}" class="next-up__headline" data-trackable="headline-link--{{source}}{{#if moreRecent}}--moreRecent{{/if}}">{{headline.text}}</a>
+		<time class="next-up__timestamp {{#if moreRecent}}next-up__timestamp__more-recent{{/if}} o-date" data-o-component="o-date" datetime="{{#dateformat}}{{lastUpdated}}{{/dateformat}}" data-o-date-js>
+			{{#dateformat "dddd, d mmmm, yyyy"}}{{lastUpdated}}{{/dateformat}}
+		</time>
+	</aside>
+{{/with}}


### PR DESCRIPTION
lead article read next (behind articleSuggestedRead flag)

**Key features**
*Header*
- remove tags on RHS and replace with lead read next article
- different visual treatment based on whether the article is more recent than main article
- move standfirst from header to after image, before 1st paragraph

*Bottom of article*
- lead read next article inserted after article sharing and before related stories / more-ons 

*Logic for lead read next article*
- first available of the following (in order of compellingness)
    - more recent story on same topic as main article
    - first story in curated story package
    - most recent story on same topic as main article 

Screenshots
![screen shot 2015-09-15 at 16 30 15](https://cloud.githubusercontent.com/assets/8938227/9881755/4f437226-5bc9-11e5-8c4f-7797e33b3d1d.png)
![screen shot 2015-09-15 at 16 30 35](https://cloud.githubusercontent.com/assets/8938227/9881756/4f4386c6-5bc9-11e5-92c2-73a6c2e0fe54.png)
![screen shot 2015-09-15 at 16 31 50](https://cloud.githubusercontent.com/assets/8938227/9881757/4f456e00-5bc9-11e5-875c-01eb59445017.png)
![screen shot 2015-09-15 at 16 45 38](https://cloud.githubusercontent.com/assets/8938227/9881758/4f47054e-5bc9-11e5-8eb4-424308133ce3.png)


(lots of fixtures for test stubbing)