### PR TITLE
remove visual test from provision in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ provision:
 	nbt configure ft-next-article ${TEST_APP} --overrides "NODE_ENV=branch"
 	nbt deploy-hashed-assets
 	nbt deploy ${TEST_APP} --skip-enable-preboot --docker
-	make -j2 smoke
+	make smoke
 
 smoke:
 	nbt test-urls ${TEST_APP};

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ provision:
 	nbt configure ft-next-article ${TEST_APP} --overrides "NODE_ENV=branch"
 	nbt deploy-hashed-assets
 	nbt deploy ${TEST_APP} --skip-enable-preboot --docker
-	make -j2 visual smoke
+	make -j2 smoke
 
 smoke:
 	nbt test-urls ${TEST_APP};


### PR DESCRIPTION
As visual test suite is adding no current value and is causing build failure issues, propose removing it from the provision step in Makefile.