### PR TITLE
uses comments property of the viewModel

### DIFF
--- a/views/article-v2.html
+++ b/views/article-v2.html
@@ -175,13 +175,13 @@
 		{{/unless}}
 	</div>
 
-	{{#unless barrier}}
+	{{#if comments}}
 		<div class="o-grid-row">
 			<div data-o-grid-colspan="12 L8 XL7 XLoffset1">
 				<div data-trackable="comments" class="article__comments o-comments" id="comments"></div>
 			</div>
 		</div>
-	{{/unless}}
+	{{/if}}
 
 	{{#if barrierOverlay}}
 		<div class="barrier-overlay"></div>


### PR DESCRIPTION
/cc @ifyio @commuterjoy 

@andygnewman and I thought it would be clearer to depend on the `comments` property of the viewModel, which is set to `null` in the article controller whenever barriers are shown.