### PR TITLE
fix(anonSampleArticles): fix existing data-tracking (sic) attrs, add some new ones

### DIFF
--- a/views/content.html
+++ b/views/content.html
@@ -7,11 +7,11 @@
 	<link rel="amphtml" href="https://amp.ft.com/content/{{id}}" />
 {{/defineBlock}}
 {{#if sampleArticles}}
-	<header class="sample-articles__ribbon">
+	<header class="sample-articles__ribbon" data-trackable="sample-articles-ribbon">
 		<div class="sample-articles__ribbon__wrapper">
 			<h2 class="sample-articles__ribbon__banner__heading">You're sampling the Financial Times</h2>
 			<div class="sample-articles__ribbon__link__banner__wrapper">
-				<a class="sample-articles__ribbon__text_link" href="#more-sample-articles">More sample articles</a>
+				<a class="sample-articles__ribbon__text_link" href="#more-sample-articles" data-trackable="more">More sample articles</a>
 				<i class="sample-articles__ribbon__text_link__icon"></i>
 			</div>
 		</div>

--- a/views/partials/related/sample-articles.html
+++ b/views/partials/related/sample-articles.html
@@ -1,4 +1,4 @@
-<section class="sample-articles" data-tracking="sample-articles">
+<section class="sample-articles" data-trackable="sample-articles">
 	<header class="sample-articles__ribbon">
 		<div class="sample-articles__ribbon__wrapper jump-to-block" id="more-sample-articles">
 			<h3 class="sample-articles__ribbon__heading">
@@ -11,6 +11,7 @@
 				<a
 					class="sample-articles__ribbon__link n-header__marketing-promo__link"
 					href="/products"
+					data-trackable="subscribe"
 				>Subscribe</a>
 			</div>
 		</div>
@@ -22,7 +23,7 @@
 			data-o-expander-count-selector="li"
 			data-o-expander-expanded-toggle-text="Show less"
 			data-o-expander-collapsed-toggle-text="Show more"
-			data-tracking="sample-articles-main-topic"
+			data-trackable="main-topic"
 		>
 			<h3 class="sample-articles__header__lead">Related Articles</h3>
 			<ul class="o-expander__content sample-articles__items">
@@ -43,7 +44,7 @@
 	{{/with}}
 		<div class="sample-articles__wrapper">
 			<h3 class="sample-articles__header__lead">Recommended Reads</h3>
-			<ul class="sample-articles__items" data-tracking="sample-articles-other-topics">
+			<ul class="sample-articles__items" data-trackable="other-topics">
 				{{#each sampleArticles.otherTopics}}
 					<li class="sample-articles__item__wrapper">
 						<article class="sample-articles__item">


### PR DESCRIPTION
 - Change existing attrs named `data-tracking` to be `data-trackable`.
 - DRY up attr values, removing `sample-articles-` prefix
 - Add data-trackable for subscribe button
 - Add data-trackable for ribbon & link

/cc @commuterjoy 