### PR TITLE
Add generic share received message

### DIFF
--- a/server/controllers/article.js
+++ b/server/controllers/article.js
@@ -144,6 +144,7 @@ module.exports = function articleV3Controller(req, res, next, payload) {
 
 	if (req.get('FT-Labs-Gift') === 'GRANTED') {
 		payload.shared = true;
+		res.vary('FT-Labs-Gift');
 	}
 
 	return Promise.all(asyncWorkToDo)

--- a/server/controllers/article.js
+++ b/server/controllers/article.js
@@ -142,6 +142,10 @@ module.exports = function articleV3Controller(req, res, next, payload) {
 		payload.suggestedTopic = payload.primaryTag;
 	}
 
+	if (req.get('FT-Labs-Gift') === 'GRANTED') {
+		payload.shared = true;
+	}
+
 	return Promise.all(asyncWorkToDo)
 		.then(() => {
 			payload.layout = 'wrapper';

--- a/views/partials/social.html
+++ b/views/partials/social.html
@@ -1,4 +1,9 @@
 <div class="article__share" data-trackable="share">
+  {{#if shared}}
+    <div class="article__share-share-message">
+      This article has been gifted to you by an FT Subscriber.
+    </div>
+  {{/if}}
   {{#if @root.flags.articleShareButtons}}
 
     {{#if @root.flags.ftlabsurlsharing}}


### PR DESCRIPTION
If a user came to an article because somebody shared it with them with a share token, we want to display a generic message to mention this to the user.