### PR TITLE
Bump n-layout to v6.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "next-article",
   "dependencies": {
-    "n-layout": "^5.0.0",
+    "n-layout": "^6.0.0",
     "o-fonts": "^1.6.4",
     "o-big-number": "^1.1.0",
     "o-gallery": "^1.6.1",


### PR DESCRIPTION
Fixes problem with n-welcome containing templates at the root of it's
package, and not within ./templates directory

https://github.com/Financial-Times/next-welcome/pull/67