### PR TITLE
enable multiple <hr>s in the body

### DIFF
--- a/server/transforms/replace-hrs.js
+++ b/server/transforms/replace-hrs.js
@@ -1,4 +1,4 @@
 'use strict';
 module.exports = function(body) {
-	return body.replace(/<p>\s*(?:<strong>)?(?:[-*]{3,}|&hellip;)(?:<\/strong>)?\s*<\/p>/, '<hr />');
+	return body.replace(/<p>\s*(?:<strong>)?(?:[-*]{3,}|&hellip;)(?:<\/strong>)?\s*<\/p>/g, '<hr />');
 };

--- a/test/server/transforms/replace-hrs.test.js
+++ b/test/server/transforms/replace-hrs.test.js
@@ -1,0 +1,18 @@
+/*global describe, it*/
+"use strict";
+
+const replaceHrsTransform = require('../../../server/transforms/replace-hrs');
+
+describe('Replace hrs', () => {
+
+  it('should replace <p>---</p> with an <hr> element', () => {
+    replaceHrsTransform('<p>---</p>').should.equal('<hr />');
+  });
+
+  it('should replace multiple <p>---</p> with <hr> elememnts', () => {
+    const body = '<p>Some text</p><p>---</p><p>Some more text</p><p>---</p><p>The end</p>';
+    const result = '<p>Some text</p><hr /><p>Some more text</p><hr /><p>The end</p>'
+    replaceHrsTransform(body).should.equal(result);
+  });
+
+});


### PR DESCRIPTION
Editorial sometimes use <p>---</p> for an <hr> element.

This change enables multiple replacements following a request from Editorial, plus has (some) test coverage.