### PR TITLE
Revert "add follow button to primary tag"

### DIFF
--- a/client/components/article/_main.scss
+++ b/client/components/article/_main.scss
@@ -93,23 +93,15 @@
 	}
 }
 .article__primary-theme {
-	position: relative;
 	margin: 0 0 5px;
 
 	@media print {
 		padding-top: 30px;
 	}
 }
-
-.article__primary-theme .n-myft-ui--follow {
-	position: absolute;
-	top: 0;
-}
-
 .article__primary-theme__link {
 	@include nLinksTopic();
 	@include oTypographySansDataBold(l);
-	padding-right: 15px;
 }
 
 .article__actions {

--- a/views/article.html
+++ b/views/article.html
@@ -26,12 +26,9 @@
 								</p>
 							{{else}}
 								{{#if primaryTag}}
-									<div class="article__primary-theme" data-trackable="primary-theme">
-										<a href="/stream/{{primaryTag.taxonomy}}Id/{{primaryTag.id}}" class="article__primary-theme__link" data-trackable="section-link" aria-label="posted in category {{primaryTag.name}}" data-concept-id="{{primaryTag.id}}">{{primaryTag.name}}</a>
-									{{#if @root.flags.myFtApi}}
-										{{>next-myft-ui/templates/follow version='3' conceptId=primaryTag.id}}
-									{{/if}}
-									</div>
+								<p class="article__primary-theme">
+									<a href="/stream/{{primaryTag.taxonomy}}Id/{{primaryTag.id}}" class="article__primary-theme__link" data-trackable="section-link" aria-label="posted in category {{primaryTag.name}}" data-concept-id="{{primaryTag.id}}">{{primaryTag.name}}</a>
+								</p>
 								{{/if}}
 							{{/if}}
 							<h1 class="article__title">{{title}}</h1>


### PR DESCRIPTION
This reverts commit 8bf85d0a85e65385f6122f103eb884624b341c25.

Feature didn't work as expected in live environment. Was rolled back shortly after go live. This PR is to revert it out of master so subsequent PR's don't promote it, whilst working to understand why it wasn't working.