### PR TITLE
enable pull quotes to have images

### DIFF
--- a/client/components/article/_promo-box.scss
+++ b/client/components/article/_promo-box.scss
@@ -92,7 +92,8 @@
 }
 
 .promo-box__image,
-.related-box__image {
+.related-box__image
+.pull-quote__image {
 	margin: 12px 0;
 
 	img {

--- a/server/stylesheets/pull-quotes.xsl
+++ b/server/stylesheets/pull-quotes.xsl
@@ -2,19 +2,26 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
     <xsl:template match="pull-quote">
-        <blockquote class="ng-inline-element article__quote article__quote--pull-quote">
-          <div class="pull-quote__quote-marks"></div>
-            <p><xsl:value-of select="pull-quote-text" /></p>
-            <xsl:apply-templates select="pull-quote-source" />
-        </blockquote>
+      <blockquote class="ng-inline-element article__quote article__quote--pull-quote">
+        <div class="pull-quote__quote-marks"></div>
+          <p><xsl:value-of select="pull-quote-text" /></p>
+          <xsl:apply-templates select="pull-quote-source" />
+          <xsl:apply-templates select="pull-quote-image" />
+      </blockquote>
     </xsl:template>
 
     <xsl:template match="pull-quote-source">
-        <xsl:if test="text()">
-            <cite class="article__quote-citation">
-                <xsl:apply-templates select="text()" />
-            </cite>
-        </xsl:if>
+      <xsl:if test="text()">
+        <cite class="article__quote-citation">
+          <xsl:apply-templates select="text()" />
+        </cite>
+      </xsl:if>
+    </xsl:template>
+
+    <xsl:template match="pull-quote-image">
+      <div class="pull-quote__image">
+        <xsl:apply-templates select="current()/img" mode="aside-image" />
+      </div>
     </xsl:template>
 
 </xsl:stylesheet>

--- a/server/stylesheets/related-box.xsl
+++ b/server/stylesheets/related-box.xsl
@@ -95,11 +95,11 @@
       <xsl:choose>
         <xsl:when test="$linkurl !=''">
           <a class="related-box__image--link" data-trackable="link-image" href="{$linkurl}">
-            <xsl:apply-templates select="current()" mode="related-box-image" />
+            <xsl:apply-templates select="current()" mode="aside-image" />
           </a>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:apply-templates select="current()" mode="related-box-image" />
+          <xsl:apply-templates select="current()" mode="aside-image" />
         </xsl:otherwise>
       </xsl:choose>
     </div>
@@ -108,7 +108,7 @@
   <xsl:template match="ft-related/media/img" />
   <xsl:template match="ft-related/media" />
 
-  <xsl:template match="ft-related/media/img" mode="related-box-image">
+  <xsl:template match="ft-related/media/img | pull-quote-image/img" mode="aside-image">
     <xsl:variable name="maxWidth" select="300" />
     <xsl:choose>
       <xsl:when test="count(current()[@width][@height]) = 1">

--- a/test/server/stylesheets/pull-quotes.test.js
+++ b/test/server/stylesheets/pull-quotes.test.js
@@ -1,12 +1,12 @@
 /* global describe, it */
 'use strict';
 
-var transform = require('./transform-helper');
+const transform = require('./transform-helper');
 require('chai').should();
 
 describe('Pull Quotes', function () {
 
-	it('should turn capi v2 pull-quotes into n-quotes', function() {
+	it('should turn capi v2 pull-quotes into n-quotes', () => {
 		return transform(
 				'<body>' +
 					'<pull-quote>' +
@@ -15,7 +15,7 @@ describe('Pull Quotes', function () {
 					'</pull-quote>' +
 				'</body>'
 			)
-			.then(function (transformedXml) {
+			.then(transformedXml => {
 				transformedXml.should.equal(
 					'<blockquote class="ng-inline-element article__quote article__quote--pull-quote">' +
 						'<div class="pull-quote__quote-marks"></div>' +
@@ -26,7 +26,7 @@ describe('Pull Quotes', function () {
 			});
 	});
 
-	it('should not include citation if non available', function() {
+	it('should not include citation if non available', () => {
 		return transform(
 				'<body>' +
 					'<pull-quote>' +
@@ -35,7 +35,7 @@ describe('Pull Quotes', function () {
 					'</pull-quote>' +
 				'</body>'
 			)
-			.then(function (transformedXml) {
+			.then(transformedXml => {
 				transformedXml.should.equal(
 					'<blockquote class="ng-inline-element article__quote article__quote--pull-quote">' +
 						'<div class="pull-quote__quote-marks"></div>' +
@@ -43,6 +43,29 @@ describe('Pull Quotes', function () {
 					'</blockquote>\n'
 				);
 			});
+	});
+
+	it('should include an image if one was supplied', () => {
+		return transform(
+			'<body>' +
+				'<pull-quote><pull-quote-text><p>Quote with master image</p></pull-quote-text>' +
+					'<pull-quote-image><img src="http://com.ft.imagepublish.prod.s3.amazonaws.com/aa4eec2e-1bfd-11e5-8201-cbdb03d71480" alt="Housing market economic dashboard" longdesc="" width="2048" height="1152" /></pull-quote-image>' +
+					'<pull-quote-source>Source with image</pull-quote-source>' +
+				'</pull-quote>' +
+			'</body>'
+		)
+		.then(transformedXml => {
+			transformedXml.should.equal(
+				'<blockquote class="ng-inline-element article__quote article__quote--pull-quote">' +
+					'<div class="pull-quote__quote-marks"></div>' +
+					'<p>Quote with master image</p>' +
+					'<cite class="article__quote-citation">Source with image</cite>' +
+					'<div class="pull-quote__image"><div class="article-image__placeholder" style="padding-top:56.25%;">' +
+						'<img alt="Housing market economic dashboard" src="https://next-geebee.ft.com/image/v1/images/raw/http://com.ft.imagepublish.prod.s3.amazonaws.com/aa4eec2e-1bfd-11e5-8201-cbdb03d71480?source=next&amp;fit=scale-down&amp;width=300">' +
+					'</div></div>' +
+				'</blockquote>\n'
+			);
+		});
 	});
 
 });


### PR DESCRIPTION
To be imminently unleashed by content programme.
More detailed styling (full width image) to follow once being used and in conjunction with related-content / promo-boxes - opportunity to refactor these asides to share styling components.