### PR TITLE
remove interactive graphics that use http not https

### DIFF
--- a/server/stylesheets/interactive-graphics.xsl
+++ b/server/stylesheets/interactive-graphics.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-    <xsl:template match="a[@data-asset-type='interactive-graphic']">
+    <xsl:template match="a[@data-asset-type='interactive-graphic' and contains(@href, 'https')]">
       <iframe class="article__interactive" src="{@href}" width="{@data-width}" height="{@data-height}" scrolling="no"></iframe>
     </xsl:template>
 

--- a/test/server/stylesheets/interactive-graphics.test.js
+++ b/test/server/stylesheets/interactive-graphics.test.js
@@ -1,0 +1,40 @@
+/* global describe, it */
+'use strict';
+
+var transform = require('./transform-helper');
+require('chai').should();
+
+describe('Interactoive Graphics', function () {
+
+	it('turns it into an iframe', () => {
+		return transform(
+				'<body>' +
+					'<p>' +
+						'<a data-asset-type="interactive-graphic" data-height="370" data-width="600" href="https://www.ft.com/ig/features/women-of-the-year-2015/"></a>' +
+					'</p>' +
+				'</body>'
+			)
+			.then(function (transformedXml) {
+				transformedXml.should.equal(
+					'<p><iframe class="article__interactive" src="https://www.ft.com/ig/features/women-of-the-year-2015/" width="600" height="370" scrolling="no"></iframe></p>\n'
+				);
+			});
+	});
+
+	it('removes it if it does not use https', () => {
+		return transform(
+			'<body>' +
+				'<p>' +
+					'<a data-asset-type="interactive-graphic" data-height="370" data-width="600" href="http://www.ft.com/ig/features/women-of-the-year-2015/"></a>' +
+				'</p>' +
+			'</body>'
+			)
+			.then(function (transformedXml) {
+				transformedXml.should.equal(
+					'<p></p>\n'
+				);
+			});
+
+	});
+
+});


### PR DESCRIPTION
cc: @matthew-andrews 

Given our intention shortly to migrate the xslt transforms from article to ES, then this is probably where it should be done.