### PR TITLE
fix pod mapping with empty main image

### DIFF
--- a/server/mappings/article-pod-mapping-v3.js
+++ b/server/mappings/article-pod-mapping-v3.js
@@ -14,7 +14,7 @@ module.exports = function articlePodMapping(article) {
 		subheading: Array.isArray(article.summaries) ? article.summaries[0] : null,
 	};
 
-	if (article.mainImage) {
+	if (Object.keys(article.mainImage).length > 0) {
 		Object.assign(article.mainImage, nImageOptions, { alt: article.mainImage.description });
 	}
 

--- a/test/server/mappings/article-pod-mapping-v3.test.js
+++ b/test/server/mappings/article-pod-mapping-v3.test.js
@@ -3,6 +3,7 @@
 'use strict';
 
 const expect = require('chai').expect;
+const _ = require('lodash');
 const subject = require('../../../server/mappings/article-pod-mapping-v3');
 const fixture = require('../../fixtures/v3-elastic-article-found').docs[0]._source;
 
@@ -24,4 +25,15 @@ describe('Article Pod Mapping V3', () => {
         expect(result.mainImage).to.include.keys('srcset', 'alt');
     });
 
+    describe('article with no main image', () => {
+
+        let fixtureNoMainImage = _.clone(fixture);
+        fixtureNoMainImage.mainImage = {};
+        let resultNoMainImage = subject(fixtureNoMainImage);
+
+        it('does not decorate an empty main image with n-image component options', () => {
+            expect(resultNoMainImage.mainImage).to.not.include.keys('srcset', 'alt');
+        });
+
+    });
 });


### PR DESCRIPTION
- mapping was decorating an empty mainImage object with n-image options.
- this fixes that (and has a test so it doesn't happen again!)