### PR TITLE
move data-trackable into a element

### DIFF
--- a/views/partials/share.html
+++ b/views/partials/share.html
@@ -3,16 +3,16 @@
 	<h3 class="article-share__header">Share this article</h3>
 	<ul>
 		<li class="o-share__action o-share__action--twitter">
-			<a target="_blank" href="https://twitter.com/intent/tweet?url=https://next.ft.com/{{id}}&amp;text={{encode (decodeHtmlEntities title)}}&amp;via=FT"><i data-trackable="twitter">Twitter</i></a>
+			<a target="_blank" href="https://twitter.com/intent/tweet?url=https://next.ft.com/{{id}}&amp;text={{encode (decodeHtmlEntities title)}}&amp;via=FT" data-trackable="twitter"><i>Twitter</i></a>
 		</li>
 		<li class="o-share__action o-share__action--facebook">
-			<a target="_blank" href="http://www.facebook.com/sharer.php?u=https://next.ft.com/{{id}}&amp;t={{encode (decodeHtmlEntities title)}}"><i data-trackable="facebook">Facebook</i></a>
+			<a target="_blank" href="http://www.facebook.com/sharer.php?u=https://next.ft.com/{{id}}&amp;t={{encode (decodeHtmlEntities title)}}" data-trackable="facebook"><i>Facebook</i></a>
 		</li>
 		<li class="o-share__action o-share__action--linkedin">
-			<a target="_blank" href="http://www.linkedin.com/shareArticle?mini=true&amp;url=https://next.ft.com/{{id}}&amp;title={{encode (decodeHtmlEntities title)}}&amp;source=Financial+Times"><i data-trackable="linkedin">LinkedIn</i></a>
+			<a target="_blank" href="http://www.linkedin.com/shareArticle?mini=true&amp;url=https://next.ft.com/{{id}}&amp;title={{encode (decodeHtmlEntities title)}}&amp;source=Financial+Times" data-trackable="linkedin"><i>LinkedIn</i></a>
 		</li>
 		<li class="o-share__action o-share__action--whatsapp" data-o-grid-colspan="Mhide">
-			<a target="_blank" href="whatsapp://send?text={{encode (decodeHtmlEntities title)}}%20-%20https://next.ft.com/{{id}}"><i data-trackable="whatsapp">Whatsapp</i></a>
+			<a target="_blank" href="whatsapp://send?text={{encode (decodeHtmlEntities title)}}%20-%20https://next.ft.com/{{id}}" data-trackable="whatsapp"><i>Whatsapp</i></a>
 		</li>
 	</ul>
 </div>


### PR DESCRIPTION
Since last week CTA events only fire on <a> and <button> elements.

Share actions had data-trackable on <i> elements and therefore tracking was broken.

This puts the data-trackable into the surrounding <a> element.