### PR TITLE
fix(anonSampleArticles): IE11 flex overflow

### DIFF
--- a/client/components/sample-articles/_main.scss
+++ b/client/components/sample-articles/_main.scss
@@ -182,7 +182,7 @@
 		margin: 0 0 0 6px;
 		max-width: 321px;
 		text-align: left;
-		flex: 2;
+		flex: 1 0 auto;
 		align-self: baseline;
 	}
 


### PR DESCRIPTION
A known issue with IE11 is that any flex container with flex-direction:row will not pay attention to
the height of it's children. This was causing the ULs inside the anonSampleArticles components to
overflow out of their boxes, and looked very broken. The solution, (which is irritatingly simple,
considering the time it took to fix) is for some unknown reason to write out the full "flex"
properties for the children - so rather than `flex: 1`, `flex: 1 0 auto`.