### PR TITLE
Add dummy version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "ft-next-article",
+  "version": "0.0.0",
   "private": true,
   "description": "Render a Next FT Article",
   "main": "app.js",


### PR DESCRIPTION
We want to be able to `npm install Financial-Times/next-article` but npm doesn't like the lack of version. Currently we're working around it by installing with Bower which is just horrible.