### PR TITLE
ensure styling can withstand no social buttons

### DIFF
--- a/client/components/share/main.scss
+++ b/client/components/share/main.scss
@@ -7,7 +7,7 @@
 @include oShareActionIcon(linkedin, o-share);
 
 .article__share {
-
+	overflow: hidden;
 	position: relative;
 	margin: 15px 0;
 	padding: 5px 0;


### PR DESCRIPTION
With no share buttons the styling of the article share element 'collapsed'.
Overflow hidden fixes this.