### PR TITLE
incorporate bare in fragment

### DIFF
--- a/server/controllers/article.js
+++ b/server/controllers/article.js
@@ -150,7 +150,6 @@ module.exports = function articleV3Controller(req, res, next, content) {
 		.then(() => {
 			res.set(cacheControlUtil);
 			if (req.query.fragment) {
-				content.layout = 'vanilla';
 				res.render('fragment', content);
 			} else {
 				content.layout = 'wrapper';

--- a/server/controllers/article.js
+++ b/server/controllers/article.js
@@ -150,9 +150,7 @@ module.exports = function articleV3Controller(req, res, next, content) {
 		.then(() => {
 			res.set(cacheControlUtil);
 			if (req.query.fragment) {
-				if (!req.query.bare) {
-					content.layout = 'vanilla';
-				}
+				content.layout = 'vanilla';
 				res.render('fragment', content);
 			} else {
 				content.layout = 'wrapper';


### PR DESCRIPTION
Query String
- bare applied the vanilla layout (without headers and footers)
- this was differentiated from fragment (article body) when testing iframe vs dom insertion for open article in stream

Now decision made to go with dom insertion, the vanilla layout can be applied to fragment.