### PR TITLE
Allow a users followed topics to be displayed via a query string

### DIFF
--- a/server/controllers/article-helpers/decorate-metadata.js
+++ b/server/controllers/article-helpers/decorate-metadata.js
@@ -46,7 +46,7 @@ function selectTagsMyftTagsForDisplay(article) {
 
 	return article.metadata
 		.filter(isPrimaryTag(article))
-		.filter(tag => myftTopics.some(id => id === tag.id ));
+		.filter(tag => myftTopics.some(id => id === tag.id));
 }
 
 function selectTagsForDisplay(article) {

--- a/server/controllers/article-helpers/decorate-metadata.js
+++ b/server/controllers/article-helpers/decorate-metadata.js
@@ -37,15 +37,27 @@ function selectPrimaryTag(article) {
 	article.primaryTag = primaryTag;
 }
 
+function isPrimaryTag(article) {
+	return (tag) => (!article.primaryTag || article.primaryTag.id !== tag.id);
+}
+
+function selectTagsMyftTagsForDisplay(article) {
+	let myftTopics = article.myftTopics || [];
+
+	return article.metadata
+		.filter(isPrimaryTag(article))
+		.filter(tag => myftTopics.some(id => id === tag.id ));
+}
+
 function selectTagsForDisplay(article) {
 	let ignore = [ 'genre', 'mediaType', 'iptc', 'icb' ];
+	let myftTopics = selectTagsMyftTagsForDisplay(article);
+	let defaultTopics = article.metadata
+		.filter(tag => !myftTopics.some(myftTag => myftTag.id === tag.id))
+		.filter(tag => !ignore.find(taxonomy => taxonomy === tag.taxonomy))
+		.filter(isPrimaryTag(article));
 
-	article.tags = article.metadata
-		.filter(
-			tag => !ignore.find(taxonomy => taxonomy === tag.taxonomy)
-				&& (!article.primaryTag || article.primaryTag.id !== tag.id)
-		)
-		.slice(0, 5);
+	article.tags = myftTopics.concat(defaultTopics).slice(0,5);
 }
 
 module.exports = function(article) {

--- a/server/controllers/article.js
+++ b/server/controllers/article.js
@@ -97,6 +97,10 @@ module.exports = function articleV3Controller(req, res, next, payload) {
 		payload.firstClickFree = res.locals.firstClickFreeModel;
 	}
 
+	if (req.query.myftTopics) {
+		payload.myftTopics = req.query.myftTopics.split(',');
+	}
+
 	// Decorate article with primary tags and tags for display
 	decorateMetadataHelper(payload);
 	payload.isSpecialReport = payload.primaryTag && payload.primaryTag.taxonomy === 'specialReports';

--- a/test/server/controllers/article-helpers/myft-metadata.test.js
+++ b/test/server/controllers/article-helpers/myft-metadata.test.js
@@ -1,0 +1,53 @@
+/*global describe, context, it, beforeEach */
+
+'use strict';
+
+const sinon = require('sinon');
+const expect = require('chai').expect;
+const proxyquire = require('proxyquire');
+const httpMocks = require('node-mocks-http');
+
+const fixtureEsFound = require('../../../fixtures/v3-elastic-article-found').docs[0]._source;
+
+const subject = proxyquire('../../../../server/controllers/article', {
+	'./article-helpers/suggested': () => Promise.resolve(),
+	'../transforms/article-xslt': (article) => Promise.resolve(article.bodyXML),
+	'../transforms/body': (articleHtml) => { return { html: () => articleHtml } }
+});
+
+describe('myFT metadata', () => {
+
+	let request;
+	let response;
+	let next;
+	let result;
+
+	function createInstance(params, flags) {
+		next = sinon.stub();
+		request = httpMocks.createRequest(params);
+		response = httpMocks.createResponse();
+		response.locals = { flags: flags || {} };
+		return subject(request, response, next, fixtureEsFound);
+	}
+
+	beforeEach(() => {
+		result = null;
+
+		let flags = {
+			openGraph: true
+		};
+
+		return createInstance({query: {
+			myftTopics: 'NTc=-U2VjdGlvbnM=,NTQ=-U2VjdGlvbnM='
+		}}, flags).then(() => {
+			result = response._getRenderData();
+		});
+	});
+
+	it('it should promote users myft tags to be displayed', () => {
+		expect(result.tags.find(tag => tag.id === 'NTc=-U2VjdGlvbnM=')).to.exist;
+		expect(result.tags.find(tag => tag.id === 'NTQ=-U2VjdGlvbnM=')).to.exist;
+	});
+
+});
+

--- a/test/server/controllers/article-helpers/myft-metadata.test.js
+++ b/test/server/controllers/article-helpers/myft-metadata.test.js
@@ -50,4 +50,3 @@ describe('myFT metadata', () => {
 	});
 
 });
-


### PR DESCRIPTION
As discussed in person, this PR allows for a users followed myFT topics to be passed in via a query string `?myftTopics`. This will ensure that their given topics are always displayed in the tags array in top right hand corner of layout. 

#### N.b.
This is to fix an issue whereby users are getting confused as they are displayed the content in their feed for a given topic which is then not displayed on the content page.


#### Future
I have discussed with the POs and designers that we should re-think how followed topics are presented to a user when on a content page.