### PR TITLE
consistent arrow and link styling

### DIFF
--- a/client/components/read-next/main.scss
+++ b/client/components/read-next/main.scss
@@ -38,6 +38,22 @@
 	}
 }
 
+.next-up__item {
+
+	margin-left: 15px;
+
+	h4 {
+		margin: 0;
+	}
+
+	&::before {
+		@include nextIcon(arrow-right, getColor('cold-2'), 17);
+		content: '';
+		position: absolute;
+		top: 22px;
+		left: 10px;
+	}
+}
 .next-up__bottom__wrapper {
 	margin-top: 45px;
 	border-top: 1px solid getColor('warm-3');
@@ -73,19 +89,9 @@
 	color: getColor('cold-2');
 	text-decoration: none;
 	border-bottom: 0;
-	display: inline-block;
 
 	.next-up__header & {
 		font-size: 24px; // FIXME: revist upon type scale revisions
-		&::after {
-			@include nextIcon(arrow-right, getColor('cold-2'), 17);
-			content: '';
-			speak: none;
-			position: absolute;
-			bottom: 6px;
-			padding-left: 10px;
-		}
-
 	}
 
 	.next-up__bottom & {

--- a/client/components/suggested-reads/main.scss
+++ b/client/components/suggested-reads/main.scss
@@ -1,6 +1,6 @@
 $suggested-reads-border: getColor('warm-3');
 
-.article__suggested-reads {
+.suggested-reads {
 	max-width: 300px;
 	margin: 0 auto;
 	a {
@@ -8,7 +8,7 @@ $suggested-reads-border: getColor('warm-3');
 	}
 }
 
-.article__suggested-reads__item {
+.suggested-reads__item {
 	margin-bottom: 15px;
 	padding: 0;
 	position: relative;
@@ -17,11 +17,11 @@ $suggested-reads-border: getColor('warm-3');
 		@include nextIcon(arrow-right, getColor('cold-2'), 15);
 		content: '';
 		position: absolute;
-		top: 5px;
+		top: 4px;
 	}
 }
 
-.article__suggested-reads__article-list {
+.suggested-reads__article-list {
 	border: 1px solid $suggested-reads-border;
 	margin: 30px 0 20px;
 	padding: 15px;
@@ -34,7 +34,7 @@ $suggested-reads-border: getColor('warm-3');
 
 }
 
-.article__suggested-reads__title {
+.suggested-reads__title {
 	@include nTypeFoxtrot(3);
 	font-size: 19px;
 	margin-bottom: 15px;
@@ -48,35 +48,33 @@ $suggested-reads-border: getColor('warm-3');
 	font-weight: 900;
 }
 
-.article__suggested-reads__item__content {
+.suggested-reads__item__content {
 	margin-left: 20px;
 	a { text-decoration: none; }
 }
 
-.article__suggested-reads__item__headline {
+.suggested-reads__item__headline {
 	@include nTypeFoxtrot(3);
+	@include nLinksHeadline();
 	color: getColor('cold-2');
 	margin: 0;
 	margin-bottom: 5px;
 }
 
-.article__suggested-reads__item__topic {
+.suggested-reads__item__topic {
 	@include nLinksTopic();
-	@include nTypeBravo(4);
-	font-size: 14px;
-	line-height: 16px;
-	display: inline;
-	margin: 0;
-	display: none;
+	@include nTypeBravo(3);
+	font-style: normal;
+	text-transform: capitalize;
 }
 
-.article__suggested-reads__item__image {
+.suggested-reads__item__image {
 	@include oGridColumn(4);
 	align-self: center;
 	display: none;
 }
 
-.article__suggested-reads__topic {
+.suggested-reads__topic {
 	border: 1px solid $suggested-reads-border;
 	margin: 20px 0;
 	padding: 15px;
@@ -92,24 +90,4 @@ $suggested-reads-border: getColor('warm-3');
 	h4 { margin: 0; }
 
 	h3 { margin-left: 5px; }
-
-
-	a {
-		@include nLinksTopic();
-		@include nTypeBravo(3);
-		font-style: normal;
-		text-transform: capitalize;
-		&::after {
-			@include nextIcon(arrow-right, oColorsGetPaletteColor('claret'), 15);
-			content: '';
-			margin-bottom: -2px;
-		}
-
-		&:hover::after {
-			@include nextIcon(arrow-right, getColor('cold-2'), 15);
-			content: '';
-			margin-bottom: -2px;
-		}
-
-	}
 }

--- a/views/partials/read-next-bottom.html
+++ b/views/partials/read-next-bottom.html
@@ -5,7 +5,7 @@
 			<ul class="next_up__bottom__article_list">
 				{{#slice articles limit=3}}
 					<li class="next_up__bottom__article">
-						<h4><a href="{{headline.url}}" class="next-up__headline" data-trackable="headline-link--{{source}}{{#if moreRecent}}--moreRecent{{/if}}">{{headline.text}}</a></h4>
+						<h4><a href="{{headline.url}}" class="next-up__headline" data-trackable="headline-link">{{headline.text}}</a></h4>
 					</li>
 				{{/slice}}
 			</ul>

--- a/views/partials/read-next-header.html
+++ b/views/partials/read-next-header.html
@@ -2,7 +2,9 @@
 	<aside class="article__aside o-grid-remove-gutters--XL" data-o-grid-colspan="hide L4 XL3 XLoffset1" data-trackable="next-up-header" role="complementary" aria-hidden="true">
 		<div class="next-up next-up__header">
 			<p class="next-up__intro next-up__intro__header">{{#if moreRecent}}Read latest:{{else}}Read next:{{/if}}</p>
-				<a href="{{headline.url}}" class="next-up__headline" data-trackable="headline-link--{{source}}{{#if moreRecent}}--moreRecent{{/if}}">{{headline.text}}</a>
+			<div class="next-up__item">
+				<h4><a href="{{headline.url}}" class="next-up__headline" data-trackable="headline-link--{{source}}{{#if moreRecent}}--moreRecent{{/if}}">{{headline.text}}</a></h4>
+			</div>
 			<time class="next-up__timestamp {{#if moreRecent}}next-up__timestamp__more-recent{{/if}} o-date" data-o-component="o-date" datetime="{{#dateformat}}{{lastUpdated}}{{/dateformat}}" data-o-date-js>
 				{{#dateformat "dddd, d mmmm, yyyy"}}{{lastUpdated}}{{/dateformat}}
 			</time>

--- a/views/partials/related/suggested-reads.html
+++ b/views/partials/related/suggested-reads.html
@@ -1,12 +1,10 @@
 {{#if items.length}}
-	<div class="article__suggested-reads__article-list" role="group" aria-labelledBy="article__suggested-reads__title" >
-		<h3 id="article__suggested-reads__title" class="article__suggested-reads__title">Recommended:</h3>
+	<div class="suggested-reads__article-list" role="group" aria-labelledBy="suggested-reads__title" >
+		<h3 id="suggested-reads__title" class="suggested-reads__title">Recommended:</h3>
 		{{#each items}}
-			<article class="article__suggested-reads__item">
-				<div class="article__suggested-reads__item__content">
-					<a href="{{headline.url}}" data-trackable="related">
-						<h4 class="article__suggested-reads__item__headline">{{headline.text}}</h4>
-					</a>
+			<article class="suggested-reads__item">
+				<div class="suggested-reads__item__content">
+					<h4><a class="suggested-reads__item__headline" href="{{headline.url}}" data-trackable="related">{{headline.text}}</a></h4>
 				</div>
 			</article>
 		{{/each}}

--- a/views/partials/related/suggested-topic.html
+++ b/views/partials/related/suggested-topic.html
@@ -1,8 +1,12 @@
 {{#with suggested}}
-	<div class="article__suggested-reads">
-		<div class="article__suggested-reads__topic">
-			<h3 class="article__suggested-reads__title">More on:</h3>
-			<h4><a data-trackable="suggested-topic" href="{{topicLink}}">{{topicName}}</a></h4>
+	<div class="suggested-reads">
+		<div class="suggested-reads__topic">
+			<h3 class="suggested-reads__title">More on:</h3>
+			<div class="suggested-reads__item">
+				<div class="suggested-reads__item__content">
+					<h4><a class="suggested-reads__item__topic" data-trackable="suggested-topic" href="{{topicLink}}">{{topicName}}</a></h4>
+				</div>
+			</div>
 		</div>
 	</div>
 {{/with}}


### PR DESCRIPTION
Ensure the read next and recommended reads have consistent arrow positioning and link styling.

Fixes the link styling issues raised here https://github.com/Financial-Times/next-article/issues/924