### PR TITLE
Disable scrolldepth for articles

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -19,7 +19,6 @@ require('next-js-setup').bootstrap(({flags}) => {
 	const comments = require('./components/comments/main');
 	const share = require('./components/share/main');
 	const readingHistory = require('./components/reading-history');
-	const scrollDepth = require('./components/article/scroll-depth');
 
 	const labsShare = require('./components/labsshare/main');
 
@@ -73,7 +72,6 @@ require('next-js-setup').bootstrap(({flags}) => {
 		collapsedToggleText: 'Show more',
 		expandedToggleText: 'Show less'
 	});
-	scrollDepth.init(flags);
 
 	window.addEventListener('load', () => {
 		comments.init(uuid, flags);


### PR DESCRIPTION
Article accounts for ~55% of the scrolldepth events going into Keen. Spoke to Max, who isn't using it so have disabled.

cc @commuterjoy @adambraimbridge @wheresrhys  