### PR TITLE
Fix empty space next to aside

### DIFF
--- a/client/components/ads/main.scss
+++ b/client/components/ads/main.scss
@@ -31,10 +31,12 @@ $ad-medium-breakpoint: 760px;
 .in-article-advert {
 	visibility: hidden;
 	height: 0;
+	width: 0;
 	overflow: hidden;
 	&[data-o-ads-loaded="Responsive"][data-o-ads-master-loaded="Responsive"] {
 		visibility: visible;
 		height: auto;
+		width: auto;
 		clear: both;
 	}
 

--- a/server/transforms/inline-ad.js
+++ b/server/transforms/inline-ad.js
@@ -1,7 +1,11 @@
 module.exports = function ($, flags, adsLayout) {
 	const pars = $('p');
 	pars.each((index, par) => {
-		if(index > 1 && par.next && par.next.name === 'p' && !par.parent) {
+		if(index > 1
+			&& par.next
+			&& par.next.name === 'p'
+			&& !par.parent
+			&& par.prev.name !== 'aside') {
 			$(par).after(`<div class="o-ads in-article-advert"
 				data-o-ads-name="mpu"
 				data-o-ads-center="true"

--- a/test/server/transforms/inline-ad.test.js
+++ b/test/server/transforms/inline-ad.test.js
@@ -38,4 +38,9 @@ describe('Inline ad inside body', function () {
 		expect($.html()).to.equal('<p>1</p><p>2</p><aside><p>3</p><p>4</p></aside>');
 	});
 
+	it('should not place an ad directly after an aside', function() {
+		var $ = cheerio.load('<p>1</p><aside>2</aside><p>3</p><p>4</p><p>5</p>');
+		$ = inlineAdTransform($, {}, 'responsive');
+		expect($.html()).to.equal(`<p>1</p><aside>2</aside><p>3</p><p>4</p>${adHtml.replace("pos=mpu;", "pos=mid;")}<p>5</p>`);
+	});
 });


### PR DESCRIPTION
@VladDubrovskis @andygnewman @andrewgeorgiou1981 @leggsimon 

* Stop empty ad taking up space in between article
* If an ad was next to an aside, wait another paragraph, so there is less empty space next to the aside

After:
<img width="912" alt="screen shot 2016-04-28 at 09 29 38" src="https://cloud.githubusercontent.com/assets/1978880/14883888/0caff584-0d39-11e6-9828-0ae945ad0cc3.png">
