### PR TITLE
Remove serif bold usage

### DIFF
--- a/client/components/article/_genre-styles.scss
+++ b/client/components/article/_genre-styles.scss
@@ -55,7 +55,7 @@ $brand-color: getColor('warm-1');
 }
 
 .article__brand--title {
-	@include oTypographySerifDisplayBold(l);
+	@include oTypographySerifDisplay(l);
 	margin-left: 30px;
 }
 

--- a/client/components/ftlabsadblockerhandling/main.scss
+++ b/client/components/ftlabsadblockerhandling/main.scss
@@ -97,7 +97,7 @@
 }
 
 .ftlabs-ad-block__title {
-	@include oTypographySerifDisplayBold(m);
+	@include oTypographySerifDisplay(m);
 	position: absolute;
 	background-color: getColor('pink');
 	color: getColor('cold-2');

--- a/client/components/onward-journey/_main.scss
+++ b/client/components/onward-journey/_main.scss
@@ -57,7 +57,7 @@
 	}
 
 	.header__type {
-		@include oTypographySerifDisplayBold(m);
+		@include oTypographySerifDisplay(m);
 		position: absolute;
 		top: -15px;
 		left: 10px;
@@ -242,7 +242,7 @@
 	overflow: hidden;
 }
 .header__name {
-	@include oTypographySerifDisplayBold(m);
+	@include oTypographySerifDisplay(m);
 	display: inline;
 	margin: 0 10px 0 0;
 	padding: 10px 0 0;

--- a/client/components/read-next/main.scss
+++ b/client/components/read-next/main.scss
@@ -13,7 +13,7 @@
 }
 
 .next-up__intro {
-	@include oTypographySerifDisplayBold(m);
+	@include oTypographySerifDisplay(m);
 	position: absolute;
 	background-color: getColor('warm-5');
 	color: getColor('cold-2');

--- a/client/components/suggested-reads/main.scss
+++ b/client/components/suggested-reads/main.scss
@@ -8,7 +8,7 @@
 }
 
 .suggested-reads__title {
-	@include oTypographySerifDisplayBold(m);
+	@include oTypographySerifDisplay(m);
 	position: absolute;
 	top: -10px;
 	left: 10px;

--- a/client/components/toc/_main.scss
+++ b/client/components/toc/_main.scss
@@ -23,7 +23,7 @@
 }
 
 .table-of-contents__title {
-	@include oTypographySerifDisplayBold(m);
+	@include oTypographySerifDisplay(m);
 	position: absolute;
 	top: -10px;
 	left: 10px;


### PR DESCRIPTION
in favour of regular. 

Reason is, we're adding a medium weight of FianacierDisplay, which would be used by any reference to bold FianacierDisplay (it uses the 'nearest' font weight and 'fauxs' it), therefore increasing the number of fonts downloaded on article pages to 4