### PR TITLE
handle thin images better

### DIFF
--- a/client/components/article/_images.scss
+++ b/client/components/article/_images.scss
@@ -10,13 +10,19 @@
 
 .article-image--inline {
 
-	@include oGridRespondTo(M) {
+	@include oGridRespondTo(S) {
 		float: left;
 		clear: left;
 		max-width: 100%;
 		margin-right: 1em;
 	}
 
+}
+
+.article-image--thin {
+		float: left;
+		max-width: 100%;
+		margin-right: 1em;
 }
 
 .article-image__placeholder {

--- a/server/stylesheets/external-image.xsl
+++ b/server/stylesheets/external-image.xsl
@@ -26,6 +26,7 @@
     <xsl:template match="img" mode="figure">
         <xsl:variable name="variation">
             <xsl:choose>
+                <xsl:when test="@width &lt;= 150">thin</xsl:when>
                 <xsl:when test="@width &lt;= 350">inline</xsl:when>
                 <xsl:when test="(@width &lt; @height) and (@width &lt; 600)">inline</xsl:when>
                 <xsl:when test="@width &lt; 700">center</xsl:when>

--- a/test/server/stylesheets/external-image.test.js
+++ b/test/server/stylesheets/external-image.test.js
@@ -112,6 +112,29 @@ describe('External images', () => {
 
 	describe('layout variations', () => {
 
+		it('applies thin variation when source image width is very small', () => {
+			return transform(
+					'<html>' +
+						'<body>' +
+							'<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>' +
+							'<p><img src="http://my-image/image.jpg" width="100" height="160" /></p>' +
+							'<p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>' +
+						'</body>' +
+					'</html>\n'
+				)
+				.then((transformedXml) => {
+					expect(transformedXml).to.equal(
+						'<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>' +
+						'<figure class="article-image article-image--thin" style="width:100px;">' +
+							'<div class="article-image__placeholder" style="padding-top:160%;">' +
+								'<img alt="" src="https://next-geebee.ft.com/image/v1/images/raw/http://my-image/image.jpg?source=next&amp;fit=scale-down&amp;width=100">' +
+							'</div>' +
+						'</figure>' +
+						'<p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>\n'
+					);
+				});
+		});
+
 		it('applies inline variation when source image is small', () => {
 			return transform(
 					'<html>' +


### PR DESCRIPTION
Some images are thin (width < 150px). Currently these are treated as inline images and when in M screen size and below, they are centred full width.

eg.  on iPhone 5
![screen shot 2015-12-01 at 14 42 24](https://cloud.githubusercontent.com/assets/8938227/11503707/d136b8c2-9839-11e5-9392-15107fd09e1b.png)

![screen shot 2015-12-01 at 14 41 57](https://cloud.githubusercontent.com/assets/8938227/11503711/d9177112-9839-11e5-80d3-ed317ddc2afc.png)


This PR introduces a new image variant of 'thin' for images with width < 150px and keeps them inline regardless of screen width.

eg. on iPhone 5

![screen shot 2015-12-01 at 14 33 33](https://cloud.githubusercontent.com/assets/8938227/11503453/9cfd2b1e-9838-11e5-9989-01ba439e383f.png)

![screen shot 2015-12-01 at 14 34 00](https://cloud.githubusercontent.com/assets/8938227/11503459/a552d05c-9838-11e5-9fa9-55e257fe1c89.png)

It also proposed to change the breakpoint at which inline images are full width centred, from M to S.

Eg on a Nexus 7 (portrait)

Current

![screen shot 2015-12-01 at 14 39 50](https://cloud.githubusercontent.com/assets/8938227/11503648/88530fe8-9839-11e5-9748-73e59c614879.png)

Proposed

![screen shot 2015-12-01 at 14 40 06](https://cloud.githubusercontent.com/assets/8938227/11503661/9589361a-9839-11e5-8ef6-b65b1a7e15a0.png)




