### PR TITLE
turn off comments when article has comments.enabled false

### DIFF
--- a/views/article.html
+++ b/views/article.html
@@ -168,7 +168,7 @@
 		{{/if}}
 	</div>
 
-	{{#if comments}}
+	{{#if comments.enabled}}
 		<div class="o-grid-row">
 			<div data-o-grid-colspan="12 L8 XL7 XLoffset1">
 				<div data-trackable="comments" class="article__comments o-comments n-util-hide@print" id="comments"></div>


### PR DESCRIPTION
/cc @commuterjoy 

With move to ES v3 I think the syntax for comments was changed to have comments.enabled (true/false).

This didn't seem to get changed in the template.
