### PR TITLE
Clear left inlines

### DIFF
--- a/client/components/article/_images.scss
+++ b/client/components/article/_images.scss
@@ -12,6 +12,7 @@
 
 	@include oGridRespondTo(M) {
 		float: left;
+		clear: left;
 		max-width: 100%;
 		margin-right: 1em;
 	}


### PR DESCRIPTION
E.g. https://next.ft.com/content/3c92a3ec-8f6b-11e5-a549-b89a1dfede9b

Before:-
![screen shot 2015-11-20 at 19 14 38](https://cloud.githubusercontent.com/assets/825088/11309313/1761fc26-8fbb-11e5-8c42-897b211063ac.png)

After:-
![screen shot 2015-11-20 at 19 15 48](https://cloud.githubusercontent.com/assets/825088/11309320/216fd4c2-8fbb-11e5-8718-4d75eb28e398.png)
