### PR TITLE
Fix targeting name for inline ad

### DIFF
--- a/client/components/ads/main.scss
+++ b/client/components/ads/main.scss
@@ -39,5 +39,6 @@ $ad-medium-breakpoint: 760px;
 	[data-ads-layout="responsive"] &,
 	[data-ads-layout="hlfpage"] & {
 		display: block;
+		clear: both;
 	}
 }

--- a/server/controllers/article.js
+++ b/server/controllers/article.js
@@ -32,7 +32,7 @@ function transformArticleBody(article, flags) {
 	};
 
 	return articleXsltTransform(article.bodyXML, 'main', xsltParams).then(articleBody => {
-		return bodyTransform(articleBody, flags);
+		return bodyTransform(articleBody, flags, article.adsLayout);
 	});
 }
 
@@ -51,6 +51,8 @@ module.exports = function articleV3Controller(req, res, next, content) {
 	}
 
 	content.thisYear = new Date().getFullYear();
+
+	content.adsLayout = getAdsLayout(req.query.adsLayout, res.locals.flags);
 
 	if (req.query.myftTopics) {
 		content.myftTopics = req.query.myftTopics.split(',');
@@ -124,7 +126,6 @@ module.exports = function articleV3Controller(req, res, next, content) {
 	return Promise.all(asyncWorkToDo)
 		.then(() => {
 			res.set(cacheControlUtil);
-			content.adsLayout = getAdsLayout(req.query.adsLayout, res.locals.flags);
 			content.contentType = 'article';
 			if (req.query.fragment) {
 				res.render('fragment', content);

--- a/server/transforms/body.js
+++ b/server/transforms/body.js
@@ -15,9 +15,9 @@ const extractMainImageAndToc = require('./extract-main-image-and-toc');
 const inlineAd = require('./inline-ad');
 const externalLinks = require('./external-links');
 
-let transform = function ($, flags) {
+let transform = function ($, flags, adsLayout) {
 	let withFn = function ($, transformFn) {
-		let transformed$ = transformFn($, flags);
+		let transformed$ = transformFn($, flags, adsLayout);
 		return {
 			'with': withFn.bind(withFn, transformed$),
 			get: function () {
@@ -30,13 +30,13 @@ let transform = function ($, flags) {
 	};
 };
 
-module.exports = function (body, flags) {
+module.exports = function (body, flags, adsLayout) {
 	body = replaceEllipses(body);
 	body = body.replace(/<\/a>\s+([,;.:])/mg, '</a>$1');
 	body = body.replace(/http:\/\/www\.ft\.com\/ig\//g, '/ig/');
 	body = body.replace(/http:\/\/ig\.ft\.com\//g, '/ig/');
 
-	let $ = transform(cheerio.load(body, { decodeEntities: false }), flags)
+	let $ = transform(cheerio.load(body, { decodeEntities: false }), flags, adsLayout)
 		// other transforms
 		.with(trimmedLinks)
 		.with(dataTrackable)

--- a/server/transforms/inline-ad.js
+++ b/server/transforms/inline-ad.js
@@ -1,8 +1,7 @@
 module.exports = function ($, flags, adsLayout) {
 	const pars = $('p');
-	console.log('adsLayout', adsLayout);
 	pars.each((index, par) => {
-		if(index > 1 && par.next && par.next.name === 'p' && !(par.previous && par.previous.name === 'aside')) {
+		if(index > 1 && par.next && par.next.name === 'p') {
 			$(par).after(`<div class="o-ads in-article-advert"
 				data-o-ads-name="mpu"
 				data-o-ads-center="true"

--- a/server/transforms/inline-ad.js
+++ b/server/transforms/inline-ad.js
@@ -1,12 +1,13 @@
-module.exports = function ($) {
+module.exports = function ($, flags, adsLayout) {
 	const pars = $('p');
+	console.log('adsLayout', adsLayout);
 	pars.each((index, par) => {
-		if(index > 1 && par.next && par.next.name === 'p') {
+		if(index > 1 && par.next && par.next.name === 'p' && !(par.previous && par.previous.name === 'aside')) {
 			$(par).after(`<div class="o-ads in-article-advert"
 				data-o-ads-name="mpu"
 				data-o-ads-center="true"
 				data-o-ads-label="true"
-				data-o-ads-targeting="pos=mpu;"
+				data-o-ads-targeting="pos=${adsLayout === 'default' ? 'mpu' : 'mid'};"
 				data-o-ads-formats-default="MediumRectangle,Responsive"
 				data-o-ads-formats-small="MediumRectangle,Responsive"
 				data-o-ads-formats-medium="MediumRectangle,Responsive"

--- a/server/utils/get-ads-layout.js
+++ b/server/utils/get-ads-layout.js
@@ -6,8 +6,6 @@ module.exports = (requestedLayout, flags) => {
 	if(flags.adsNewProposition && !requestedLayout) {
 		requestedLayout = 'responsive';
 	}
-	const mapping = {
-		'responsive': 'hlfpage'
-	};
-	return mapping[requestedLayout] || requestedLayout || 'default';
+
+	return requestedLayout || 'default';
 }

--- a/test/server/transforms/inline-ad.test.js
+++ b/test/server/transforms/inline-ad.test.js
@@ -10,20 +10,26 @@ describe('Inline ad inside body', function () {
 
 	it('should insert an ad between the third and fourth paragraphs', function() {
 		var $ = cheerio.load('<p>1</p><p>2</p><p>3</p><p>4</p>');
-		$ = inlineAdTransform($);
+		$ = inlineAdTransform($, {}, 'default');
 		expect($.html()).to.equal(`<p>1</p><p>2</p><p>3</p>${adHtml}<p>4</p>`);
 	});
 
 	it('should not insert an ad if there are only three paragraphs', function() {
 		var $ = cheerio.load('<p>1</p><img><p>2</p><p>3</p><img>');
-		$ = inlineAdTransform($);
+		$ = inlineAdTransform($, {}, 'default');
 		expect($.html()).to.equal(`<p>1</p><img><p>2</p><p>3</p><img>`);
 	});
 
 	it('should move the ad later if there is any other element after the third paragraph', function() {
 		var $ = cheerio.load('<p>1</p><img><p>2</p><p>3</p><img><p>4</p><p>5</p>');
-		$ = inlineAdTransform($);
+		$ = inlineAdTransform($, {}, 'default');
 		expect($.html()).to.equal(`<p>1</p><img><p>2</p><p>3</p><img><p>4</p>${adHtml}<p>5</p>`);
+	});
+
+	it('should call the targeting pos "mid" for the new layout', function() {
+		var $ = cheerio.load('<p>1</p><img><p>2</p><p>3</p><img><p>4</p><p>5</p>');
+		$ = inlineAdTransform($, {}, 'responsive');
+		expect($.html()).to.equal(`<p>1</p><img><p>2</p><p>3</p><img><p>4</p>${adHtml.replace("pos=mpu;", "pos=mid;")}<p>5</p>`);
 	});
 
 });

--- a/views/partials/ads/top.html
+++ b/views/partials/ads/top.html
@@ -1,7 +1,7 @@
 <div
 	class="article-header-advert o-ads o-ads__center"
 	data-o-ads-name="entry"
-	data-o-ads-targeting="pos=entry;"
+	data-o-ads-targeting="pos=top;"
 	data-o-ads-formats-default="false"
 	data-o-ads-formats-small="false"
 	data-o-ads-formats-medium="Leaderboard,Responsive"


### PR DESCRIPTION
/cc @VladDubrovskis @andygnewman 

* Update the pos names, without affecting live site pos names.
* Remove URL mapping hack
* clear both (probably needs more thought) on demo responsive ads layout, to prevent ad appearing squashed next to an aside.