### PR TITLE
Don't wait for load event before initialising comments

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -79,8 +79,5 @@ require('next-js-setup').bootstrap(({flags}) => {
 		expandedToggleText: 'Show less'
 	});
 	scrollDepth.init(flags);
-
-	window.addEventListener('load', () => {
-		comments.init(uuid, flags);
-	}, false);
+	comments.init(uuid, flags);
 });


### PR DESCRIPTION
At this point there's no guarantee the load event hasn't already fired (seems to be more common on Safari), hence comments will never load

Any idea why this was here in the first place? Seems no reason the 'wait' for the load event - @i-like-robots @andygnewman 