### PR TITLE
rhr subhead and numbering mvt

### DIFF
--- a/client/components/suggested-reads/main.scss
+++ b/client/components/suggested-reads/main.scss
@@ -1,6 +1,22 @@
+.suggested-reads--number {
+	counter-reset: articleIndex;
+}
+
 .suggested-reads__item {
 	margin-bottom: 20px;
 	padding: 0;
+	position: relative;
+	.suggested-reads--number & {
+		padding-left: 20px;
+		&:before {
+			@include oTypographySans(m);
+			color: getColor('pink-tint4');
+			counter-increment: articleIndex;
+			content: counter(articleIndex);
+			position: absolute;
+			left: 0;
+		}
+	}
 }
 
 .suggested-reads__container {
@@ -27,6 +43,7 @@
 
 .suggested-reads__subheading {
 	@include oTypographySans(s);
+	color: getColor('grey-tint5');
 	border-bottom: 1px solid getColor('warm-3');
 	margin-top: 0;
 	padding-bottom: 10px;
@@ -38,10 +55,21 @@
 
 .suggested-reads__item__headline--control {
 	@include nLinksHeadline();
+	color: getColor('grey-tint4');
+
 }
 
 .suggested-reads__item__headline--variant {
 
+}
+
+.suggested-reads__item__subheading {
+	display: none;
+	.suggested-reads--subhead & {
+		@include oTypographySans(s);
+		display: block;
+		color: getColor('grey-tint5');
+	}
 }
 
 .suggested-reads__item__topic {

--- a/server/controllers/article.js
+++ b/server/controllers/article.js
@@ -138,10 +138,8 @@ module.exports = function articleV3Controller(req, res, next, content) {
 		content.readNextTopic = content.primaryTag;
 
 		const rhrSubHeadNumber = res.locals.flags.articleRHRSubheadAndNumber;
-		if ( rhrSubHeadNumber && rhrSubHeadNumber !== 'control') {
-			content.rhrShowSubhead = rhrSubHeadNumber.split('-')[0] === 'sub' ? true : false;
-			content.rhrShowNumber = rhrSubHeadNumber.split('-')[1] === 'num' ? true : false;
-		}
+		content.rhrShowSubhead = /^sub-/.test(rhrSubHeadNumber);
+		content.rhrShowNumber = /-num$/.test(rhrSubHeadNumber);
 	}
 
 	if (req.get('FT-Labs-Gift') === 'GRANTED') {

--- a/server/controllers/article.js
+++ b/server/controllers/article.js
@@ -136,6 +136,12 @@ module.exports = function articleV3Controller(req, res, next, content) {
 		);
 
 		content.readNextTopic = content.primaryTag;
+
+		const rhrSubHeadNumber = res.locals.flags.articleRHRSubheadAndNumber;
+		if ( rhrSubHeadNumber && rhrSubHeadNumber !== 'control') {
+			content.rhrShowSubhead = rhrSubHeadNumber.split('-')[0] === 'sub' ? true : false;
+			content.rhrShowNumber = rhrSubHeadNumber.split('-')[1] === 'num' ? true : false;
+		}
 	}
 
 	if (req.get('FT-Labs-Gift') === 'GRANTED') {

--- a/views/partials/suggested-reads.html
+++ b/views/partials/suggested-reads.html
@@ -2,6 +2,9 @@
 	<div class="suggested-reads__container" role="group" aria-labelledBy="suggested-reads__title" >
 		<h3 id="suggested-reads__title" class="suggested-reads__title">More on this topic</h3>
 		<p class="suggested-reads__subheading">Suggestions below based on <span>
+	<div class="suggested-reads__container{{#if rhrShowSubhead}} suggested-reads--subhead{{/if}}{{#if rhrShowNumber}} suggested-reads--number{{/if}}" role="group" aria-labelledBy="suggested-reads__title" >
+		<h3 id="suggested-reads__title" class="suggested-reads__title">More on this topic</h3>
+		<p class="suggested-reads__subheading">Suggestions below based on <span>
 		{{#with topic}}
 			<a class="suggested-reads__item__topic" data-trackable="suggested-topic" href="{{url}}">{{name}}</a>
 		{{/with}}
@@ -9,6 +12,7 @@
 		{{#each articles}}
 		<article class="suggested-reads__item">
 			<h4><a class="suggested-reads__item__headline suggested-reads__item__headline--{{#if @root.flags.articleRHRLinkStyle}}variant{{else}}control{{/if}}" href="{{url}}" data-trackable="suggested-article">{{title}}</a></h4>
+			<div class="suggested-reads__item__subheading">{{subheading}}</div>
 		</article>
 		{{/each}}
 	</div>


### PR DESCRIPTION
Styles the right hand rail recommended reads according to MVT variants ['sub-num', 'sub-none', 'none-num'].

sub-num
![screen shot 2016-03-03 at 09 33 24](https://cloud.githubusercontent.com/assets/8938227/13490226/51ab7092-e123-11e5-9dc1-1eb02ec1f98b.png)

sub-none
![screen shot 2016-03-03 at 09 33 47](https://cloud.githubusercontent.com/assets/8938227/13490232/5b8e72bc-e123-11e5-9224-7a9b2b242f9c.png)

none-num
![screen shot 2016-03-03 at 09 34 18](https://cloud.githubusercontent.com/assets/8938227/13490244/6445f286-e123-11e5-9ebf-ab05a1bde972.png)

control
![screen shot 2016-03-03 at 09 34 36](https://cloud.githubusercontent.com/assets/8938227/13490251/6b34f1e6-e123-11e5-92df-5a64b797afeb.png)

and in case we have a result from the 'making links look like links' test
![screen shot 2016-03-03 at 09 35 04](https://cloud.githubusercontent.com/assets/8938227/13490255/6ff11138-e123-11e5-8b3f-b96ac3277907.png)



