### PR TITLE
Use margin right rather than padding right to stop border bottom linking up with follow button

### DIFF
--- a/client/components/article/_main.scss
+++ b/client/components/article/_main.scss
@@ -13,7 +13,7 @@
 .article__header-inner {
 	padding-top: 12px;
 
-	@include oGridRespondTo(L) {
+	@include.article__primary-theme__link oGridRespondTo(L) {
 		display: flex;
 	}
 }
@@ -98,7 +98,7 @@
 .article__primary-theme__link {
 	@include nLinksTopic();
 	@include oTypographySansDataBold(l);
-	padding-right: 10px;
+	margin-right: 10px;
 }
 
 .article__actions {

--- a/client/components/article/_main.scss
+++ b/client/components/article/_main.scss
@@ -13,7 +13,7 @@
 .article__header-inner {
 	padding-top: 12px;
 
-	@include.article__primary-theme__link oGridRespondTo(L) {
+	@include oGridRespondTo(L) {
 		display: flex;
 	}
 }


### PR DESCRIPTION
@andygnewman 

Before:
![screen shot 2015-12-05 at 11 23 40](https://cloud.githubusercontent.com/assets/825088/11607547/a79668d0-9b42-11e5-8d27-a13d90fedf64.png)


After:
![screen shot 2015-12-05 at 11 22 17](https://cloud.githubusercontent.com/assets/825088/11607546/9aa98580-9b42-11e5-842c-8618173fd3ec.png)
