### PR TITLE
Homepage follow journey

### DIFF
--- a/client/components/_common.scss
+++ b/client/components/_common.scss
@@ -160,7 +160,8 @@
 	text-align: center;
 }
 
-.u-hide--L {
+//Want this to be capital L for consistency with o-grid definition
+.u-hide--L { 	// scss-lint:disable SelectorFormat
 	@include oGridRespondTo(L) {
 		display: none;
 	}

--- a/client/components/_common.scss
+++ b/client/components/_common.scss
@@ -15,34 +15,6 @@
 	padding: 16px 0;
 	width: 100%;
 
-	&--inline {
-		float: left;
-		@include oGridRespondTo(S) {
-			max-width: 300px;
-			margin-right: 24px;
-		}
-	}
-
-	&__title {
-		margin: -40px 0 8px 10px;
-	}
-
-	&__title-text {
-		@include oTypographySerifDisplay(m);
-		color: getColor('cold-1');
-		display: inline-block;
-		margin: 0;
-		padding: 10px;
-		padding-bottom: 0;
-		font-weight: 900;
-		background-color: inherit;
-		a {
-			color: getColor('cold-1');
-			border-bottom: 0;
-			text-decoration: none;
-		}
-	}
-
 	.o-expander__toggle {
 		@include oTypographySans(m);
 		margin-top: 12px;
@@ -67,36 +39,65 @@
 
 }
 
+.c-box--inline {
+	float: left;
+	@include oGridRespondTo(S) {
+		max-width: 300px;
+		margin-right: 24px;
+	}
+}
+
+.c-box__title {
+	margin: -40px 0 8px 10px;
+}
+
+.c-box__title-text {
+	@include oTypographySerifDisplay(m);
+	color: getColor('cold-1');
+	display: inline-block;
+	margin: 0;
+	padding: 10px;
+	padding-bottom: 0;
+	font-weight: 900;
+	background-color: inherit;
+	a {
+		color: getColor('cold-1');
+		border-bottom: 0;
+		text-decoration: none;
+	}
+}
+
 .c-topic {
 	@include nLinksTopic;
 	font-style: normal;
+}
 
-	&--medium {
-		@include oTypographySansBoldSize(m);
-	}
+.c-topic--medium {
+	@include oTypographySansBoldSize(m);
+}
 
-	&--link {
-		border-bottom: 1px dotted transparent;
-		transition-property: border-bottom-color, color;
-		transition-duration: 0.3s;
-		&:hover {
-			border-bottom-color: darken(getColorFor(topic, text), 20%);
-		}
-	}
-
-	&--with-follow {
-		line-height: 26px;
-		vertical-align: middle;
-		margin-right: 10px;
-	}
-
-	&--list {
-		display: block;
-		padding: 2px 15px 2px 8px;
-		position: relative;
-		border-bottom-width: 0;
+.c-topic--link {
+	border-bottom: 1px dotted transparent;
+	transition-property: border-bottom-color, color;
+	transition-duration: 0.3s;
+	&:hover {
+		border-bottom-color: darken(getColorFor(topic, text), 20%);
 	}
 }
+
+.c-topic--with-follow {
+	line-height: 26px;
+	vertical-align: middle;
+	margin-right: 10px;
+}
+
+.c-topic--list {
+	display: block;
+	padding: 2px 15px 2px 8px;
+	position: relative;
+	border-bottom-width: 0;
+}
+
 
 .c-myft-logo {
 	@include nextIcon(myft-bolder, getColorFor(title, text), 26);
@@ -105,68 +106,62 @@
 
 // Utilities
 
-.u-margin {
-	&--left-right {
-		margin-left: 16px;
-		margin-right: 16px;
-	}
-
-	&--bottom {
-		margin-bottom: 8px;
-		&--none {
-			margin-bottom: 0;
-		}
-	}
-
-	&--none {
-		margin: 0;
-	}
+.u-margin--left-right {
+	margin-left: 16px;
+	margin-right: 16px;
 }
 
-.u-padding {
-	&--left-right {
-		padding-left: 16px;
-		padding-right: 16px;
-	}
-
-	&--bottom {
-		padding-bottom: 16px;
-		&__none {
-			padding-bottom: 0;
-		}
-	}
-
-	&--none {
-		padding: 0;
-	}
+.u-margin--bottom {
+	margin-bottom: 8px;
 }
 
-.u-background-color {
-	&--pink {
-		background-color: getColor('pink');
-	}
-	&--page {
-		background-color: getColorFor('page', 'background');
-	}
+.u-margin--bottom-none {
+	margin-bottom: 0;
 }
 
-.u-border {
-	&--all {
-		border: 1px solid getColor('warm-3');
-	}
-	&--left {
-		border-left: 1px solid getColor('warm-3');
-	}
+.u-margin--none {
+	margin: 0;
+}
+
+.u-padding--left-right {
+	padding-left: 16px;
+	padding-right: 16px;
+}
+
+.u-padding--bottom {
+	padding-bottom: 16px;
+}
+
+.u-padding--bottom-none {
+	padding-bottom: 0;
+}
+
+.u-padding--none {
+	padding: 0;
+}
+
+.u-background-color--pink {
+	background-color: getColor('pink');
+}
+
+.u-background-color--page {
+	background-color: getColorFor('page', 'background');
+}
+
+.u-border--all {
+	border: 1px solid getColor('warm-3');
+}
+
+.u-border--left {
+	border-left: 1px solid getColor('warm-3');
 }
 
 .u-align-center {
 	text-align: center;
 }
 
-.u-hide {
-	&--L {
-		@include oGridRespondTo(L) {
-			display: none;
-		}
+.u-hide--L {
+	@include oGridRespondTo(L) {
+		display: none;
 	}
 }

--- a/client/components/_common.scss
+++ b/client/components/_common.scss
@@ -143,3 +143,11 @@
 .u-align-center {
 	text-align: center;
 }
+
+.u-hide {
+	&--L {
+		@include oGridRespondTo(L) {
+			display: none;
+		}
+	}
+}

--- a/client/components/_common.scss
+++ b/client/components/_common.scss
@@ -23,22 +23,22 @@
 		}
 	}
 
-	&--title {
+	&__title {
 		margin: -40px 0 8px 10px;
+	}
 
-		&__text {
-			@include oTypographySerifDisplay(m);
+	&__title-text {
+		@include oTypographySerifDisplay(m);
+		color: getColor('cold-1');
+		display: inline-block;
+		padding: 10px;
+		padding-bottom: 0;
+		font-weight: 900;
+		background-color: inherit;
+		a {
 			color: getColor('cold-1');
-			display: inline-block;
-			padding: 10px;
-			padding-bottom: 0;
-			font-weight: 900;
-			background-color: inherit;
-			a {
-				color: getColor('cold-1');
-				border-bottom: 0;
-				text-decoration: none;
-			}
+			border-bottom: 0;
+			text-decoration: none;
 		}
 	}
 

--- a/client/components/_common.scss
+++ b/client/components/_common.scss
@@ -98,12 +98,28 @@
 	}
 }
 
+.c-myft-logo {
+	@include nextIcon(myft-bolder, getColorFor(title, text), 26);
+	width: 40px;
+}
+
 // Utilities
 
 .u-margin {
 	&--left-right {
 		margin-left: 16px;
 		margin-right: 16px;
+	}
+
+	&--bottom {
+		margin-bottom: 8px;
+		&--none {
+			margin-bottom: 0;
+		}
+	}
+
+	&--none {
+		margin: 0;
 	}
 }
 
@@ -128,6 +144,9 @@
 .u-background-color {
 	&--pink {
 		background-color: getColor('pink');
+	}
+	&--page {
+		background-color: getColorFor('page', 'background');
 	}
 }
 

--- a/client/components/_common.scss
+++ b/client/components/_common.scss
@@ -31,6 +31,7 @@
 		@include oTypographySerifDisplay(m);
 		color: getColor('cold-1');
 		display: inline-block;
+		margin: 0;
 		padding: 10px;
 		padding-bottom: 0;
 		font-weight: 900;
@@ -70,7 +71,7 @@
 	@include nLinksTopic;
 	font-style: normal;
 
-	&__medium {
+	&--medium {
 		@include oTypographySansBoldSize(m);
 	}
 
@@ -118,6 +119,10 @@
 			padding-bottom: 0;
 		}
 	}
+
+	&--none {
+		padding: 0;
+	}
 }
 
 .u-background-color {
@@ -133,4 +138,8 @@
 	&--left {
 		border-left: 1px solid getColor('warm-3');
 	}
+}
+
+.u-align-center {
+	text-align: center;
 }

--- a/client/components/article/_main.scss
+++ b/client/components/article/_main.scss
@@ -2,7 +2,6 @@
 .article__header {
 	position: relative;
 	background: getColor('pink');
-	font-weight: 100;
 }
 
 .article__header--wrapper {

--- a/client/main.scss
+++ b/client/main.scss
@@ -61,6 +61,7 @@ $o-comments-is-silent: false;
 	.article__comments,
 	.article__share,
 	.story-package,
+	.follow-promo,
 	.article__actions,
 	.js-special-report,
 	.next-up__bottom__wrapper,

--- a/server/controllers/article-helpers/decorate-metadata.js
+++ b/server/controllers/article-helpers/decorate-metadata.js
@@ -60,6 +60,15 @@ function selectTagsForDisplay(article) {
 	article.tags = myftTopics.concat(defaultTopics).slice(0,5);
 }
 
+function selectTagToFollow(article) {
+	if(!article.tagToFollow) {
+		return;
+	}
+
+	article.tagToFollow = article.metadata
+		.find(tag => tag.id === article.tagToFollow);
+}
+
 module.exports = function(article) {
 	fillProperties(article);
 	selectPrimaryTheme(article);
@@ -67,6 +76,6 @@ module.exports = function(article) {
 	selectPrimaryBrand(article);
 	selectPrimaryTag(article);
 	selectTagsForDisplay(article);
-
+	selectTagToFollow(article);
 	return article;
 };

--- a/server/controllers/article-helpers/decorate-metadata.js
+++ b/server/controllers/article-helpers/decorate-metadata.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const addTagTitlePrefix = require('./tag-title-prefix');
+
 function fillProperties(article) {
 	article.metadata = article.metadata.map(tag => {
 		let v1 = {
@@ -67,6 +69,8 @@ function selectTagToFollow(article) {
 
 	article.tagToFollow = article.metadata
 		.find(tag => tag.id === article.tagToFollow);
+
+	addTagTitlePrefix(article.tagToFollow);
 }
 
 module.exports = function(article) {

--- a/server/controllers/article-helpers/tag-title-prefix.js
+++ b/server/controllers/article-helpers/tag-title-prefix.js
@@ -1,0 +1,23 @@
+'use strict'
+
+module.exports = (tag) => {
+	let title;
+
+	switch(tag.taxonomy) {
+		case 'authors':
+			title = 'from';
+			break;
+		case 'sections':
+			title = 'in';
+			break;
+		case 'genre':
+			title = '';
+			break;
+		default:
+			title = 'on';
+	}
+
+	tag.title = title;
+
+	return tag;
+};

--- a/server/controllers/article.js
+++ b/server/controllers/article.js
@@ -105,6 +105,11 @@ module.exports = function articleV3Controller(req, res, next, content) {
 		content.myftTopics = req.query.myftTopics.split(',');
 	}
 
+	//When a user comes to an article from a myFT promo area, we want to push them to follow the topic they came from
+	if (req.query.tagToFollow) {
+		content.tagToFollow = req.query.tagToFollow;
+	}
+
 	// Decorate article with primary tags and tags for display
 	decorateMetadataHelper(content);
 	content.isSpecialReport = content.primaryTag && content.primaryTag.taxonomy === 'specialReports';

--- a/server/controllers/article.js
+++ b/server/controllers/article.js
@@ -3,6 +3,7 @@
 const logger = require('ft-next-express').logger;
 const cacheControlUtil = require('../utils/cache-control');
 const getDfpUtil = require('../utils/get-dfp');
+const addTagTitlePrefix = require('./article-helpers/tag-title-prefix');
 const barrierHelper = require('./article-helpers/barrier');
 const suggestedHelper = require('./article-helpers/suggested');
 const readNextHelper = require('./article-helpers/read-next');
@@ -50,30 +51,7 @@ function getMoreOnTags(primaryTheme, primarySection, primaryBrand) {
 		return;
 	}
 
-	return moreOnTags.slice(0, 2).map(tag => {
-		let title;
-
-		switch (tag.taxonomy) {
-			case 'authors':
-				title = 'from';
-				break;
-			case 'brand':
-				title = 'from';
-				break;
-			case 'sections':
-				title = 'in';
-				break;
-			case 'genre':
-				title = '';
-				break;
-			default:
-				title = 'on';
-		}
-
-		tag.title = title;
-
-		return tag;
-	});
+	return moreOnTags.slice(0, 2).map(addTagTitlePrefix);
 }
 
 module.exports = function articleV3Controller(req, res, next, content) {

--- a/server/stylesheets/pull-quotes.xsl
+++ b/server/stylesheets/pull-quotes.xsl
@@ -5,7 +5,7 @@
 
       <xsl:variable name="imagePaddingStyle">
         <xsl:choose>
-          <xsl:when test="count(current()/pull-quote-image) > 0"> u-padding--bottom__none</xsl:when>
+          <xsl:when test="count(current()/pull-quote-image) > 0"> u-padding--bottom-none</xsl:when>
           <xsl:otherwise></xsl:otherwise>
         </xsl:choose>
       </xsl:variable>

--- a/server/stylesheets/related-box.xsl
+++ b/server/stylesheets/related-box.xsl
@@ -49,8 +49,8 @@
 
       <xsl:choose>
         <xsl:when test="$type = 'article' and count(current()/title) = 0">
-          <div class="c-box--title">
-            <div class="c-box--title__text u-background-color--pink">Related article</div>
+          <div class="c-box__title">
+            <div class="c-box__title-text u-background-color--pink">Related article</div>
           </div>
         </xsl:when>
         <xsl:otherwise>
@@ -84,8 +84,8 @@
   </xsl:template>
 
   <xsl:template match="title | promo-title" mode="aside-title">
-    <div class="c-box--title">
-      <div class="c-box--title__text u-background-color--pink">
+    <div class="c-box__title">
+      <div class="c-box__title-text u-background-color--pink">
         <xsl:apply-templates select="current()" mode="extract-content" />
       </div>
     </div>

--- a/test/server/controllers/article-helpers/decorate-metadata.test.js
+++ b/test/server/controllers/article-helpers/decorate-metadata.test.js
@@ -66,4 +66,20 @@ describe('Metadata', () => {
 
 	});
 
+	context('when passed a query string with a topic to follow', () => {
+	
+		beforeEach(() => {
+			// Subject modifies the data given to it so always start fresh
+			fixtureData = JSON.parse(JSON.stringify(fixtureEsFound));
+
+			fixtureData.tagToFollow = 'Q0ItMDAwMDcyMw==-QXV0aG9ycw==';
+
+			result = subject(fixtureData);
+		});
+
+		it('selects the primary section as the primary tag', () => {
+			expect(result.tagToFollow.prefLabel).to.equal('Martin Arnold');
+		});
+	});
+
 });

--- a/test/server/stylesheets/promo-box.test.js
+++ b/test/server/stylesheets/promo-box.test.js
@@ -19,7 +19,7 @@ describe('Promo-boxes', function() {
 		.then(function (transformedXml) {
 			transformedXml.should.equal(
 				'<aside class="c-box c-box--inline u-border--all" data-trackable="related-box" role="complementary">' +
-					'<div class="c-box--title"><div class="c-box--title__text u-background-color--pink">Tatomer Riesling 2012</div></div>' +
+					'<div class="c-box__title"><div class="c-box__title-text u-background-color--pink">Tatomer Riesling 2012</div></div>' +
 					'<div class="aside--headline u-margin--left-right">Greece debt crisis</div>' +
 					'<div class="aside--image">' +
 						'<img alt="" src="https://next-geebee.ft.com/image/v1/images/raw/http://com.ft.imagepublish.prod.s3.amazonaws.com/1871b094-3b7d-11e5-bbd1-b37bc06f590c?source=next&amp;fit=scale-down&amp;width=470">' +
@@ -44,7 +44,7 @@ describe('Promo-boxes', function() {
 		.then(function (transformedXml) {
 			transformedXml.should.equal(
 				'<aside class="c-box c-box--inline u-border--all" data-trackable="related-box" role="complementary">' +
-					'<div class="c-box--title"><div class="c-box--title__text u-background-color--pink">Tatomer Riesling 2012</div></div>' +
+					'<div class="c-box__title"><div class="c-box__title-text u-background-color--pink">Tatomer Riesling 2012</div></div>' +
 					'<div class="aside--headline u-margin--left-right">Greece debt crisis</div>' +
 					'<div class="aside--image">' +
 						'<img alt="" src="https://next-geebee.ft.com/image/v1/images/raw/http://com.ft.imagepublish.prod.s3.amazonaws.com/1871b094-3b7d-11e5-bbd1-b37bc06f590c?source=next&amp;fit=scale-down&amp;width=470">' +
@@ -73,7 +73,7 @@ describe('Promo-boxes', function() {
 		.then(function (transformedXml) {
 			transformedXml.should.equal(
 				'<aside class="c-box c-box--inline u-border--all" data-trackable="related-box" role="complementary">' +
-					'<div class="c-box--title"><div class="c-box--title__text u-background-color--pink">Tatomer Riesling 2012</div></div>' +
+					'<div class="c-box__title"><div class="c-box__title-text u-background-color--pink">Tatomer Riesling 2012</div></div>' +
 					'<div class="aside--headline u-margin--left-right">Greece debt crisis</div>' +
 					'<div class="aside--content u-margin--left-right">' +
 						'<p>The first paragraph</p>' +
@@ -102,7 +102,7 @@ describe('Promo-boxes', function() {
 		.then(function (transformedXml) {
 			transformedXml.should.equal(
 				'<aside class="c-box c-box--inline u-border--all o-expander" data-trackable="related-box" role="complementary" data-o-component="o-expander" data-o-expander-shrink-to="0" data-o-expander-count-selector=".aside--content__extension">' +
-					'<div class="c-box--title"><div class="c-box--title__text u-background-color--pink">Tatomer Riesling 2012</div></div>' +
+					'<div class="c-box__title"><div class="c-box__title-text u-background-color--pink">Tatomer Riesling 2012</div></div>' +
 					'<div class="aside--headline u-margin--left-right">Greece debt crisis</div>' +
 					'<div class="aside--image">' +
 						'<img alt="" src="https://next-geebee.ft.com/image/v1/images/raw/http://com.ft.imagepublish.prod.s3.amazonaws.com/1871b094-3b7d-11e5-bbd1-b37bc06f590c?source=next&amp;fit=scale-down&amp;width=470">' +
@@ -135,7 +135,7 @@ describe('Promo-boxes', function() {
 		.then(function (transformedXml) {
 			transformedXml.should.equal(
 				'<aside class="c-box c-box--inline u-border--all o-expander" data-trackable="related-box" role="complementary" data-o-component="o-expander" data-o-expander-shrink-to="0" data-o-expander-count-selector=".aside--content__extension">' +
-					'<div class="c-box--title"><div class="c-box--title__text u-background-color--pink">Tatomer Riesling 2012</div></div>' +
+					'<div class="c-box__title"><div class="c-box__title-text u-background-color--pink">Tatomer Riesling 2012</div></div>' +
 					'<div class="aside--headline u-margin--left-right">Greece debt crisis</div>' +
 					'<div class="aside--content u-margin--left-right o-expander__content">' +
 						'<p><strong>Breakthrough:</strong> “Closing our first seed round in 10 days three times oversubscribed gave us momentum [to carry through] to the execution of our strategy and into the IPO.”</p>' +
@@ -183,7 +183,7 @@ describe('Promo-boxes', function() {
 		.then(function(transformedXml) {
 			transformedXml.should.equal(
 				'<aside class="c-box c-box--inline u-border--all" data-trackable="related-box" role="complementary">' +
-					'<div class="c-box--title"><div class="c-box--title__text u-background-color--pink"><a href="/c9175806-3054-11e5-8873-775ba7c2ea3d" data-trackable="link">Greece crisis tests start-ups’ staying power</a> </div></div>' +
+					'<div class="c-box__title"><div class="c-box__title-text u-background-color--pink"><a href="/c9175806-3054-11e5-8873-775ba7c2ea3d" data-trackable="link">Greece crisis tests start-ups’ staying power</a> </div></div>' +
 				'</aside>\n'
 			);
 		});
@@ -225,7 +225,7 @@ describe('Promo-boxes', function() {
 		.then(function(transformedXml) {
 			transformedXml.should.equal(
 				'<aside class="c-box c-box--inline u-border--all o-expander" data-trackable="related-box" role="complementary" data-o-component="o-expander" data-o-expander-shrink-to="0" data-o-expander-count-selector=".aside--content__extension">' +
-					'<div class="c-box--title"><div class="c-box--title__text u-background-color--pink">Tatomer Riesling 2012</div></div>' +
+					'<div class="c-box__title"><div class="c-box__title-text u-background-color--pink">Tatomer Riesling 2012</div></div>' +
 					'<div class="aside--headline u-margin--left-right">Greece debt crisis</div>' +
 					'<div class="aside--image">' +
 						'<img alt="" src="https://next-geebee.ft.com/image/v1/images/raw/http://com.ft.imagepublish.prod.s3.amazonaws.com/1871b094-3b7d-11e5-bbd1-b37bc06f590c?source=next&amp;fit=scale-down&amp;width=470">' +
@@ -239,7 +239,7 @@ describe('Promo-boxes', function() {
 					'<button class="o-expander__toggle o--if-js u-margin--left-right" data-trackable="expander-toggle"></button>' +
 				'</aside>' +
 				'<aside class="c-box c-box--inline u-border--all" data-trackable="related-box" role="complementary">' +
-					'<div class="c-box--title"><div class="c-box--title__text u-background-color--pink">Tatomer Riesling 2012</div></div>' +
+					'<div class="c-box__title"><div class="c-box__title-text u-background-color--pink">Tatomer Riesling 2012</div></div>' +
 					'<div class="aside--headline u-margin--left-right">Greece debt crisis</div>' +
 					'<div class="aside--image">' +
 						'<img alt="" src="https://next-geebee.ft.com/image/v1/images/raw/http://com.ft.imagepublish.prod.s3.amazonaws.com/1871b094-3b7d-11e5-bbd1-b37bc06f590c?source=next&amp;fit=scale-down&amp;width=470">' +
@@ -262,7 +262,7 @@ describe('Promo-boxes', function() {
 		.then(function(transformedXml) {
 			transformedXml.should.equal(
 				'<aside class="c-box c-box--inline u-border--all" data-trackable="related-box" role="complementary">' +
-					'<div class="c-box--title"><div class="c-box--title__text u-background-color--pink">Series: China Great Game</div></div>' +
+					'<div class="c-box__title"><div class="c-box__title-text u-background-color--pink">Series: China Great Game</div></div>' +
 					'<div class="aside--headline u-margin--left-right">As China seeks to expand its sphere of influence, it is likely to encounter significant resistance. <a href="http://www.ft.com/indepth/china-great-game" data-trackable="link">Read more</a> </div>' +
 					'<div class="aside--content u-margin--left-right">' +
 						'<p><a href="/content/6e098274-587a-11e5-a28b-50226830d644" data-trackable="link">Road to a new empire </a> <br>A modern-day Silk route is Xi Jinping’s signature foreign policy. <a href="/content/6e098274-587a-11e5-a28b-50226830d644" data-trackable="link">Read more </a> </p>' +
@@ -283,7 +283,7 @@ describe('Promo-boxes', function() {
 		.then(function(transformedXml) {
 			transformedXml.should.equal(
 				'<aside class="c-box c-box--inline u-border--all" data-trackable="related-box" role="complementary">' +
-					'<div class="c-box--title"><div class="c-box--title__text u-background-color--pink"><b>CV</b></div></div>' +
+					'<div class="c-box__title"><div class="c-box__title-text u-background-color--pink"><b>CV</b></div></div>' +
 					'<div class="aside--headline u-margin--left-right">This is the headline</div>' +
 					'<div class="aside--content u-margin--left-right"><p>Here is some content</p></div>' +
 				'</aside>\n'
@@ -303,7 +303,7 @@ describe('Promo-boxes', function() {
 		.then(function(transformedXml) {
 			transformedXml.should.equal(
 				'<aside class="c-box c-box--inline u-border--all" data-trackable="related-box" role="complementary">' +
-					'<div class="c-box--title"><div class="c-box--title__text u-background-color--pink">Tatomer Riesling 2012</div></div>' +
+					'<div class="c-box__title"><div class="c-box__title-text u-background-color--pink">Tatomer Riesling 2012</div></div>' +
 					'<div class="aside--headline u-margin--left-right">Greece debt crisis</div>' +
 					'<div class="aside--image u-margin--left-right"><div class="article-image__placeholder" style="padding-top:96px;">' +
 						'<img alt="start-up" src="https://next-geebee.ft.com/image/v1/images/raw/http://com.ft.imagepublish.prod.s3.amazonaws.com/79ac73d6-7718-11e5-933d-efcdc3c11c89?source=next&amp;fit=scale-down&amp;width=167"></div></div>' +

--- a/test/server/stylesheets/pull-quotes.test.js
+++ b/test/server/stylesheets/pull-quotes.test.js
@@ -60,7 +60,7 @@ describe('Pull Quotes', function () {
 		)
 		.then(transformedXml => {
 			transformedXml.should.equal(
-				'<blockquote class="article__quote article__quote--pull-quote aside--content c-box c-box--inline u-border--all u-padding--bottom__none">' +
+				'<blockquote class="article__quote article__quote--pull-quote aside--content c-box c-box--inline u-border--all u-padding--bottom-none">' +
 					'<div class="pull-quote__quote-marks"></div>' +
 					'<div class="u-padding--left-right u-padding--bottom">' +
 						'<p>Quote with master image</p>' +

--- a/test/server/stylesheets/related-box.test.js
+++ b/test/server/stylesheets/related-box.test.js
@@ -63,7 +63,7 @@ describe('Related Box', () => {
 		.then(transformedXml => {
 			transformedXml.should.equal(
 				'<aside class="c-box c-box--inline u-border--all" data-trackable="related-box" role="complementary">' +
-					'<div class="c-box--title"><div class="c-box--title__text u-background-color--pink">FT Property Summit 2015</div></div>' +
+					'<div class="c-box__title"><div class="c-box__title-text u-background-color--pink">FT Property Summit 2015</div></div>' +
 					'<div class="aside--headline u-margin--left-right"><a data-trackable="link-headline" href="https://live.ft.com/Events/2015/FT-Property-Summit-2015">9th Annual Property Summit</a></div>' +
 					'<div class="aside--image"><a data-trackable="link-image" href="https://live.ft.com/Events/2015/FT-Property-Summit-2015"><div class="article-image__placeholder" style="padding-top:56.25%;">' +
 					'<img alt="Housing market economic dashboard" src="https://next-geebee.ft.com/image/v1/images/raw/http://com.ft.imagepublish.prod.s3.amazonaws.com/aa4eec2e-1bfd-11e5-8201-cbdb03d71480?source=next&amp;fit=scale-down&amp;width=470"></div></a></div>' +
@@ -87,7 +87,7 @@ describe('Related Box', () => {
 		.then(transformedXml => {
 			transformedXml.should.equal(
 				'<aside class="c-box c-box--inline u-border--all" data-trackable="related-box" role="complementary">' +
-					'<div class="c-box--title"><div class="c-box--title__text u-background-color--pink">FT Property Summit 2015</div></div>' +
+					'<div class="c-box__title"><div class="c-box__title-text u-background-color--pink">FT Property Summit 2015</div></div>' +
 					'<div class="aside--headline u-margin--left-right"><a data-trackable="link-headline" href="https://live.ft.com/Events/2015/FT-Property-Summit-2015">9th Annual Property Summit</a></div>' +
 					'<div class="aside--image u-margin--left-right"><a data-trackable="link-image" href="https://live.ft.com/Events/2015/FT-Property-Summit-2015"><div class="article-image__placeholder" style="padding-top:96px;">' +
 					'<img alt="Housing market economic dashboard" src="https://next-geebee.ft.com/image/v1/images/raw/http://com.ft.imagepublish.prod.s3.amazonaws.com/aa4eec2e-1bfd-11e5-8201-cbdb03d71480?source=next&amp;fit=scale-down&amp;width=167"></div></a></div>' +
@@ -110,7 +110,7 @@ describe('Related Box', () => {
 		.then(transformedXml => {
 			transformedXml.should.equal(
 				'<aside class="c-box c-box--inline u-border--all" data-trackable="related-box" role="complementary">' +
-						'<div class="c-box--title"><div class="c-box--title__text u-background-color--pink">Related article</div></div>' +
+						'<div class="c-box__title"><div class="c-box__title-text u-background-color--pink">Related article</div></div>' +
 						'<div class="aside--image"><a data-trackable="link-image" href="/content/e539eab8-8c83-11e5-8be4-3506bf20cc2b"><div class="article-image__placeholder" style="padding-top:56.25%;">' +
 						'<img alt="Housing market economic dashboard" src="https://next-geebee.ft.com/image/v1/images/raw/http://com.ft.imagepublish.prod.s3.amazonaws.com/aa4eec2e-1bfd-11e5-8201-cbdb03d71480?source=next&amp;fit=scale-down&amp;width=470"></div></a></div>' +
 						'<div class="aside--headline u-margin--left-right"><a data-trackable="link-headline" href="/content/e539eab8-8c83-11e5-8be4-3506bf20cc2b">9th Annual Property Summit</a></div>' +
@@ -134,7 +134,7 @@ describe('Related Box', () => {
 		.then(transformedXml => {
 			transformedXml.should.equal(
 				'<aside class="c-box c-box--inline u-border--all" data-trackable="related-box" role="complementary">' +
-					'<div class="c-box--title"><div class="c-box--title__text u-background-color--pink">Bridge the generation gap</div></div>' +
+					'<div class="c-box__title"><div class="c-box__title-text u-background-color--pink">Bridge the generation gap</div></div>' +
 					'<div class="aside--image"><a data-trackable="link-image" href="/content/e539eab8-8c83-11e5-8be4-3506bf20cc2b"><div class="article-image__placeholder" style="padding-top:56.25%;">' +
 					'<img alt="Housing market economic dashboard" src="https://next-geebee.ft.com/image/v1/images/raw/http://com.ft.imagepublish.prod.s3.amazonaws.com/aa4eec2e-1bfd-11e5-8201-cbdb03d71480?source=next&amp;fit=scale-down&amp;width=470"></div></a></div>' +
 					'<div class="aside--headline u-margin--left-right"><a data-trackable="link-headline" href="/content/e539eab8-8c83-11e5-8be4-3506bf20cc2b">9th Annual Property Summit</a></div>' +

--- a/views/article.html
+++ b/views/article.html
@@ -29,11 +29,7 @@
 									<div class="article__primary-theme" data-trackable="primary-theme">
 										<a href="/stream/{{primaryTag.taxonomy}}Id/{{primaryTag.id}}" class="c-topic c-topic--medium c-topic--with-follow c-topic--link" data-trackable="section-link" aria-label="posted in category {{primaryTag.name}}" data-concept-id="{{primaryTag.id}}">{{primaryTag.name}}</a>
 										{{#ifAll @root.flags.myFtApi @root.flags.articleFollowPrimayTag}}
-										{{#if tagToFollow}}
-											<span class="u-hide--L">
-										{{else}}
-											<span>
-										{{/if}}
+											<span{{#if tagToFollow}} class="u-hide--L"{{/if}}>
 												{{>next-myft-ui/templates/follow version='3' conceptId=primaryTag.id name=primaryTag.prefLabel taxonomy=primaryTag.taxonomy}}
 											</span>
 										{{/ifAll}}
@@ -101,7 +97,7 @@
 					{{#if mainImageHtml}}
 						{{{mainImageHtml}}}
 					{{/if}}
-	
+
 					{{> social location='top'}}
 					{{#if tagToFollow}}
 						<aside class="article__aside u-padding--none follow-promo" data-o-grid-colspan="12 Lhide" data-trackable="follow-promo-article" role="complementary" aria-hidden="true">

--- a/views/article.html
+++ b/views/article.html
@@ -22,12 +22,12 @@
 							{{#if isSpecialReport}}
 								<p class="article__primary-theme">
 									Special Report:
-									<a href="/special-reports/{{primaryTag.id}}" class="c-topic c-topic__medium c-topic--with-follow c-topic--link" data-trackable="section-link" aria-label="posted in category {{primaryTag.name}}" data-concept-id="{{primaryTag.id}}">{{primaryTag.name}}</a>
+									<a href="/special-reports/{{primaryTag.id}}" class="c-topic c-topic--medium c-topic--with-follow c-topic--link" data-trackable="section-link" aria-label="posted in category {{primaryTag.name}}" data-concept-id="{{primaryTag.id}}">{{primaryTag.name}}</a>
 								</p>
 							{{else}}
 								{{#if primaryTag}}
 									<div class="article__primary-theme" data-trackable="primary-theme">
-										<a href="/stream/{{primaryTag.taxonomy}}Id/{{primaryTag.id}}" class="c-topic c-topic__medium c-topic--with-follow c-topic--link" data-trackable="section-link" aria-label="posted in category {{primaryTag.name}}" data-concept-id="{{primaryTag.id}}">{{primaryTag.name}}</a>
+										<a href="/stream/{{primaryTag.taxonomy}}Id/{{primaryTag.id}}" class="c-topic c-topic--medium c-topic--with-follow c-topic--link" data-trackable="section-link" aria-label="posted in category {{primaryTag.name}}" data-concept-id="{{primaryTag.id}}">{{primaryTag.name}}</a>
 										{{#ifAll @root.flags.myFtApi @root.flags.articleFollowPrimayTag}}
 											{{>next-myft-ui/templates/follow version='3' conceptId=primaryTag.id name=primaryTag.prefLabel taxonomy=primaryTag.taxonomy}}
 										{{/ifAll}}
@@ -55,12 +55,13 @@
 					</div>
 					{{/if}}
 				</div>
-				{{#if readNextArticle}}
-					{{>read-next-header article=readNextArticle}}
+				{{#if tagToFollow}}
+					<aside class="article__aside o-grid-remove-gutters--XL" data-o-grid-colspan="hide L4 XL3 XLoffset1" data-trackable="follow-promo-header" role="complementary" aria-hidden="true">
+						{{>follow-promo center=true tag=tagToFollow}}
+					</aside>
 				{{else}}
-					{{#if tagToFollow}}
-						FOLLOW ME {{tagToFollow.id}} {{tagToFollow.url}} {{tagToFollow.name}}
-
+					{{#if readNextArticle}}
+						{{>read-next-header article=readNextArticle}}
 					{{else}}
 						{{#if tags}}
 						<aside
@@ -94,7 +95,13 @@
 					{{#if mainImageHtml}}
 						{{{mainImageHtml}}}
 					{{/if}}
+	
 					{{> social location='top'}}
+					{{#if tagToFollow}}
+						<aside class="article__aside u-padding--none" data-o-grid-colspan="12 Lhide" data-trackable="follow-promo-article" role="complementary" aria-hidden="true">
+							{{>follow-promo  tag=tagToFollow}}
+						</aside>
+					{{/if}}
 					<div class="article__time-byline">
 						{{#if publishedDate}}
 							<time class="article__timestamp o-date" data-o-component="o-date" datetime="{{#dateformat}}{{publishedDate}}{{/dateformat}}" data-o-date-js>

--- a/views/article.html
+++ b/views/article.html
@@ -58,24 +58,29 @@
 				{{#if readNextArticle}}
 					{{>read-next-header article=readNextArticle}}
 				{{else}}
-					{{#if tags}}
-					<aside
-						role="complementary"
-						data-o-grid-colspan="hide L3 Loffset1"
-						class="article__tags {{#if mainImageHtml}}article__tags--main-image{{/if}}">
-						<h3 class="article__tags__title">Topics mentioned in this article</h3>
-						<ul class="article__tags-list" data-trackable="tags">
-							{{#each tags}}
-							<li class="article__tag">
-								<a
-									href="{{url}}"
-									class="c-topic c-topic--link c-topic--list"
-									data-trackable="tag"
-									{{#if id}}data-concept-id="{{id}}"{{/if}}>{{name}}</a>
-							</li>
-							{{/each}}
-						</ul>
-					</aside>
+					{{#if tagToFollow}}
+						FOLLOW ME {{tagToFollow.id}} {{tagToFollow.url}} {{tagToFollow.name}}
+
+					{{else}}
+						{{#if tags}}
+						<aside
+							role="complementary"
+							data-o-grid-colspan="hide L3 Loffset1"
+							class="article__tags {{#if mainImageHtml}}article__tags--main-image{{/if}}">
+							<h3 class="article__tags__title">Topics mentioned in this article</h3>
+							<ul class="article__tags-list" data-trackable="tags">
+								{{#each tags}}
+								<li class="article__tag">
+									<a
+										href="{{url}}"
+										class="c-topic c-topic--link c-topic--list"
+										data-trackable="tag"
+										{{#if id}}data-concept-id="{{id}}"{{/if}}>{{name}}</a>
+								</li>
+								{{/each}}
+							</ul>
+						</aside>
+						{{/if}}
 					{{/if}}
 				{{/if}}
 			</div>

--- a/views/article.html
+++ b/views/article.html
@@ -62,7 +62,7 @@
 					{{/if}}
 				</div>
 				{{#if tagToFollow}}
-					<aside class="article__aside o-grid-remove-gutters--XL" data-o-grid-colspan="hide L4 XL3 XLoffset1" data-trackable="follow-promo-header" role="complementary" aria-hidden="true">
+					<aside class="article__aside o-grid-remove-gutters--XL follow-promo" data-o-grid-colspan="hide L4 XL3 XLoffset1" data-trackable="follow-promo-header" role="complementary" aria-hidden="true">
 						{{>follow-promo center=true tag=tagToFollow}}
 					</aside>
 				{{else}}
@@ -104,7 +104,7 @@
 	
 					{{> social location='top'}}
 					{{#if tagToFollow}}
-						<aside class="article__aside u-padding--none" data-o-grid-colspan="12 Lhide" data-trackable="follow-promo-article" role="complementary" aria-hidden="true">
+						<aside class="article__aside u-padding--none follow-promo" data-o-grid-colspan="12 Lhide" data-trackable="follow-promo-article" role="complementary" aria-hidden="true">
 							{{>follow-promo  tag=tagToFollow}}
 						</aside>
 					{{/if}}

--- a/views/article.html
+++ b/views/article.html
@@ -29,7 +29,13 @@
 									<div class="article__primary-theme" data-trackable="primary-theme">
 										<a href="/stream/{{primaryTag.taxonomy}}Id/{{primaryTag.id}}" class="c-topic c-topic--medium c-topic--with-follow c-topic--link" data-trackable="section-link" aria-label="posted in category {{primaryTag.name}}" data-concept-id="{{primaryTag.id}}">{{primaryTag.name}}</a>
 										{{#ifAll @root.flags.myFtApi @root.flags.articleFollowPrimayTag}}
-											{{>next-myft-ui/templates/follow version='3' conceptId=primaryTag.id name=primaryTag.prefLabel taxonomy=primaryTag.taxonomy}}
+										{{#if tagToFollow}}
+											<span class="u-hide--L">
+										{{else}}
+											<span>
+										{{/if}}
+												{{>next-myft-ui/templates/follow version='3' conceptId=primaryTag.id name=primaryTag.prefLabel taxonomy=primaryTag.taxonomy}}
+											</span>
 										{{/ifAll}}
 									</div>
 								{{/if}}

--- a/views/partials/follow-promo.html
+++ b/views/partials/follow-promo.html
@@ -1,0 +1,15 @@
+{{#with tag}}
+	<div class="c-box u-border--all">
+		<div class="c-box__title">
+			<h3 class="c-box__title-text u-background-color--pink">For updates {{title}}:</h3>
+		</div>
+		<div class="u-margin--left-right {{#if ../center}}u-align-center{{/if}}">
+
+			<a href="{{url}}" class="c-topic c-topic--medium c-topic--link {{#unless ../center}}c-topic--with-follow{{/unless}}">{{name}}</a>
+			{{#if @root.flags.myFtApi}}
+				{{>next-myft-ui/templates/follow version='3' conceptId=id name=prefLabel taxonomy=taxonomy buttonText="Follow in myFT" alternateButtonText="Following" size="big"}}
+			{{/if}}
+
+		</div>
+	</div>
+{{/with}}

--- a/views/partials/follow-promo.html
+++ b/views/partials/follow-promo.html
@@ -1,6 +1,6 @@
 {{#with tag}}
 	<div class="c-box u-border--all">
-		<div class="c-box__title u-margin--bottom--none">
+		<div class="c-box__title u-margin--bottom-none">
 			<h3 class="c-box__title-text u-background-color--pink">
 				<i class="c-myft-logo"></i>
 				<span class="n-util-visually-hidden">myFT</span>

--- a/views/partials/follow-promo.html
+++ b/views/partials/follow-promo.html
@@ -7,11 +7,14 @@
 			</h3>
 		</div>
 		<div class="u-margin--left-right {{#if ../center}}u-align-center{{/if}}">
+			{{#if ../center}}
 			<div class="u-margin--bottom">
-
-			<p class="u-margin--none">Never miss a story {{title}}:</p>
-			<a href="{{url}}" class="c-topic c-topic--medium c-topic--link {{#unless ../center}}c-topic--with-follow{{/unless}}">{{name}}</a>
-			</div>	
+			{{/if}}
+				<p class="u-margin--none">Never miss a story {{title}}:</p>
+				<a href="{{url}}" class="c-topic c-topic--medium c-topic--link {{#unless ../center}}c-topic--with-follow{{/unless}}">{{name}}</a>
+			{{#if ../center}}
+			</div>
+			{{/if}}
 			{{#if @root.flags.myFtApi}}
 				{{>next-myft-ui/templates/follow version='3' conceptId=id name=prefLabel taxonomy=taxonomy size="big"}}
 			{{/if}}

--- a/views/partials/follow-promo.html
+++ b/views/partials/follow-promo.html
@@ -1,15 +1,20 @@
 {{#with tag}}
 	<div class="c-box u-border--all">
-		<div class="c-box__title">
-			<h3 class="c-box__title-text u-background-color--pink">For updates {{title}}:</h3>
+		<div class="c-box__title u-margin--bottom--none">
+			<h3 class="c-box__title-text u-background-color--pink">
+				<i class="c-myft-logo"></i>
+				<span class="n-util-visually-hidden">myFT</span>
+			</h3>
 		</div>
 		<div class="u-margin--left-right {{#if ../center}}u-align-center{{/if}}">
+			<div class="u-margin--bottom">
 
+			<p class="u-margin--none">Never miss a story {{title}}:</p>
 			<a href="{{url}}" class="c-topic c-topic--medium c-topic--link {{#unless ../center}}c-topic--with-follow{{/unless}}">{{name}}</a>
+			</div>	
 			{{#if @root.flags.myFtApi}}
-				{{>next-myft-ui/templates/follow version='3' conceptId=id name=prefLabel taxonomy=taxonomy buttonText="Follow in myFT" alternateButtonText="Following" size="big"}}
+				{{>next-myft-ui/templates/follow version='3' conceptId=id name=prefLabel taxonomy=taxonomy size="big"}}
 			{{/if}}
-
 		</div>
 	</div>
 {{/with}}

--- a/views/partials/more-ons-ab-test-b.html
+++ b/views/partials/more-ons-ab-test-b.html
@@ -12,7 +12,7 @@
 				<div class="header">
 					<h2 id="more-on-{{@index}}-title" class="header__name">
 						<span class="n-util-visually-hidden">Latest {{title}} </span>
-						<a class="c-topic c-topic__medium c-topic--with-follow c-topic--link" href="{{url}}" data-trackable="link-topic-title">{{name}}</a>
+						<a class="c-topic c-topic--medium c-topic--with-follow c-topic--link" href="{{url}}" data-trackable="link-topic-title">{{name}}</a>
 					</h2>
 					{{#if @root.flags.myFtApi }}
 						{{>next-myft-ui/templates/follow version='3' conceptId=id}}

--- a/views/partials/more-ons-tags.html
+++ b/views/partials/more-ons-tags.html
@@ -4,10 +4,11 @@
 	class="article-tags c-box u-border--all"
 	data-trackable="mentions"
 	aria-labelledby="my-ft-title">
-	<div class="header article-tags__header">
-		<h2 id="my-ft-title" class="header__name header__name--sans-serif">
-			<i>my</i>FT
-		</h2>
+	<div class="c-box__title u-margin--bottom--none">
+		<h3 class="c-box__title-text u-background-color--page">
+			<i class="c-myft-logo"></i>
+			<span class="n-util-visually-hidden">myFT</span>
+		</h3>
 	</div>
 	<div class="article-tags__intro">
 		<p>Follow the topics mentioned in this article</p>

--- a/views/partials/more-ons-tags.html
+++ b/views/partials/more-ons-tags.html
@@ -4,7 +4,7 @@
 	class="article-tags c-box u-border--all"
 	data-trackable="mentions"
 	aria-labelledby="my-ft-title">
-	<div class="c-box__title u-margin--bottom--none">
+	<div class="c-box__title u-margin--bottom-none">
 		<h3 class="c-box__title-text u-background-color--page">
 			<i class="c-myft-logo"></i>
 			<span class="n-util-visually-hidden">myFT</span>

--- a/views/podcast.html
+++ b/views/podcast.html
@@ -18,7 +18,7 @@
 						<div class="article__header-primary">
 							<p class="article__primary-theme">
 								{{#with primaryTag}}
-								<a href="/stream/{{taxonomy}}Id/{{id}}" class="c-topic c-topic__medium c-topic--with-follow c-topic--link" data-trackable="section-link" aria-label="posted in category {{name}}" data-concept-id="{{id}}">{{name}}</a>
+								<a href="/stream/{{taxonomy}}Id/{{id}}" class="c-topic c-topic--medium c-topic--with-follow c-topic--link" data-trackable="section-link" aria-label="posted in category {{name}}" data-concept-id="{{id}}">{{name}}</a>
 								{{/with}}
 							</p>
 							<h1 class="article__title">{{title}}</h1>


### PR DESCRIPTION
/cc @ironsidevsquincy @andygnewman @Financial-Times/next-myft 

For a user being recommended a topic to follow on the front page and coming to an article, we want to promote that topic to them to encourage them to follow it. This may or may not be the same as the primary topic of the page.

We will give them a single large follow CTA (hiding the follow button next to the primary tag on desktop).

Also in this PR is some BEM tidy up, and changing the myFT text logo at the bottom of the page to the myFT logo.


<img width="1193" alt="screen shot 2016-01-21 at 12 29 38" src="https://cloud.githubusercontent.com/assets/1978880/12480559/235eb90a-c03b-11e5-81ce-293862a6228c.png">
<img width="610" alt="screen shot 2016-01-21 at 12 29 46" src="https://cloud.githubusercontent.com/assets/1978880/12480560/247b6900-c03b-11e5-9ef5-88900e0bcbee.png">
