### PR TITLE
Remove legacy myft-client dep

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,6 +33,7 @@
     "next-myft-ui": "^3.0.0",
     "o-buttons": "v3",
     "next-card": "^6.1.0",
-    "next-feature-flags-client": "^v8.0.0"
+    "next-feature-flags-client": "^v8.0.0",
+    "next-myft-client": "switch"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,6 @@
     "n-video": "^2.5.1",
     "o-comments": "2.0.6",
     "o-comment-ui": "2.0.2",
-    "next-myft-client": "^1.0.0",
     "next-myft-ui": "^2.8.0",
     "n-topic": "^2.0.0",
     "next-card": "^6.1.0",


### PR DESCRIPTION
This is no longer needed to be a dep at an app level as is imported via `next-js-setup`

/cc @adgad 