### PR TITLE
take outer html of main image out of body

### DIFF
--- a/server/transforms/body.js
+++ b/server/transforms/body.js
@@ -38,7 +38,7 @@ module.exports = function (body, flags) {
 		.get();
 
 	let resultObject = {
-		mainImageHTML: $('figure.article-image--full, figure.article-image--center').first().remove().html(),
+		mainImageHTML: $('figure.article-image--full, figure.article-image--center').first().remove(),
 		tocHTML: $.html('.article__toc')
 	};
 


### PR DESCRIPTION
Ensure take outer `<figure>` element around main image out of the article body when putting it at the top of the article. 