### PR TITLE
related-boxes (the new promo-boxes)

### DIFF
--- a/client/components/article/_main.scss
+++ b/client/components/article/_main.scss
@@ -288,3 +288,4 @@
 @import 'quotes';
 @import 'genre-styles';
 @import 'big-number';
+@import 'related-box';

--- a/client/components/article/_promo-box.scss
+++ b/client/components/article/_promo-box.scss
@@ -24,7 +24,7 @@
 }
 
 .promo-box__title__name {
-	@include nTypeFoxtrot(3);
+	@include oTypographySerifDisplay(m);
 	display: inline-block;
 	padding: 10px;
 	color: getColor('cold-1');
@@ -67,7 +67,9 @@
 }
 
 .promo-box__headline {
-	@include nTypeBravo(2);
+	@include oTypographySansDataBold(l);
+	font-size: 26px;
+	line-height: 27px;
 	margin-top: 10px;
 	color: getColor('cold-3');
 	p {

--- a/client/components/article/_related-box.scss
+++ b/client/components/article/_related-box.scss
@@ -1,0 +1,64 @@
+.related-box {
+	&:after {
+		content: '';
+		display: table;
+		clear: both;
+	}
+}
+
+.related-box__title {
+	margin-top: -48px;
+}
+
+.related-box__title__name {
+	@include oTypographySerifDisplay(m);
+	display: inline-block;
+	padding: 10px;
+	color: getColor('cold-1');
+	background-color: getColor('pink');
+	font-weight: 900;
+	a {
+		color: getColor('cold-1');
+		border-bottom: 0;
+		text-decoration: none;
+	}
+}
+
+.related-box__wrapper {
+	position: relative;
+	float: left;
+	margin-top: 13px;
+	padding: 15px;
+	padding-top: 24px;
+	border: 1px solid getColor('warm-3');
+}
+
+.related-box__headline {
+	@include oTypographySansDataBold(l);
+	font-size: 26px;
+	line-height: 27px;
+	margin-top: 10px;
+	color: getColor('cold-3');
+	p {
+		margin: 0;
+	}
+}
+
+.related-box__content {
+	display: inline;
+	p {
+		margin: 5px 0 0;
+	}
+}
+
+.related-box__image {
+	margin: 12px 0;
+
+	img {
+		display: block;
+		max-width: 100%;
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+}

--- a/server/stylesheets/main.xsl
+++ b/server/stylesheets/main.xsl
@@ -16,6 +16,7 @@
     <xsl:include href="links.xsl" />
     <xsl:include href="promo-box.xsl" />
     <xsl:include href="pull-quotes.xsl" />
+    <xsl:include href="related-box.xsl" />
     <xsl:include href="slideshow.xsl" />
     <xsl:include href="subheaders.xsl" />
     <xsl:include href="tables.xsl" />

--- a/server/stylesheets/related-box.xsl
+++ b/server/stylesheets/related-box.xsl
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+
+  <xsl:template match="/html/body/ft-related">
+    <aside data-trackable="related-box" role="complementary">
+
+      <xsl:variable name="type">
+        <xsl:choose>
+          <xsl:when test="substring(@type, string-length(@type) - 6) = 'Article'">article</xsl:when>
+          <xsl:otherwise></xsl:otherwise>
+        </xsl:choose>
+      </xsl:variable>
+
+      <xsl:variable name="class-type">
+        <xsl:choose>
+          <xsl:when test="$type = 'article'"> related-box__article</xsl:when>
+          <xsl:otherwise></xsl:otherwise>
+        </xsl:choose>
+      </xsl:variable>
+
+      <xsl:variable name="class-fetch">
+        <xsl:choose>
+          <xsl:when test="$type = 'article' and current()[@url]"> to-fetch</xsl:when>
+          <xsl:otherwise></xsl:otherwise>
+        </xsl:choose>
+      </xsl:variable>
+
+      <xsl:attribute name="class">
+        <xsl:value-of select="concat('related-box', $class-type, $class-fetch)" />
+      </xsl:attribute>
+
+      <xsl:if test="$type = 'article' and current()[@url]">
+        <xsl:attribute name="uuid">
+          <xsl:value-of select="substring(@url, string-length(@url) - 35)" />
+        </xsl:attribute>
+      </xsl:if>
+
+      <div class="related-box__wrapper">
+          <xsl:if test="$type != 'article'">
+            <xsl:apply-templates select="current()/title" mode="related-box-title" />
+            <xsl:apply-templates select="current()/headline" mode="related-box-headline" >
+              <xsl:with-param name="url" select="@url" />
+            </xsl:apply-templates>
+            <xsl:apply-templates select="current()/media/img" mode="related-box-image" >
+              <xsl:with-param name="url" select="@url" />
+            </xsl:apply-templates>
+            <xsl:apply-templates />
+            <xsl:if test="current()[@url]">
+              <div>
+                <a href="{@url}" class="related-box__link" data-trackable="link-read-more">Read more</a>
+              </div>
+            </xsl:if>
+          </xsl:if>
+      </div>
+
+    </aside>
+
+  </xsl:template>
+
+  <xsl:template match="title" mode="related-box-title">
+    <div class="related-box__title">
+      <div class="related-box__title__name">
+        <xsl:value-of select="current()/text()" />
+      </div>
+    </div>
+  </xsl:template>
+
+  <xsl:template match="title" />
+
+  <xsl:template match="headline" mode="related-box-headline">
+    <xsl:param name="url" />
+
+    <div class="related-box__headline">
+      <xsl:choose>
+        <xsl:when test="$url">
+          <a class="related-box__headline--link" data-trackable="link-headline" href="{$url}">
+            <xsl:value-of select="current()/text()" />
+          </a>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="current()/text()" />
+        </xsl:otherwise>
+      </xsl:choose>
+    </div>
+  </xsl:template>
+
+  <xsl:template match="headline" />
+
+  <xsl:template match="ft-related/media/img" mode="related-box-image">
+    <xsl:param name="url" />
+    <xsl:variable name="maxWidth" select="300" />
+
+    <div class="related-box__image">
+      <xsl:choose>
+        <xsl:when test="$url">
+          <a class="related-box__image--link" data-trackable="link-image" href="{$url}">
+            <xsl:choose>
+              <xsl:when test="count(current()[@width][@height]) = 1">
+                <xsl:apply-templates select="current()" mode="placehold-image">
+                    <xsl:with-param name="maxWidth" select="$maxWidth" />
+                </xsl:apply-templates>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:apply-templates select="current()" mode="dont-placehold-image">
+                    <xsl:with-param name="maxWidth" select="$maxWidth" />
+                </xsl:apply-templates>
+              </xsl:otherwise>
+            </xsl:choose>
+          </a>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:choose>
+            <xsl:when test="count(current()[@width][@height]) = 1">
+              <xsl:apply-templates select="current()" mode="placehold-image">
+                <xsl:with-param name="maxWidth" select="$maxWidth" />
+              </xsl:apply-templates>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:apply-templates select="current()" mode="dont-placehold-image">
+                <xsl:with-param name="maxWidth" select="$maxWidth" />
+              </xsl:apply-templates>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:otherwise>
+      </xsl:choose>
+    </div>
+  </xsl:template>
+
+  <xsl:template match="ft-related/media/img" />
+  <xsl:template match="ft-related/media" />
+
+  <xsl:template match="intro">
+    <div class="related-box__content">
+      <xsl:apply-templates />
+    </div>
+  </xsl:template>
+
+
+</xsl:stylesheet>

--- a/server/transforms/related-box.js
+++ b/server/transforms/related-box.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const $ = require('cheerio');
+const articlePodMapping = require('../mappings/article-pod-mapping-v3');
+const api = require('next-ft-api-client');
+const fetchres = require('fetchres');
+
+function extractUuid ($relatedArticles) {
+	return $relatedArticles.map(function () {
+			return $(this).attr('uuid');
+	}).get();
+}
+
+// TO DO move this into a helper - used in multiple places
+function getArticle (uuids) {
+	return api.content({
+		uuid: uuids,
+		index: 'v3_api_v2'
+	})
+		// Some things aren't in CAPI v3 (e.g. Syndicated content)
+		.catch(function(error) {
+			if (fetchres.originatedError(error)) {
+				return;
+			} else {
+				throw error;
+			}
+		});
+}
+
+// TO DO convert these to templates??
+function createHtml (article) {
+	return [`${article.mainImage ? articleMainImage(article) : ''}`,
+		`<div class="related-box__headline"><a class="related-box__headline--link" data-trackable="link-headline" href="${article.url}">${article.title}</a></div>`,
+		`<div class="related-box__content"><p>${article.subheading}</p></div><div>`,
+		`<a href="${article.url}" class="related-box__link" data-trackable="link-read-more">Read more</a></div>`
+	].join('');
+}
+
+function articleMainImage (article) {
+	return [`<div class="related-box__image"><a class="related-box__image--link" data-trackable="link-image" href="${article.url}">`,
+		`<div class="article-image__placeholder" style="padding-top:${article.mainImage.paddingTop}">`,
+		`<img alt="${article.mainImage.alt}" src="https://next-geebee.ft.com/image/v1/images/raw/${article.mainImage.url}?source=next&amp;fit=scale-down&amp;width=300"></div></a></div>`
+	].join('');
+
+}
+
+module.exports = function($body) {
+	let $relatedArticles = $body('aside.to-fetch.related-box__article');
+	const uuids = extractUuid($relatedArticles);
+	return getArticle(uuids)
+		.then(articles => [].concat(articles).map(article => articlePodMapping(article)))
+		.then(mappedArticles => {
+			let articleHtmlArray = [];
+			mappedArticles.forEach(article => {
+				if (article.mainImage) {
+					article.mainImage.paddingTop = 100 / Math.max(300, article.mainImage.width) * article.mainImage.height;
+					article.mainImage.alt = '';
+				}
+				articleHtmlArray.push(createHtml(article));
+			});
+			articleHtmlArray.forEach((articleHtml, i) => {
+				$relatedArticles.eq(i).children().first().append($(articleHtml));
+			})
+			return $body;
+		});
+};

--- a/test/server/stylesheets/related-box.test.js
+++ b/test/server/stylesheets/related-box.test.js
@@ -1,0 +1,114 @@
+/* global describe, it */
+'use strict';
+
+const transform = require('./transform-helper');
+require('chai').should();
+
+describe('Related Box', () => {
+
+	it('should put in the appropriate classes for a related box that is an article with no mark up', () => {
+		return transform(
+			'<ft-related type="http://www.ft.com/ontology/content/Article" url="http://api.ft.com/content/e539eab8-8c83-11e5-8be4-3506bf20cc2b"></ft-related>'
+		)
+		.then(transformedXml => {
+			transformedXml.should.equal(
+				'<aside data-trackable="related-box" role="complementary" class="related-box related-box__article to-fetch" uuid="e539eab8-8c83-11e5-8be4-3506bf20cc2b">' +
+					'<div class="related-box__wrapper"></div>' +
+				'</aside>\n'
+			);
+		});
+	});
+
+	it('should put in the appropriate mark up for a related box that is not an article with existing mark up - no title', () => {
+		return transform(
+			'<ft-related url="https://live.ft.com/Events/2015/FT-Property-Summit-2015">' +
+				'<media><img src="http://com.ft.imagepublish.prod.s3.amazonaws.com/aa4eec2e-1bfd-11e5-8201-cbdb03d71480" alt="Housing market economic dashboard" longdesc="" width="2048" height="1152" /></media>' +
+				'<headline>9th Annual Property Summit</headline>' +
+				'<intro><p>The Financial Times is delighted to present the 9th annual <strong>FT Property Summit</strong></p>' +
+				'<p>This will bring together global investors, occupiers, lenders and developers to explore the opportunities available in the UK commercial property market</p></intro>' +
+			'</ft-related>'
+		)
+		.then(transformedXml => {
+			transformedXml.should.equal(
+				'<aside data-trackable="related-box" role="complementary" class="related-box">' +
+					'<div class="related-box__wrapper">' +
+						'<div class="related-box__headline"><a class="related-box__headline--link" data-trackable="link-headline" href="https://live.ft.com/Events/2015/FT-Property-Summit-2015">9th Annual Property Summit</a></div>' +
+						'<div class="related-box__image"><a class="related-box__image--link" data-trackable="link-image" href="https://live.ft.com/Events/2015/FT-Property-Summit-2015"><div class="article-image__placeholder" style="padding-top:56.25%;">' +
+						'<img alt="Housing market economic dashboard" src="https://next-geebee.ft.com/image/v1/images/raw/http://com.ft.imagepublish.prod.s3.amazonaws.com/aa4eec2e-1bfd-11e5-8201-cbdb03d71480?source=next&amp;fit=scale-down&amp;width=300"></div></a></div>' +
+						'<div class="related-box__content"><p>The Financial Times is delighted to present the 9th annual <strong>FT Property Summit</strong></p>' +
+						'<p>This will bring together global investors, occupiers, lenders and developers to explore the opportunities available in the UK commercial property market</p></div>' +
+					'<div><a href="https://live.ft.com/Events/2015/FT-Property-Summit-2015" class="related-box__link" data-trackable="link-read-more">Read more</a></div></div>' +
+				'</aside>\n'
+			);
+		});
+	});
+
+	it('should put in the appropriate mark up for a related box that is not an article with existing mark up - no url', () => {
+		return transform(
+			'<ft-related>' +
+				'<media><img src="http://com.ft.imagepublish.prod.s3.amazonaws.com/aa4eec2e-1bfd-11e5-8201-cbdb03d71480" alt="Housing market economic dashboard" longdesc="" width="2048" height="1152" /></media>' +
+				'<headline>9th Annual Property Summit</headline>' +
+				'<intro><p>The Financial Times is delighted to present the 9th annual <strong>FT Property Summit</strong></p>' +
+				'<p>This will bring together global investors, occupiers, lenders and developers to explore the opportunities available in the UK commercial property market</p></intro>' +
+			'</ft-related>'
+		)
+		.then(transformedXml => {
+			transformedXml.should.equal(
+				'<aside data-trackable="related-box" role="complementary" class="related-box">' +
+					'<div class="related-box__wrapper">' +
+						'<div class="related-box__headline">9th Annual Property Summit</div>' +
+						'<div class="related-box__image"><div class="article-image__placeholder" style="padding-top:56.25%;">' +
+						'<img alt="Housing market economic dashboard" src="https://next-geebee.ft.com/image/v1/images/raw/http://com.ft.imagepublish.prod.s3.amazonaws.com/aa4eec2e-1bfd-11e5-8201-cbdb03d71480?source=next&amp;fit=scale-down&amp;width=300"></div></div>' +
+						'<div class="related-box__content"><p>The Financial Times is delighted to present the 9th annual <strong>FT Property Summit</strong></p>' +
+						'<p>This will bring together global investors, occupiers, lenders and developers to explore the opportunities available in the UK commercial property market</p></div>' +
+					'</div>' +
+				'</aside>\n'
+			);
+		});
+	});
+
+	it('should put in the appropriate mark up for a related box that is not an article with existing mark up - with title', () => {
+		return transform(
+			'<ft-related url="https://live.ft.com/Events/2015/FT-Property-Summit-2015">' +
+				'<media><img src="http://com.ft.imagepublish.prod.s3.amazonaws.com/aa4eec2e-1bfd-11e5-8201-cbdb03d71480" alt="Housing market economic dashboard" longdesc="" width="2048" height="1152" /></media>' +
+				'<title>FT Property Summit 2015</title>' +
+				'<headline>9th Annual Property Summit</headline>' +
+				'<intro><p>The Financial Times is delighted to present the 9th annual <strong>FT Property Summit</strong></p>' +
+				'<p>This will bring together global investors, occupiers, lenders and developers to explore the opportunities available in the UK commercial property market</p></intro>' +
+			'</ft-related>'
+		)
+		.then(transformedXml => {
+			transformedXml.should.equal(
+				'<aside data-trackable="related-box" role="complementary" class="related-box">' +
+					'<div class="related-box__wrapper">' +
+						'<div class="related-box__title"><div class="related-box__title__name">FT Property Summit 2015</div></div>' +
+						'<div class="related-box__headline"><a class="related-box__headline--link" data-trackable="link-headline" href="https://live.ft.com/Events/2015/FT-Property-Summit-2015">9th Annual Property Summit</a></div>' +
+						'<div class="related-box__image"><a class="related-box__image--link" data-trackable="link-image" href="https://live.ft.com/Events/2015/FT-Property-Summit-2015"><div class="article-image__placeholder" style="padding-top:56.25%;">' +
+						'<img alt="Housing market economic dashboard" src="https://next-geebee.ft.com/image/v1/images/raw/http://com.ft.imagepublish.prod.s3.amazonaws.com/aa4eec2e-1bfd-11e5-8201-cbdb03d71480?source=next&amp;fit=scale-down&amp;width=300"></div></a></div>' +
+						'<div class="related-box__content"><p>The Financial Times is delighted to present the 9th annual <strong>FT Property Summit</strong></p>' +
+						'<p>This will bring together global investors, occupiers, lenders and developers to explore the opportunities available in the UK commercial property market</p></div>' +
+					'<div><a href="https://live.ft.com/Events/2015/FT-Property-Summit-2015" class="related-box__link" data-trackable="link-read-more">Read more</a></div></div>' +
+				'</aside>\n'
+			);
+		});
+	});
+
+	it('should remove mark up for a related box that is an article with existing mark up', () => {
+		return transform(
+			'<ft-related type="http://www.ft.com/ontology/content/Article" url="http://api.ft.com/content/e539eab8-8c83-11e5-8be4-3506bf20cc2b">' +
+				'<media><img src="http://com.ft.imagepublish.prod.s3.amazonaws.com/aa4eec2e-1bfd-11e5-8201-cbdb03d71480" alt="Housing market economic dashboard" longdesc="" width="2048" height="1152" /></media>' +
+				'<headline>9th Annual Property Summit</headline>' +
+				'<intro><p>The Financial Times is delighted to present the 9th annual <strong>FT Property Summit</strong></p>' +
+				'<p>This will bring together global investors, occupiers, lenders and developers to explore the opportunities available in the UK commercial property market</p></intro>' +
+			'</ft-related>'
+		)
+		.then(transformedXml => {
+			transformedXml.should.equal(
+				'<aside data-trackable="related-box" role="complementary" class="related-box related-box__article to-fetch" uuid="e539eab8-8c83-11e5-8be4-3506bf20cc2b">' +
+					'<div class="related-box__wrapper"></div>' +
+				'</aside>\n'
+			);
+		});
+	});
+
+});

--- a/test/server/transforms/related-box.test.js
+++ b/test/server/transforms/related-box.test.js
@@ -1,0 +1,142 @@
+/*global describe, it*/
+"use strict";
+
+require('chai').should();
+const cheerio = require('cheerio');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+
+const stubs = {content: null};
+
+const subject = proxyquire('../../../server/transforms/related-box', {
+	'next-ft-api-client': stubs,
+	'../mappings/article-pod-mapping-v3': (article) => article
+});
+
+const relatedArticleAsideFirst = '<aside data-trackable="related-article" role="complementary" class="related-box related-box__article to-fetch" uuid="765af108-8c7b-11e5-a549-b89a1dfede9b"><div class="related-box__wrapper"></div></aside>';
+const relatedArticleAsideSecond = '<aside data-trackable="related-article" role="complementary" class="related-box related-box__article to-fetch" uuid="765af108-8c7b-11e5-a549-0rand0mchar5"><div class="related-box__wrapper"></div></aside>';
+
+const articleFirst = {
+	title: "Belgian PM threatens to close ‘certain radical mosques’",
+	subheading: "Security services home in on deprived Molenbeek neighbourhood of Brussels",
+	url: "/content/765af108-8c7b-11e5-a549-b89a1dfede9b",
+	mainImage:
+		{alt: "Police officers man a cordon as an operation takes place in the Molenbeek district of Brussels on November 16, 2015. AFP PHOTO / JOHN THYSJOHN THYS/AFP/Getty Images",
+		url: "http://com.ft.imagepublish.prod.s3.amazonaws.com/00933f30-8c52-11e5-a549-b89a1dfede9b",
+		width: 2048,
+		height: 1152}
+};
+
+const articleSecond = {
+	title: "This is the headline",
+	subheading: "Here lies the subheading or standfirst",
+	url: "/content/765af108-8c7b-11e5-a549-0rand0mchar5",
+	mainImage:
+		{alt: "This will be blanked",
+		url: "http://com.ft.imagepublish.prod.s3.amazonaws.com/00933f30-8c52-11e5-a549-0rand0mchar5",
+		width: 230,
+		height: 129}
+};
+
+const articleThird = {
+	title: "Belgian PM threatens to close ‘certain radical mosques’",
+	subheading: "Security services home in on deprived Molenbeek neighbourhood of Brussels",
+	url: "/content/765af108-8c7b-11e5-a549-b89a1dfede9b",
+};
+
+const expectedHtml1 = [
+	'<body><aside data-trackable="related-article" role="complementary" class="related-box related-box__article to-fetch" uuid="765af108-8c7b-11e5-a549-b89a1dfede9b">',
+	'<div class="related-box__wrapper">',
+	'<div class="related-box__image"><a class="related-box__image--link" data-trackable="link-image" href="/content/765af108-8c7b-11e5-a549-b89a1dfede9b">',
+	'<div class="article-image__placeholder" style="padding-top:56.25">',
+	'<img alt="" src="https://next-geebee.ft.com/image/v1/images/raw/http://com.ft.imagepublish.prod.s3.amazonaws.com/00933f30-8c52-11e5-a549-b89a1dfede9b?source=next&amp;fit=scale-down&amp;width=300">',
+	'</div></a></div>',
+	'<div class="related-box__headline"><a class="related-box__headline--link" data-trackable="link-headline" href="/content/765af108-8c7b-11e5-a549-b89a1dfede9b">Belgian PM threatens to close &#x2018;certain radical mosques&#x2019;</a></div>',
+	'<div class="related-box__content"><p>Security services home in on deprived Molenbeek neighbourhood of Brussels</p></div>',
+	'<div><a href="/content/765af108-8c7b-11e5-a549-b89a1dfede9b" class="related-box__link" data-trackable="link-read-more">Read more</a></div>',
+	'</div></aside>'
+].join('');
+
+const expectedHtml2 = [
+	'<aside data-trackable="related-article" role="complementary" class="related-box related-box__article to-fetch" uuid="765af108-8c7b-11e5-a549-0rand0mchar5">',
+	'<div class="related-box__wrapper">',
+	'<div class="related-box__image"><a class="related-box__image--link" data-trackable="link-image" href="/content/765af108-8c7b-11e5-a549-0rand0mchar5">',
+	'<div class="article-image__placeholder" style="padding-top:43">',
+	'<img alt="" src="https://next-geebee.ft.com/image/v1/images/raw/http://com.ft.imagepublish.prod.s3.amazonaws.com/00933f30-8c52-11e5-a549-0rand0mchar5?source=next&amp;fit=scale-down&amp;width=300">',
+	'</div></a></div>',
+	'<div class="related-box__headline"><a class="related-box__headline--link" data-trackable="link-headline" href="/content/765af108-8c7b-11e5-a549-0rand0mchar5">This is the headline</a></div>',
+	'<div class="related-box__content"><p>Here lies the subheading or standfirst</p></div>',
+	'<div><a href="/content/765af108-8c7b-11e5-a549-0rand0mchar5" class="related-box__link" data-trackable="link-read-more">Read more</a></div>',
+	'</div></aside></body>'
+].join('');
+
+const expectedHtml3 = [
+	'<body><aside data-trackable="related-article" role="complementary" class="related-box related-box__article to-fetch" uuid="765af108-8c7b-11e5-a549-b89a1dfede9b">',
+	'<div class="related-box__wrapper">',
+	'<div class="related-box__headline"><a class="related-box__headline--link" data-trackable="link-headline" href="/content/765af108-8c7b-11e5-a549-b89a1dfede9b">Belgian PM threatens to close &#x2018;certain radical mosques&#x2019;</a></div>',
+	'<div class="related-box__content"><p>Security services home in on deprived Molenbeek neighbourhood of Brussels</p></div>',
+	'<div><a href="/content/765af108-8c7b-11e5-a549-b89a1dfede9b" class="related-box__link" data-trackable="link-read-more">Read more</a></div>',
+	'</div></aside></body>'
+].join('');
+
+describe('Related Box Transform', function() {
+
+	let results;
+
+	describe('Single article related-box', function() {
+
+		before(function() {
+
+			const $ = cheerio.load(`<body>${relatedArticleAsideFirst}</body>`);
+
+			stubs.content = sinon.stub().returns(
+				Promise.resolve(articleFirst)
+			);
+
+			return subject($)
+				.then(result => results = result.html());
+		});
+
+		it('should return the required article', function() {
+			results.should.equal(expectedHtml1.concat(['</body>']));
+		});
+
+	});
+
+	describe('Mulitple article related-box', function() {
+
+		before(function() {
+			const $ = cheerio.load(`<body>${relatedArticleAsideFirst}${relatedArticleAsideSecond}</body>`);
+
+			stubs.content = sinon.stub().returns(
+				Promise.resolve([articleFirst, articleSecond])
+			);
+
+			return subject($)
+				.then(result => results = result.html());
+		});
+
+		it('should return the required articles', function() {
+			results.should.equal(expectedHtml1.concat(expectedHtml2));
+		});
+
+	});
+
+	describe('Related box for article without an image', () => {
+		before(function() {
+			const $ = cheerio.load(`<body>${relatedArticleAsideFirst}</body>`);
+
+			stubs.content = sinon.stub().returns(
+				Promise.resolve([articleThird])
+			);
+
+			return subject($)
+				.then(result => results = result.html());
+		});
+
+		it('should return the required structure without any image', () => {
+			results.should.equal(expectedHtml3);
+		});
+	});
+
+});


### PR DESCRIPTION
TO DO
- [x] XSLT - identify related items that are articles with uuids that we can fetch later
- [x] XSLT - strip any existing markup from articles we will fetch later.
- [x] XSLT - transform for presentation any other `<ft-related>` items without amending content except for adding links to image / headline and a Read More if `<ft-related>` has a url attribute.
- [x] Cheerio - Fetch the article(s) and create the html within the body
- [x] Cheerio - Ensure it works for an article without an image
- [x] Styling - bring into line with promo-box styling - can amend later once live