### PR TITLE
add two new smoke tests for fragment and special report more on

### DIFF
--- a/test/smoke.js
+++ b/test/smoke.js
@@ -19,9 +19,14 @@ module.exports = [
 			'/content/5cf687c7-ddb9-4243-8fea-69e50b6b5682': 200,
 			// slideshow
 			'/embedded-components/slideshow/593496fc-a4d5-11e5-97e1-a754d5d9538c': 200,
-			// related fragments
+			// fragment view
+			'/content/a85bf481-457c-3bd4-bd49-3801d175d583?fragment=true': 200,
+			// related fragments - story package
 			'/article/02cad03a-844f-11e4-bae9-00144feabdc0/story-package?articleIds=b56232bc-adec-11e4-919e-00144feab7de,8a5c2c02-a47e-11e4-b943-00144feab7de,6bfcdc6e-a0b6-11e4-8ad8-00144feab7de,c0dbd6d6-8072-11e4-9907-00144feabdc0': 200,
+			// related fragments - more-ons
 			'/article/02cad03a-844f-11e4-bae9-00144feabdc0/more-on?tagIds=TnN0ZWluX1BOX1BvbGl0aWNpYW5fMTY4OA==-UE4=,NDdiMzAyNzctMTRlMy00Zjk1LWEyZjYtYmYwZWIwYWU2NzAy-VG9waWNz&index=1': 200,
+			// related fragments - special-reports
+			'/article/2d94241e-e15b-11e5-9217-6ae3733a2cd1/special-report?tagId=MDJlNjNjMjgtMTNmNy00ZDVkLWIyMDItMWE3YzJlNzRjMzRm-U3BlY2lhbFJlcG9ydHM=&count=5': 200,
 			// articles with not tagged with X
 			'/article/02cad03a-844f-11e4-bae9-00144feabdc0/more-on?tagIds=TnN0ZWluX1BOX1BvbGl0aWNpYW5fMTY4OA==-UE4=,NDdiMzAyNzctMTRlMy00Zjk1LWEyZjYtYmYwZWIwYWU2NzAy-VG9waWNz&index=1': {
 				content: ''


### PR DESCRIPTION
Learnings from putting the new 'single' content view live.