### PR TITLE
enable 600 width images to be full width

### DIFF
--- a/server/stylesheets/external-image.xsl
+++ b/server/stylesheets/external-image.xsl
@@ -27,7 +27,7 @@
         <xsl:variable name="variation">
             <xsl:choose>
                 <xsl:when test="@width &lt;= 350">inline</xsl:when>
-                <xsl:when test="@width &lt; @height">inline</xsl:when>
+                <xsl:when test="(@width &lt; @height) and (@width &lt; 600)">inline</xsl:when>
                 <xsl:when test="@width &lt; 700">center</xsl:when>
                 <xsl:otherwise>full</xsl:otherwise>
             </xsl:choose>
@@ -35,7 +35,7 @@
 
         <xsl:variable name="maxWidth">
             <xsl:choose>
-                <xsl:when test="@width &lt; @height and @width &gt; 350">350</xsl:when>
+                <xsl:when test="@width &lt; @height and @width &gt; 350 and @width &lt; 600">350</xsl:when>
                 <xsl:when test="@width &lt; 700"><xsl:value-of select="@width" /></xsl:when>
                 <xsl:otherwise>700</xsl:otherwise>
             </xsl:choose>


### PR DESCRIPTION
Fix the issue that is making the map image in this article https://next.ft.com/content/2a018474-8c63-11e5-a549-b89a1dfede9b an inline rather than a center image.