### PR TITLE
remove visual test, j2 and use unique urls in smoke test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ provision:
 	nbt configure ft-next-article ${TEST_APP} --overrides "NODE_ENV=branch"
 	nbt deploy-hashed-assets
 	nbt deploy ${TEST_APP} --skip-enable-preboot --docker
-	make -j2 visual smoke
+	make smoke
 
 smoke:
 	nbt test-urls ${TEST_APP};

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -3,7 +3,7 @@ module.exports = [
 		timeout: 5000,
 		urls: {
 			//methode
-			'/02cad03a-844f-11e4-bae9-00144feabdc0': 200,
+			'/395650fa-5b9c-11e5-a28b-50226830d644': 200,
 			//fastft
 			'/b002e5ee-3096-3f51-9925-32b157740c98': 200,
 			// related fragments


### PR DESCRIPTION
Not expecting this to pass the build step, using it to identify which test the endpoint is too slow on (as same URL was used in multiple smoke tests).