### PR TITLE
dedupe current article from recommended list of articles

### DIFF
--- a/server/controllers/article-helpers/suggested.js
+++ b/server/controllers/article-helpers/suggested.js
@@ -8,15 +8,20 @@ module.exports = function(article, useElasticSearch) {
 	var topic = exposeTopic(!!article.item && article.item.metadata);
 	var packageIds = getStoryPackage(article).map(function(item) { return item.id; });
 
-	if (packageIds.length < 4 && topic) {
+	if (packageIds.length < 5 && topic) {
 		return api.searchLegacy({
 			query: topic.metadata.term.taxonomy + 'Id:"' + topic.metadata.term.id + '"',
-			count: 4 - packageIds.length,
+			count: 6 - packageIds.length,
 			useElasticSearch: useElasticSearch
 		})
 		.then(function(ids) {
+			return ids.filter(function(id) {
+				return id !== article.item.id;
+			}).splice(0, 5);
+		})
+		.then(function(dedupedIds) {
 			return {
-				ids: packageIds.concat(ids)
+				ids: packageIds.concat(dedupedIds)
 			};
 		});
 	} else {


### PR DESCRIPTION
Fixes deduping issue raised here; https://github.com/Financial-Times/next-article/issues/924

Also makes it consistent to 5 articles in length whether story package or generated from topic.