### PR TITLE
Use id in place of name and sanitise naming

### DIFF
--- a/server/transforms/light-sign-up.js
+++ b/server/transforms/light-sign-up.js
@@ -6,7 +6,7 @@ module.exports = function ($, flags, options) {
 	const pars = $('p');
 	const variant = flags.lightSignUp;
 	const sectionData = options.metadata.primarySection || null;
-	let section = {
+	const section = {
 		id: 'default',
 		prefLabel: 'default'
 	}

--- a/server/transforms/light-sign-up.js
+++ b/server/transforms/light-sign-up.js
@@ -6,13 +6,14 @@ module.exports = function ($, flags, options) {
 	const pars = $('p');
 	const variant = flags.lightSignUp;
 	const sectionData = options.metadata.primarySection || null;
-	let mailingList = {
-		name: 'default',
+	let section = {
+		id: 'default',
 		prefLabel: 'default'
 	}
 
-	if (sectionData && sectionData.name && sectionData.prefLabel) {
-		mailingList = Object.assign(mailingList, sectionData);
+	if (sectionData && sectionData.idV1 && sectionData.prefLabel) {
+		section.id = sectionData.idV1;
+		section.prefLabel = sectionData.prefLabel;
 	}
 
 	if (variant === 'top') positionComponent(1, true);
@@ -27,7 +28,7 @@ module.exports = function ($, flags, options) {
 			let isOrphan = !par.parent;
 			let hasNextP = (par.next && par.next.name === 'p');
 			if (indexMatches && isOrphan && (hasNextP || !checkNextP)) {
-				$(par).after(`<div class="n-light-signup__container" data-n-light-signup-list-name="${mailingList.name}" data-n-light-signup-list-pref-label="${mailingList.prefLabel}"></div>`);
+				$(par).after(`<div class="n-light-signup__container" data-n-light-signup-section-id="${section.id}" data-n-light-signup-section-pref-label="${section.prefLabel}"></div>`);
 				return false;
 			}
 		});

--- a/test/server/transforms/light-sign-up.test.js
+++ b/test/server/transforms/light-sign-up.test.js
@@ -7,7 +7,7 @@ const lightSignupTransform = require('../../../server/transforms/light-sign-up')
 describe('Light Signup component inside body', function () {
 
 	const defaultOptions = {metadata: { primarySection: null}};
-	const lightSignupHtml = '<div class="n-light-signup__container" data-n-light-signup-list-name="default" data-n-light-signup-list-pref-label="default"></div>';
+	const lightSignupHtml = '<div class="n-light-signup__container" data-n-light-signup-section-id="default" data-n-light-signup-section-pref-label="default"></div>';
 
 	describe('CONTROL variant', function () {
 
@@ -112,15 +112,15 @@ describe('Light Signup component inside body', function () {
 
 		it('should add data attribute values to the component', () => {
 			const $ = cheerio.load('<p>1</p><p>2</p><p>3</p><p>4</p><p>5</p><p>6</p>');
-			const options = {metadata: { primarySection: {name: 'foo', prefLabel: 'bar'}}};
-			const lightSignupHtml = '<div class="n-light-signup__container" data-n-light-signup-list-name="foo" data-n-light-signup-list-pref-label="bar"></div>';
+			const options = {metadata: { primarySection: {idV1: 'foo', prefLabel: 'bar'}}};
+			const lightSignupHtml = '<div class="n-light-signup__container" data-n-light-signup-section-id="foo" data-n-light-signup-section-pref-label="bar"></div>';
 			lightSignupTransform($, flags, options);
 			expect($.html()).to.equal(`<p>1</p>${lightSignupHtml}<p>2</p><p>3</p><p>4</p><p>5</p><p>6</p>`);
 		});
 
 		it('should only add data attribute values if name and prefLabel are present', () => {
 			const $ = cheerio.load('<p>1</p><p>2</p><p>3</p><p>4</p><p>5</p><p>6</p>');
-			const options = {metadata: { primarySection: {name: 'foo', prefLabel: null}}};
+			const options = {metadata: { primarySection: {idV1: 'foo', prefLabel: null}}};
 			lightSignupTransform($, flags, options);
 			expect($.html()).to.equal(`<p>1</p>${lightSignupHtml}<p>2</p><p>3</p><p>4</p><p>5</p><p>6</p>`);
 		});


### PR DESCRIPTION
 - Use the primarySection id as an identifier instead of its name.
 - Sanitise the naming of the data attributes.
 - Tweak tests to fit