### PR TITLE
When content fetch fails, log the UUID

### DIFF
--- a/server/controllers/negotiation.js
+++ b/server/controllers/negotiation.js
@@ -72,7 +72,7 @@ module.exports = function negotiationController(req, res, next) {
 				});
 		})
 		.catch(error => {
-			logger.error({ event: "CONTENT_FETCH_FAILED", err: error.toString() });
+			logger.error({ event: "CONTENT_FETCH_FAILED", err: error.toString(), uuid: req.params.id });
 			next(error);
 		});
 };


### PR DESCRIPTION
This was the only error I saw in the logs during the 44 5xx spike, would have been useful to know what articles were affected.

@ironsidevsquincy @andygnewman 