### PR TITLE
Don't go vertical on large screens for share

### DIFF
--- a/client/components/share/main.scss
+++ b/client/components/share/main.scss
@@ -45,19 +45,4 @@
 		padding: 0;
 	}
 
-	@include oGridRespondTo(XL) {
-		@include oShareVertical();
-		width: 48px;
-		position: absolute;
-		top: 0;
-		left: -48px;
-		text-align: center;
-		.article__share__count {
-			display: block;
-			padding: 9px 0;
-		}
-		.article__share__comments {
-			position: static;
-		}
-	}
 }


### PR DESCRIPTION
/cc @i-like-robots @Financial-Times/next-myft 

Before: 
<img width="838" alt="screen shot 2015-10-05 at 13 46 47" src="https://cloud.githubusercontent.com/assets/1978880/10280785/92121726-6b67-11e5-8d0a-645401fc94ab.png">

After: 
<img width="730" alt="screen shot 2015-10-05 at 13 46 18" src="https://cloud.githubusercontent.com/assets/1978880/10280787/951080de-6b67-11e5-9ade-d538922f695a.png">

