### PR TITLE
stop article from failing in suggested read if no primaryTag

### DIFF
--- a/server/controllers/article-helpers/suggested.js
+++ b/server/controllers/article-helpers/suggested.js
@@ -7,7 +7,7 @@ const articlePodMapping = require('../../mappings/article-pod-mapping-v3');
 module.exports = function(articleId, storyPackageIds, primaryTag) {
 	let suggestedArticleFetch;
 
-	if (storyPackageIds.length < 5) {
+	if (primaryTag && storyPackageIds.length < 5) {
 		suggestedArticleFetch = api.search({
 			filter: ['metadata.idV1', primaryTag.id],
 			fields: ['id'],


### PR DESCRIPTION
Fixing this issue: https://app.getsentry.com/nextftcom/ft-next-article/issues/98153059/