### PR TITLE
Improve main image extraction

### DIFF
--- a/server/transforms/extract-main-image-and-toc.js
+++ b/server/transforms/extract-main-image-and-toc.js
@@ -10,7 +10,9 @@ module.exports = function ($) {
 
 	// check that it is the first element in the body
 	if (
-		$firstMainImage.length && !$firstMainImage.prev().length
+		$firstMainImage.length &&
+		!$firstMainImage.prev().length &&
+		(!$firstMainImage.parent() || !$firstMainImage.parent().prev().length)
 	) {
 		mainImageHtml = $.html($firstMainImage.remove());
 	}

--- a/test/server/transforms/extract-main-image-and-toc.test.js
+++ b/test/server/transforms/extract-main-image-and-toc.test.js
@@ -211,6 +211,34 @@ describe('Extracting Main Image and Table of Contents from Body', () => {
 			);
 		});
 
+		it('should not extract the image from the first child position of an elemwnt with previous siblings', () => {
+			const $ = cheerio.load(
+				'<body>' +
+					'<p>The co-founding Zoman, Deepinder Goyal, that is took time for a chat with us last week about the change going on in Indias start-up world.</p>' +
+					'<blockquote class="article__quote article__quote--full-quote aside--content c-box u-border--left u-padding--left-right">' +
+						'<figure class="article-image article-image--center" style="width:354px;"><div class="article-image__placeholder" style="padding-top:75.9887005649718%;">' +
+							'<img alt="" src="https://next-geebee.ft.com/image/v1/images/raw/http%3A%2F%2Fftalphaville.ft.com%2Ffiles%2F2016%2F02%2FScreen-Shot-2016-02-08-at-16.08.47-590x448.png?source=next&amp;fit=scale-down&amp;width=354">' +
+							'</div>' +
+						'</figure>' +
+					'</blockquote>' +
+					'<p>Or you could skip straight to stuff like this from Goyals mouth with our emphasis:</p>' +
+				'</body>'
+			);
+			const resultObject = mainImageAndToc($);
+			resultObject.bodyHtml.should.equal(
+				'<body>' +
+					'<p>The co-founding Zoman, Deepinder Goyal, that is took time for a chat with us last week about the change going on in Indias start-up world.</p>' +
+					'<blockquote class="article__quote article__quote--full-quote aside--content c-box u-border--left u-padding--left-right">' +
+						'<figure class="article-image article-image--center" style="width:354px;"><div class="article-image__placeholder" style="padding-top:75.9887005649718%;">' +
+							'<img alt="" src="https://next-geebee.ft.com/image/v1/images/raw/http%3A%2F%2Fftalphaville.ft.com%2Ffiles%2F2016%2F02%2FScreen-Shot-2016-02-08-at-16.08.47-590x448.png?source=next&amp;fit=scale-down&amp;width=354">' +
+							'</div>' +
+						'</figure>' +
+					'</blockquote>' +
+					'<p>Or you could skip straight to stuff like this from Goyals mouth with our emphasis:</p>' +
+				'</body>'
+			);
+		});
+
 	});
 
 });


### PR DESCRIPTION
Stop extracting images that are first child of elements with previous siblings.

Before;

![screen shot 2016-02-11 at 09 07 23](https://cloud.githubusercontent.com/assets/8938227/12972649/ed966baa-d09e-11e5-8f49-6931cfa96bc2.png)

After;

![screen shot 2016-02-11 at 09 07 35](https://cloud.githubusercontent.com/assets/8938227/12972653/f4943b76-d09e-11e5-843a-58cb8726e37f.png)

