### PR TITLE
Stale cache handling

### DIFF
--- a/server/utils/cache-control.js
+++ b/server/utils/cache-control.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-	'Surrogate-Control': 'max-age=120,stale-while-revalidate,stale-if-error=259200'
+	'Surrogate-Control': 'max-age=120,stale-while-revalidate=6,stale-if-error=259200'
 };

--- a/server/utils/cache-control.js
+++ b/server/utils/cache-control.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-	'Surrogate-Control': 'max-age=120'
+	'Surrogate-Control': 'max-age=120,stale-while-revalidate,stale-if-error=259200'
 };


### PR DESCRIPTION
Instructs the cache to update the content every 2 minutes but if the origin is down then show stale content for 3 days.

https://docs.fastly.com/guides/performance-tuning/serving-stale-content

/cc @ironsidevsquincy @ironsidevsquincy worth adding to the front-page imho