### PR TITLE
[Controversially] still run the XSLT transforms even if non CAPI v2

### DIFF
--- a/server/controllers/article-v3.js
+++ b/server/controllers/article-v3.js
@@ -20,11 +20,6 @@ function isCapiV2(article) {
 }
 
 function transformArticleBody(article, flags) {
-	// Return plain HTML for non-CAPI V2 content
-	if (!isCapiV2(article)) {
-		return Promise.resolve(article.bodyXML);
-	}
-
 	let xsltParams = {
 		v3: 1,
 		id: article.id,


### PR DESCRIPTION
I think the plain text vs. rich text decision should happen only in ES … which allows us to do specific clever things like enable slideshow articles (not supported in CAPI v2 but are supported in v1 and trivial to ‘polyfill’):-

http://next-es-interface.ft.com/content/b26679c4-7916-11e5-933d-efcdc3c11c89