### PR TITLE
fixed links for articles in related content boxes

### DIFF
--- a/server/stylesheets/related-box.xsl
+++ b/server/stylesheets/related-box.xsl
@@ -35,22 +35,33 @@
         </xsl:attribute>
       </xsl:if>
 
-      <div class="related-box__wrapper">
-          <!-- To reincorporate if we fetch current version of article <xsl:if test="$type != 'article'"> -->
-            <xsl:apply-templates select="current()/title" mode="related-box-title" />
-            <xsl:apply-templates select="current()/headline" mode="related-box-headline" >
-              <xsl:with-param name="url" select="@url" />
-            </xsl:apply-templates>
-            <xsl:apply-templates select="current()/media/img" mode="related-box-image" >
-              <xsl:with-param name="url" select="@url" />
-            </xsl:apply-templates>
-            <xsl:apply-templates />
-            <xsl:if test="current()[@url]">
-              <div>
-                <a href="{@url}" class="related-box__link" data-trackable="link-read-more">Read more</a>
-              </div>
+      <xsl:variable name="linkurl">
+        <xsl:choose>
+          <xsl:when test="$type = 'article' and current()[@url]">
+            <xsl:value-of select="substring(@url, string-length(@url) - 44)" />
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:if test="@url">
+              <xsl:value-of select="@url" />
             </xsl:if>
-          <!-- </xsl:if> -->
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:variable>
+
+      <div class="related-box__wrapper">
+        <xsl:apply-templates select="current()/title" mode="related-box-title" />
+        <xsl:apply-templates select="current()/headline" mode="related-box-headline" >
+          <xsl:with-param name="linkurl" select="$linkurl" />
+        </xsl:apply-templates>
+        <xsl:apply-templates select="current()/media/img" mode="related-box-image" >
+          <xsl:with-param name="linkurl" select="$linkurl" />
+        </xsl:apply-templates>
+        <xsl:apply-templates />
+        <xsl:if test="$linkurl != ''">
+          <div>
+            <a href="{$linkurl}" class="related-box__link" data-trackable="link-read-more">Read more</a>
+          </div>
+        </xsl:if>
       </div>
 
     </aside>
@@ -68,12 +79,12 @@
   <xsl:template match="title" />
 
   <xsl:template match="headline" mode="related-box-headline">
-    <xsl:param name="url" />
+    <xsl:param name="linkurl" />
 
     <div class="related-box__headline">
       <xsl:choose>
-        <xsl:when test="$url">
-          <a class="related-box__headline--link" data-trackable="link-headline" href="{$url}">
+        <xsl:when test="$linkurl != ''">
+          <a class="related-box__headline--link" data-trackable="link-headline" href="{$linkurl}">
             <xsl:value-of select="current()/text()" />
           </a>
         </xsl:when>
@@ -87,13 +98,13 @@
   <xsl:template match="headline" />
 
   <xsl:template match="ft-related/media/img" mode="related-box-image">
-    <xsl:param name="url" />
+    <xsl:param name="linkurl" />
     <xsl:variable name="maxWidth" select="300" />
 
     <div class="related-box__image">
       <xsl:choose>
-        <xsl:when test="$url">
-          <a class="related-box__image--link" data-trackable="link-image" href="{$url}">
+        <xsl:when test="$linkurl !=''">
+          <a class="related-box__image--link" data-trackable="link-image" href="{$linkurl}">
             <xsl:choose>
               <xsl:when test="count(current()[@width][@height]) = 1">
                 <xsl:apply-templates select="current()" mode="placehold-image">

--- a/test/server/stylesheets/related-box.test.js
+++ b/test/server/stylesheets/related-box.test.js
@@ -14,7 +14,7 @@ describe('Related Box', () => {
 		.then(transformedXml => {
 			transformedXml.should.equal(
 				'<aside data-trackable="related-box" role="complementary" class="related-box ng-inline-element related-box__article to-fetch" uuid="e539eab8-8c83-11e5-8be4-3506bf20cc2b">' +
-					'<div class="related-box__wrapper"><div><a href="http://api.ft.com/content/e539eab8-8c83-11e5-8be4-3506bf20cc2b" class="related-box__link" data-trackable="link-read-more">Read more</a></div></div>' +
+					'<div class="related-box__wrapper"><div><a href="/content/e539eab8-8c83-11e5-8be4-3506bf20cc2b" class="related-box__link" data-trackable="link-read-more">Read more</a></div></div>' +
 				'</aside>\n'
 			);
 		});
@@ -94,8 +94,7 @@ describe('Related Box', () => {
 		});
 	});
 
-	// PENDING until we get the article fetch working
-	xit('should remove mark up for a related box that is an article with existing mark up', () => {
+	it('should remove add the appropriate mark up for a related box that is an article with existing mark up', () => {
 		return transform(
 			'<ft-related type="http://www.ft.com/ontology/content/Article" url="http://api.ft.com/content/e539eab8-8c83-11e5-8be4-3506bf20cc2b">' +
 				'<media><img src="http://com.ft.imagepublish.prod.s3.amazonaws.com/aa4eec2e-1bfd-11e5-8201-cbdb03d71480" alt="Housing market economic dashboard" longdesc="" width="2048" height="1152" /></media>' +
@@ -107,7 +106,13 @@ describe('Related Box', () => {
 		.then(transformedXml => {
 			transformedXml.should.equal(
 				'<aside data-trackable="related-box" role="complementary" class="related-box ng-inline-element related-box__article to-fetch" uuid="e539eab8-8c83-11e5-8be4-3506bf20cc2b">' +
-					'<div class="related-box__wrapper"></div>' +
+					'<div class="related-box__wrapper">' +
+						'<div class="related-box__headline"><a class="related-box__headline--link" data-trackable="link-headline" href="/content/e539eab8-8c83-11e5-8be4-3506bf20cc2b">9th Annual Property Summit</a></div>' +
+						'<div class="related-box__image"><a class="related-box__image--link" data-trackable="link-image" href="/content/e539eab8-8c83-11e5-8be4-3506bf20cc2b"><div class="article-image__placeholder" style="padding-top:56.25%;">' +
+						'<img alt="Housing market economic dashboard" src="https://next-geebee.ft.com/image/v1/images/raw/http://com.ft.imagepublish.prod.s3.amazonaws.com/aa4eec2e-1bfd-11e5-8201-cbdb03d71480?source=next&amp;fit=scale-down&amp;width=300"></div></a></div>' +
+						'<div class="related-box__content"><p>The Financial Times is delighted to present the 9th annual <strong>FT Property Summit</strong></p>' +
+						'<p>This will bring together global investors, occupiers, lenders and developers to explore the opportunities available in the UK commercial property market</p></div>' +
+					'<div><a href="/content/e539eab8-8c83-11e5-8be4-3506bf20cc2b" class="related-box__link" data-trackable="link-read-more">Read more</a></div></div>' +
 				'</aside>\n'
 			);
 		});


### PR DESCRIPTION
urls supplied for articles in related links are in format http://api.ft.com/content/e539eab8-8c83-11e5-8be4-3506bf20cc2b

Need to translate these into something we can use.