### PR TITLE
Promobox enhancements

### DIFF
--- a/client/components/article/_promo-box.scss
+++ b/client/components/article/_promo-box.scss
@@ -13,9 +13,6 @@
 .promo-box--long {
 	float: none;
 	max-width: 100%;
-	@include oGridRespondTo(XL) {
-		margin-right: 100px;
-	}
 }
 
 .promo-box--long img {
@@ -27,16 +24,20 @@
 }
 
 .promo-box__title {
+	position: absolute;
+	top: -20px;
+	left: 10px;
 	padding: 0;
-	border-bottom: 1px solid getColor('warm-3');
 	overflow: hidden;
+	background-color: getColor('warm-5');
 }
+
 .promo-box__title__name {
-	@include nTypeAlpha(2);
+	@include nTypeFoxtrot(3);
 	display: inline-block;
-	margin: 0 10px 0 0;
-	padding: 10px 0;
+	padding: 10px;
 	color: getColor('cold-3');
+	font-weight: 900;
 	a {
 		color: getColor('cold-3');
 		border-bottom: 0;
@@ -45,11 +46,11 @@
 }
 
 .promo-box__wrapper {
+	position: relative;
 	float: left;
-	padding: 10px;
-	margin-top: 10px;
-	background-color: getColor('pink');
-	border-bottom: 1px solid getColor('warm-3');
+	margin-top: 20px;
+	padding: 15px;
+	border: 1px solid getColor('warm-3');
 	> .o-expander__toggle {
 		@include nTypeAlpha(3);
 		i {
@@ -73,16 +74,11 @@
 }
 
 .promo-box__headline {
-	@include nTypeFoxtrot(2);
-	margin: 0;
+	@include nTypeBravo(2);
+	margin-top: 10px;
 	color: getColor('cold-3');
-
 	p {
 		margin: 0;
-	}
-	a {
-		@include nLinksHeadline();
-		border-bottom: 0;
 	}
 }
 
@@ -91,4 +87,9 @@
 	p {
 		margin: 5px 0 0;
 	}
+}
+
+.promo-box__list {
+	padding-left: 20px;
+	margin: 10px 0;
 }

--- a/server/stylesheets/promo-box.xsl
+++ b/server/stylesheets/promo-box.xsl
@@ -13,17 +13,17 @@
         <xsl:when test="($imageCount > 0 and $wordCount > $longBoxWordBoundaryImage) or ($imageCount = 0 and $wordCount > $longBoxWordBoundaryNoImage)">
           <xsl:choose>
             <xsl:when test="$contentParagraphs > $expanderParaBreakPoint">
-              <aside class="promo-box promo-box--long ng-pull-out ng-inline-element o-expander" data-trackable="promobox" role="complementary" data-o-component="o-expander" data-o-expander-shrink-to="0" data-o-expander-count-selector=".promo-box__content__extension">
-                <xsl:apply-templates select="current()" mode="default-title" />
+              <aside class="promo-box promo-box--long ng-inline-element o-expander" data-trackable="promobox" role="complementary" data-o-component="o-expander" data-o-expander-shrink-to="0" data-o-expander-count-selector=".promo-box__content__extension">
                 <div class="promo-box__wrapper">
+                  <xsl:apply-templates select="current()" mode="default-title" />
                   <xsl:apply-templates />
                 </div>
               </aside>
             </xsl:when>
             <xsl:otherwise>
-              <aside class="promo-box promo-box--long ng-pull-out ng-inline-element" data-trackable="promobox" role="complementary">
-                <xsl:apply-templates select="current()" mode="default-title" />
+              <aside class="promo-box promo-box--long ng-inline-element" data-trackable="promobox" role="complementary">
                 <div class="promo-box__wrapper">
+                  <xsl:apply-templates select="current()" mode="default-title" />
                   <xsl:apply-templates />
                 </div>
               </aside>
@@ -31,9 +31,9 @@
           </xsl:choose>
         </xsl:when>
         <xsl:otherwise>
-          <aside class="promo-box ng-pull-out ng-inline-element" data-trackable="promobox" role="complementary">
-            <xsl:apply-templates select="current()" mode="default-title" />
+          <aside class="promo-box ng-inline-element" data-trackable="promobox" role="complementary">
             <div class="promo-box__wrapper">
+              <xsl:apply-templates select="current()" mode="default-title" />
               <xsl:apply-templates />
             </div>
           </aside>
@@ -43,7 +43,7 @@
 
     <xsl:template match="promo-box" mode="default-title">
       <div class="promo-box__title">
-        <h2 class="promo-box__title__name">
+        <div class="promo-box__title__name">
           <xsl:choose>
             <xsl:when test="count(current()/promo-title) = 0">
               <xsl:text>Related Content</xsl:text>
@@ -52,22 +52,25 @@
               <xsl:apply-templates select="current()/promo-title" mode="extract-content" />
             </xsl:otherwise>
           </xsl:choose>
-        </h2>
+        </div>
       </div>
     </xsl:template>
 
     <xsl:template match="promo-title"/>
 
     <xsl:template match="promo-headline">
-      <h2 class="promo-box__headline">
+      <div class="promo-box__headline">
         <xsl:apply-templates select="current()" mode="extract-content" />
-      </h2>
+      </div>
     </xsl:template>
 
     <xsl:template match="promo-headline | promo-title" mode="extract-content">
       <xsl:choose>
         <xsl:when test="count(current()/p/*) > 0">
-          <xsl:apply-templates select="current()/p/*" />
+          <xsl:apply-templates select="current()/p/@* | current()/p/node()" />
+        </xsl:when>
+        <xsl:when test="count(current()/p) = 0">
+          <xsl:apply-templates select="current()/@* | current()/node()" />
         </xsl:when>
         <xsl:otherwise>
           <xsl:value-of select="current()/p/text()" />
@@ -104,6 +107,12 @@
           </div>
         </xsl:otherwise>
       </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="ul">
+      <ul class="promo-box__list">
+        <xsl:apply-templates />
+      </ul>
     </xsl:template>
 
 </xsl:stylesheet>

--- a/test/server/stylesheets/promo-box.test.js
+++ b/test/server/stylesheets/promo-box.test.js
@@ -18,12 +18,12 @@ describe('Promo-boxes', function() {
 		.then(function (transformedXml) {
 			transformedXml.should.equal(
 				'<body>' +
-					'<aside class="promo-box ng-pull-out ng-inline-element" data-trackable="promobox" role="complementary">' +
-						'<div class="promo-box__title">' +
-							'<h2 class="promo-box__title__name">Tatomer Riesling 2012</h2>' +
-						'</div>' +
+					'<aside class="promo-box ng-inline-element" data-trackable="promobox" role="complementary">' +
 						'<div class="promo-box__wrapper">' +
-							'<h2 class="promo-box__headline">Greece debt crisis</h2>' +
+							'<div class="promo-box__title">' +
+								'<div class="promo-box__title__name">Tatomer Riesling 2012</div>' +
+							'</div>' +
+							'<div class="promo-box__headline">Greece debt crisis</div>' +
 							'<picture data-image-set-id="e7b203ac-2351-11e5-23e5-e651ba9c5bc5" class="article__image n-image">' +
 								'<!--[if IE 9]><video style="display: none;"><![endif]-->' +
 								'<source data-image-size="280" media="(min-width: 490px)"></source>' +
@@ -52,12 +52,12 @@ describe('Promo-boxes', function() {
 		.then(function (transformedXml) {
 			transformedXml.should.equal(
 				'<body>' +
-					'<aside class="promo-box promo-box--long ng-pull-out ng-inline-element" data-trackable="promobox" role="complementary">' +
-						'<div class="promo-box__title">' +
-							'<h2 class="promo-box__title__name">Tatomer Riesling 2012</h2>' +
-						'</div>' +
+					'<aside class="promo-box promo-box--long ng-inline-element" data-trackable="promobox" role="complementary">' +
 						'<div class="promo-box__wrapper">' +
-							'<h2 class="promo-box__headline">Greece debt crisis</h2>' +
+							'<div class="promo-box__title">' +
+								'<div class="promo-box__title__name">Tatomer Riesling 2012</div>' +
+							'</div>' +
+							'<div class="promo-box__headline">Greece debt crisis</div>' +
 							'<picture data-image-set-id="e7b203ac-2351-11e5-23e5-e651ba9c5bc5" class="article__image n-image">' +
 								'<!--[if IE 9]><video style="display: none;"><![endif]-->' +
 								'<source data-image-size="280" media="(min-width: 490px)"></source>' +
@@ -89,12 +89,12 @@ describe('Promo-boxes', function() {
 		.then(function (transformedXml) {
 			transformedXml.should.equal(
   			'<body>' +
-          '<aside class="promo-box promo-box--long ng-pull-out ng-inline-element o-expander" data-trackable="promobox" role="complementary" data-o-component="o-expander" data-o-expander-shrink-to="0" data-o-expander-count-selector=".promo-box__content__extension">' +
-						'<div class="promo-box__title">' +
-							'<h2 class="promo-box__title__name">Tatomer Riesling 2012</h2>' +
-						'</div>' +
+          '<aside class="promo-box promo-box--long ng-inline-element o-expander" data-trackable="promobox" role="complementary" data-o-component="o-expander" data-o-expander-shrink-to="0" data-o-expander-count-selector=".promo-box__content__extension">' +
 						'<div class="promo-box__wrapper">' +
-							'<h2 class="promo-box__headline">Greece debt crisis</h2>' +
+							'<div class="promo-box__title">' +
+								'<div class="promo-box__title__name">Tatomer Riesling 2012</div>' +
+							'</div>' +
+							'<div class="promo-box__headline">Greece debt crisis</div>' +
 							'<picture data-image-set-id="2889cee2-2fc7-11e5-0fca-327ba7efe7b6" class="article__image n-image">' +
 								'<!--[if IE 9]><video style="display: none;"><![endif]-->' +
 								'<source data-image-size="280" media="(min-width: 490px)"></source>' +
@@ -125,12 +125,12 @@ describe('Promo-boxes', function() {
 		.then(function (transformedXml) {
 			transformedXml.should.equal(
 			'<body>' +
-				'<aside class="promo-box ng-pull-out ng-inline-element" data-trackable="promobox" role="complementary">' +
-					'<div class="promo-box__title">' +
-						'<h2 class="promo-box__title__name">Related Content</h2>' +
-					'</div>' +
+				'<aside class="promo-box ng-inline-element" data-trackable="promobox" role="complementary">' +
 					'<div class="promo-box__wrapper">' +
-						'<h2 class="promo-box__headline">Greece debt crisis</h2>' +
+						'<div class="promo-box__title">' +
+							'<div class="promo-box__title__name">Related Content</div>' +
+						'</div>' +
+						'<div class="promo-box__headline">Greece debt crisis</div>' +
 						'<picture data-image-set-id="2889cee2-2fc7-11e5-0fca-327ba7efe7b6" class="article__image n-image">' +
 							'<!--[if IE 9]><video style="display: none;"><![endif]-->' +
 							'<source data-image-size="280" media="(min-width: 490px)"></source>' +
@@ -155,9 +155,10 @@ describe('Promo-boxes', function() {
 		.then(function(transformedXml) {
 			transformedXml.should.equal(
 				'<body>' +
-					'<aside class="promo-box ng-pull-out ng-inline-element" data-trackable="promobox" role="complementary">' +
-						'<div class="promo-box__title"><h2 class="promo-box__title__name"><a href="/c9175806-3054-11e5-8873-775ba7c2ea3d" data-trackable="link" class="article__body__link">Greece crisis tests start-ups’ staying power</a></h2></div>' +
-						'<div class="promo-box__wrapper"></div>' +
+					'<aside class="promo-box ng-inline-element" data-trackable="promobox" role="complementary">' +
+						'<div class="promo-box__wrapper">' +
+							'<div class="promo-box__title"><div class="promo-box__title__name"><a href="/c9175806-3054-11e5-8873-775ba7c2ea3d" data-trackable="link" class="article__body__link">Greece crisis tests start-ups’ staying power</a> </div></div>' +
+						'</div>' +
 					'</aside>' +
 				'</body>\n'
 			);
@@ -173,10 +174,10 @@ describe('Promo-boxes', function() {
 		.then(function(transformedXml) {
 			transformedXml.should.equal(
 				'<body>' +
-					'<aside class="promo-box ng-pull-out ng-inline-element" data-trackable="promobox" role="complementary">' +
-						'<div class="promo-box__title"><h2 class="promo-box__title__name">Related Content</h2></div>' +
+					'<aside class="promo-box ng-inline-element" data-trackable="promobox" role="complementary">' +
 						'<div class="promo-box__wrapper">' +
-							'<h2 class="promo-box__headline"><a href="/c9175806-3054-11e5-8873-775ba7c2ea3d" data-trackable="link" class="article__body__link">Greece crisis tests start-ups’ staying power</a></h2>' +
+							'<div class="promo-box__title"><div class="promo-box__title__name">Related Content</div></div>' +
+							'<div class="promo-box__headline"><a href="/c9175806-3054-11e5-8873-775ba7c2ea3d" data-trackable="link" class="article__body__link">Greece crisis tests start-ups’ staying power</a></div>' +
 						'</div>' +
 					'</aside>' +
 				'</body>\n'
@@ -205,10 +206,10 @@ describe('Promo-boxes', function() {
 		.then(function(transformedXml) {
 			transformedXml.should.equal(
 				'<body>' +
-					'<aside class="promo-box promo-box--long ng-pull-out ng-inline-element o-expander" data-trackable="promobox" role="complementary" data-o-component="o-expander" data-o-expander-shrink-to="0" data-o-expander-count-selector=".promo-box__content__extension">' +
-						'<div class="promo-box__title"><h2 class="promo-box__title__name">Tatomer Riesling 2012</h2></div>' +
+					'<aside class="promo-box promo-box--long ng-inline-element o-expander" data-trackable="promobox" role="complementary" data-o-component="o-expander" data-o-expander-shrink-to="0" data-o-expander-count-selector=".promo-box__content__extension">' +
 						'<div class="promo-box__wrapper">' +
-							'<h2 class="promo-box__headline">Greece debt crisis</h2>' +
+							'<div class="promo-box__title"><div class="promo-box__title__name">Tatomer Riesling 2012</div></div>' +
+							'<div class="promo-box__headline">Greece debt crisis</div>' +
 							'<picture data-image-set-id="2889cee2-2fc7-11e5-0fca-327ba7efe7b6" class="article__image n-image">' +
 								'<!--[if IE 9]><video style="display: none;"><![endif]-->' +
 								'<source data-image-size="280" media="(min-width: 490px)"></source>' +
@@ -223,10 +224,10 @@ describe('Promo-boxes', function() {
 							'<button class="o-expander__toggle o--if-js" data-trackable="expander-toggle"></button>' +
 						'</div>' +
 					'</aside>' +
-					'<aside class="promo-box ng-pull-out ng-inline-element" data-trackable="promobox" role="complementary">' +
-						'<div class="promo-box__title"><h2 class="promo-box__title__name">Tatomer Riesling 2012</h2></div>' +
+					'<aside class="promo-box ng-inline-element" data-trackable="promobox" role="complementary">' +
 						'<div class="promo-box__wrapper">' +
-							'<h2 class="promo-box__headline">Greece debt crisis</h2>' +
+							'<div class="promo-box__title"><div class="promo-box__title__name">Tatomer Riesling 2012</div></div>' +
+							'<div class="promo-box__headline">Greece debt crisis</div>' +
 							'<picture data-image-set-id="e7b203ac-2351-11e5-23e5-e651ba9c5bc5" class="article__image n-image">' +
 								'<!--[if IE 9]><video style="display: none;"><![endif]-->' +
 								'<source data-image-size="280" media="(min-width: 490px)"></source>' +
@@ -235,6 +236,56 @@ describe('Promo-boxes', function() {
 							'</picture>' +
 							'<div class="promo-box__content">' +
 							'<div class="promo-box__content__initial"><p>Graham Tatomer worked at Austrian Riesling producer Emmerich Knoll and now fashions this example from the old vines of the Kick-on Ranch in Santa Barbara (£26.95, Roberson)</p></div></div>' +
+						'</div>' +
+					'</aside>' +
+				'</body>\n'
+			);
+		});
+	});
+
+	it('should not strip out text in a headline before a link', function() {
+		return transform(
+			'<promo-box>' +
+				'<promo-title><p>Series: China Great Game</p></promo-title>' +
+				'<promo-headline><p>As China seeks to expand its sphere of influence, it is likely to encounter significant resistance. <a href="http://www.ft.com/indepth/china-great-game" title="Chinas Great Game in depth">Read more</a> </p></promo-headline>' +
+				'<promo-intro><p><a href="/content/6e098274-587a-11e5-a28b-50226830d644">Road to a new empire </a> <br/>A modern-day Silk route is Xi Jinping’s signature foreign policy. <a href="/content/6e098274-587a-11e5-a28b-50226830d644">Read more </a> </p></promo-intro>' +
+			'</promo-box>'
+		)
+		.then(function(transformedXml) {
+			transformedXml.should.equal(
+				'<body>' +
+					'<aside class="promo-box ng-inline-element" data-trackable="promobox" role="complementary">' +
+						'<div class="promo-box__wrapper">' +
+							'<div class="promo-box__title"><div class="promo-box__title__name">Series: China Great Game</div></div>' +
+							'<div class="promo-box__headline">As China seeks to expand its sphere of influence, it is likely to encounter significant resistance. <a href="http://www.ft.com/indepth/china-great-game" data-trackable="link" class="article__body__link">Read more</a> </div>' +
+							'<div class="promo-box__content">' +
+								'<div class="promo-box__content__initial"><p><a href="/content/6e098274-587a-11e5-a28b-50226830d644" data-trackable="link" class="article__body__link">Road to a new empire </a> <br>A modern-day Silk route is Xi Jinping’s signature foreign policy. <a href="/content/6e098274-587a-11e5-a28b-50226830d644" data-trackable="link" class="article__body__link">Read more </a> </p></div>' +
+								'</div>' +
+						'</div>' +
+					'</aside>' +
+				'</body>\n'
+			);
+		});
+	});
+
+	it('should accept a title without <p> element inside it', function() {
+		return transform(
+			'<promo-box>' +
+				'<promo-title><b>CV</b></promo-title>' +
+				'<promo-headline><p>This is the headline</p></promo-headline>' +
+				'<promo-intro><p>Here is some content</p></promo-intro>' +
+			'</promo-box>'
+		)
+		.then(function(transformedXml) {
+			transformedXml.should.equal(
+				'<body>' +
+					'<aside class="promo-box ng-inline-element" data-trackable="promobox" role="complementary">' +
+						'<div class="promo-box__wrapper">' +
+							'<div class="promo-box__title"><div class="promo-box__title__name"><b>CV</b></div></div>' +
+							'<div class="promo-box__headline">This is the headline</div>' +
+							'<div class="promo-box__content">' +
+								'<div class="promo-box__content__initial"><p>Here is some content</p></div>' +
+							'</div>' +
 						'</div>' +
 					'</aside>' +
 				'</body>\n'


### PR DESCRIPTION
- [x] Retain text that was missing from headline eg. https://next.ft.com/content/60f33cf8-6dae-11e5-8171-ba1968cf791a
- [x] Align text under bullets (done by Mus changing the manual bullets to `<li>` elements)
- [x] Allow for title to not be in `<p>` element
- [x] New overall design (border, background colour, title positioning)
- [x] Styling for links in headline (both when full headline or partial headline)
- [x] Test boxes flush with article body copy on all screen sizes

Note:
Use "flags" for Article Box & Topic Box to style these types of promo-boxes.  - To Be done when UPP passes through relevant flags.
