### PR TITLE
Redirect syndicated content to old ft.com

### DIFF
--- a/server/controllers/negotiation.js
+++ b/server/controllers/negotiation.js
@@ -64,6 +64,11 @@ module.exports = function negotiationController(req, res, next) {
 				return res.redirect(302, `${webUrl}${webUrl.includes('?') ? '&' : '?'}ft_site=falcon&desktop=true`);
 			}
 
+			// Redirect syndicated / wires content to old FT.com as no treatment on Next yet
+			if (article && article.originatingParty && article.originatingParty !== 'FT') {
+				return res.redirect(302, `${webUrl}${webUrl.includes('?') ? '&' : '?'}ft_site=falcon&desktop=true`);
+			}
+
 			if (article) {
 				if (isArticlePodcast(article)) {
 					return controllerPodcast(req, res, next, article);

--- a/test/server/controllers/negotiation.test.js
+++ b/test/server/controllers/negotiation.test.js
@@ -263,6 +263,29 @@ describe('Negotiation Controller', function() {
 				});
 		});
 
+		it('redirects syndicated / wires content to ft.com', () => {
+			nock('https://next-elastic.ft.com')
+				.post('/v3_api_v2/item/_mget')
+				.reply(200, {
+					docs: [{
+						found: true,
+						_source: {
+							originatingParty: 'Reuters',
+							webUrl: 'http://www.ft.com/cms/s/0/bd729e4c-644d-11e6-8310-ecf0bddad227.html'
+						}
+					}]
+				});
+
+			return createInstance({
+				params: { id: 'uuid' }
+			})
+				.then(() => {
+					expect(response.statusCode).to.equal(302);
+					expect(response._getRedirectUrl()).to.include('http://www.ft.com/cms/s/0/bd729e4c-644d-11e6-8310-ecf0bddad227.html');
+					expect(response._getRedirectUrl()).to.include('?ft_site=falcon&desktop=true');
+				});
+		});
+
 	})
 
 });


### PR DESCRIPTION
When content is not originating from the FT (eg. Reuters), redirect back to old ft.com.
Temporary measure until agreed / implemented what syndicated content on next should look like.

Should be implemented before wires content is ingested through this [PR](https://github.com/Financial-Times/next-es-interface/pull/482)