### PR TITLE
re-enable nightwatch tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,5 +51,5 @@ provision:
 
 smoke:
 	nbt test-urls ${TEST_APP} --throttle 1;
-	# TODO: re-enable nightwatch, re-enable firefox
-	# export TEST_APP=${TEST_APP}; nbt nightwatch test/browser/tests/* -e ie9,ie11,chrome44,chrome45,iphone6_plus,Android_Nexus7HD
+	# TODO: re-enable firefox
+	export TEST_APP=${TEST_APP}; nbt nightwatch test/browser/tests/* -e ie9,ie11,chrome44,chrome45,iphone6_plus,Android_Nexus7HD


### PR DESCRIPTION
when saucelabs is back online