### PR TITLE
stop promobox text overflowing when printed

### DIFF
--- a/client/components/article/_aside.scss
+++ b/client/components/article/_aside.scss
@@ -2,7 +2,6 @@
 	@include oTypographySansDataBold(l);
 	font-size: 26px;
 	line-height: 27px;
-	overflow: hidden;
 	margin-top: 8px;
 	margin-bottom: 8px;
 	color: getColor('cold-3');

--- a/client/components/article/_aside.scss
+++ b/client/components/article/_aside.scss
@@ -2,6 +2,7 @@
 	@include oTypographySansDataBold(l);
 	font-size: 26px;
 	line-height: 27px;
+	overflow: hidden;
 	margin-top: 8px;
 	margin-bottom: 8px;
 	color: getColor('cold-3');

--- a/client/components/article/_main.scss
+++ b/client/components/article/_main.scss
@@ -158,6 +158,7 @@
 			&:after {
 				text-decoration: none;
 				word-break: break-all;
+				word-wrap: break-word;
 			}
 			&[href^='/']:after {
 				content: ' (http://next.ft.com' attr(href) ')';


### PR DESCRIPTION
In response to Jira issue NFT-243 "Text overflowing out of promo boxes on firefox and IE, when printing articles."  

@andygnewman 