### PR TITLE
Fix message on very short articles

### DIFF
--- a/client/components/article/_main.scss
+++ b/client/components/article/_main.scss
@@ -175,6 +175,7 @@
 	.article__copyright-notice {
 		@include oTypographySansSize(s);
 		margin-top: 40px;
+		clear: both;
 	}
 
 	@media print {


### PR DESCRIPTION
Eg, https://next.ft.com/content/398cd594-a4e9-3cc1-aa70-6823ddecc4b1 - message is wrapped around the floated element