### PR TITLE
remove default title and quick style on big number

### DIFF
--- a/client/components/article/_big-number.scss
+++ b/client/components/article/_big-number.scss
@@ -17,5 +17,6 @@
 	}
 	.o-big-number__content {
 		@include oTypographySansData(m);
+		font-size: 16px;
 	}
 }

--- a/server/stylesheets/promo-box.xsl
+++ b/server/stylesheets/promo-box.xsl
@@ -14,7 +14,6 @@
         <xsl:when test="($contentParas > $expanderParaBreak) and (($imageCount > 0 and $wordCount > $expanderWordImage) or ($imageCount = 0 and $wordCount > $expanderWordNoImage))">
           <aside class="promo-box ng-inline-element o-expander" data-trackable="promobox" role="complementary" data-o-component="o-expander" data-o-expander-shrink-to="0" data-o-expander-count-selector=".promo-box__content__extension">
             <div class="promo-box__wrapper">
-              <xsl:apply-templates select="current()" mode="default-title" />
               <xsl:apply-templates />
             </div>
           </aside>
@@ -22,7 +21,6 @@
         <xsl:otherwise>
           <aside class="promo-box ng-inline-element" data-trackable="promobox" role="complementary">
             <div class="promo-box__wrapper">
-              <xsl:apply-templates select="current()" mode="default-title" />
               <xsl:apply-templates />
             </div>
           </aside>
@@ -30,22 +28,13 @@
       </xsl:choose>
     </xsl:template>
 
-    <xsl:template match="promo-box" mode="default-title">
+    <xsl:template match="promo-title">
       <div class="promo-box__title">
         <div class="promo-box__title__name">
-          <xsl:choose>
-            <xsl:when test="count(current()/promo-title) = 0">
-              <xsl:text>Related Content</xsl:text>
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:apply-templates select="current()/promo-title" mode="extract-content" />
-            </xsl:otherwise>
-          </xsl:choose>
+          <xsl:apply-templates select="current()" mode="extract-content" />
         </div>
       </div>
     </xsl:template>
-
-    <xsl:template match="promo-title"/>
 
     <xsl:template match="promo-headline">
       <div class="promo-box__headline">

--- a/test/server/stylesheets/promo-box.test.js
+++ b/test/server/stylesheets/promo-box.test.js
@@ -186,9 +186,6 @@ describe('Promo-boxes', function() {
 			transformedXml.should.equal(
 				'<aside class="promo-box ng-inline-element" data-trackable="promobox" role="complementary">' +
 					'<div class="promo-box__wrapper">' +
-						'<div class="promo-box__title">' +
-							'<div class="promo-box__title__name">Related Content</div>' +
-						'</div>' +
 						'<div class="promo-box__headline">Greece debt crisis</div>' +
 						'<div class="promo-box__image">' +
 							'<img alt="" src="https://next-geebee.ft.com/image/v1/images/raw/http://com.ft.imagepublish.prod.s3.amazonaws.com/1871b094-3b7d-11e5-bbd1-b37bc06f590c?source=next&amp;fit=scale-down&amp;width=300">' +
@@ -228,7 +225,6 @@ describe('Promo-boxes', function() {
 			transformedXml.should.equal(
 				'<aside class="promo-box ng-inline-element" data-trackable="promobox" role="complementary">' +
 					'<div class="promo-box__wrapper">' +
-						'<div class="promo-box__title"><div class="promo-box__title__name">Related Content</div></div>' +
 						'<div class="promo-box__headline"><a href="/c9175806-3054-11e5-8873-775ba7c2ea3d" data-trackable="link">Greece crisis tests start-ups’ staying power</a></div>' +
 					'</div>' +
 				'</aside>\n'


### PR DESCRIPTION
As discussed with Mark Alderson - remove default title for promobox
up the font size on big number supporting text to 16px