### PR TITLE
delay content and guidelines ad blocking variants

### DIFF
--- a/client/components/ftlabsadblockerhandling/delay-content.js
+++ b/client/components/ftlabsadblockerhandling/delay-content.js
@@ -1,0 +1,23 @@
+module.exports = {
+	name : "delayed-content",
+	description : "We'll Make You Wait",
+	run : () => {
+
+		const articleParent = document.querySelector('.article__body');
+		const articleParas = Array.from(document.querySelectorAll('.article__body p'))
+			.filter(el => el.parentNode === articleParent);
+
+		articleParas.map(el => el.style.display = 'none');
+
+		const adMessage = document.createElement('div');
+		adMessage.innerHTML = '<p>This article will be back shortly. We have delayed your access to it for a short while because we believe you are using ad blocking technology. The FT generates income from advertising on the site which helps ensure we can bring you intesting content like the article you will shortly be reading.</p>';
+		articleParent.insertBefore(adMessage, articleParent.firstChild);
+
+		function showContent() {
+			adMessage.style.display = 'none';
+			articleParas.map(el => el.style.display = 'block');
+		}
+
+		window.setTimeout(showContent, 10000);
+	}
+};

--- a/client/components/ftlabsadblockerhandling/guidelines.js
+++ b/client/components/ftlabsadblockerhandling/guidelines.js
@@ -1,0 +1,24 @@
+const markup = `
+	<div class="ftlabs-ad-block__guidelines">
+		<p>The FT takes a strong approach to only showing adverts that have little interference with your enjoyment of our website.</p>
+		<p>These are the guidelines that each advert must meet.</p>
+		<ul>
+			<li>First</li>
+			<li>Second</li>
+			<li>Third</li>
+			<li>Fourth</li>
+		</ul>
+		<p>Please consider 'whitelisting' the FT within your ad-blocker.</p>
+	</div>
+`;
+
+module.exports = {
+	name : "guidelines",
+	description : "We have strict rules around what adverts we show",
+	run : function (){
+
+		const adSpace = document.querySelector('.sidebar-advert.o-ads');
+		adSpace.innerHTML = markup;
+
+	}
+};

--- a/client/components/ftlabsadblockerhandling/main.js
+++ b/client/components/ftlabsadblockerhandling/main.js
@@ -3,7 +3,9 @@ const approaches = [
 	require('./bart'),
 	require('./ad-revenue'),
 	require('./lets-talk'),
-	require('./ad-blocking-articles')
+	require('./ad-blocking-articles'),
+	require('./delay-content'),
+	require('./guidelines')
 ];
 
 const storage = {


### PR DESCRIPTION
@seanmtracey 

Delay content

![openinstream](https://cloud.githubusercontent.com/assets/8938227/15046764/66cb7ac0-12d9-11e6-96e2-287e0a632b60.gif)

Show the ad guidelines
<img width="994" alt="screen shot 2016-05-04 at 15 28 38" src="https://cloud.githubusercontent.com/assets/8938227/15046775/7310bcdc-12d9-11e6-98a0-6c746e32b287.png">

