### PR TITLE
Stop diluting our Google juice by including ‘rel=canonical’s #SEO

### DIFF
--- a/views/article.html
+++ b/views/article.html
@@ -5,6 +5,7 @@
 	{{#if dfp.dfpZone}}
 	<meta name="dfp_zone" content="{{dfp.dfpZone}}" />
 	{{/if}}
+	{{> rel-canonical}}
 {{/defineBlock}}
 
 <article id="site-content" role="main" class="article{{#if designGenre}} article--brand {{#if designGenre.headshot}}article--brand--headshot{{/if}}{{/if}}" data-content-id="{{id}}" data-content-sources="{{#if articleV1}}v1{{/if}} {{#if articleV2}}v2{{/if}}" data-trackable="article" data-trackable-terminate>

--- a/views/partials/rel-canonical.html
+++ b/views/partials/rel-canonical.html
@@ -1,0 +1,3 @@
+{{#if webUrl}}
+<link rel="canonical" href="{{webUrl}}">
+{{/if}}

--- a/views/podcast.html
+++ b/views/podcast.html
@@ -5,6 +5,7 @@
 	{{#if dfp.dfpZone}}
 	<meta name="dfp_zone" content="{{dfp.dfpZone}}" />
 	{{/if}}
+	{{> rel-canonical}}
 {{/defineBlock}}
 
 <article id="site-content" role="main" class="article" data-content-id="{{id}}" data-trackable="article" data-trackable-terminate>


### PR DESCRIPTION
![screen shot 2015-12-18 at 14 31 23](https://cloud.githubusercontent.com/assets/825088/11899090/a6aeab10-a594-11e5-8d52-c6d0a8b6732d.png)
