### PR TITLE
stop suggested read error on Fast FT articles with no metadata

### DIFF
--- a/server/controllers/article-v3.js
+++ b/server/controllers/article-v3.js
@@ -228,7 +228,7 @@ module.exports = function articleV3Controller(req, res, next, payload) {
 		payload.twitterCard = getTwitterCardData(payload);
 	}
 
-	if (res.locals.flags.articleSuggestedRead) {
+	if (res.locals.flags.articleSuggestedRead && payload.metadata.length) {
 		let storyPackageIds = (payload.storyPackage || []).map(story => story.id);
 
 		asyncWorkToDo.push(


### PR DESCRIPTION
Fix this error in Sentry, specific to V3 with articleSuggestedRead flag on

https://app.getsentry.com/nextftcom/ft-next-article/group/90903127/