### PR TITLE
remove redundant flags params from xslt transform

### DIFF
--- a/server/controllers/article.js
+++ b/server/controllers/article.js
@@ -28,10 +28,7 @@ function isCapiV2(article) {
 function transformArticleBody(article, flags) {
 	let xsltParams = {
 		id: article.id,
-		webUrl: article.webUrl,
-		renderTOC: flags.articleTOC ? 1 : 0,
-		suggestedRead: flags.articleSuggestedRead ? 1 : 0,
-		useBrightcovePlayer: flags.brightcovePlayer ? 1 : 0
+		webUrl: article.webUrl
 	};
 
 	return articleXsltTransform(article.bodyXML, 'main', xsltParams).then(articleBody => {

--- a/test/server/stylesheets/transform-helper.js
+++ b/test/server/stylesheets/transform-helper.js
@@ -2,18 +2,7 @@
 
 var articleXSLT = require('../../../server/transforms/article-xslt');
 
-module.exports = function(xml, params) {
-	var defaults = {
-		useBrightcovePlayer: 0,
-		renderTOC: 0
-	};
+module.exports = function(xml) {
 
-	var xsltParams = {};
-
-	Object.keys(defaults).forEach(function(paramName) {
-		xsltParams[paramName] = params && params[paramName] ?
-			params[paramName] : defaults[paramName];
-	});
-
-	return articleXSLT(xml, 'main', xsltParams);
+	return articleXSLT(xml, 'main');
 };


### PR DESCRIPTION
cc: @i-like-robots 

A bit of tidy up ahead of migrating xslt stylesheets to next-es-interface.

Flags are no longer required in the XSLT - only in cheerio transforms.