### PR TITLE
Additional article MPU slots

### DIFF
--- a/server/transforms/inline-ad.js
+++ b/server/transforms/inline-ad.js
@@ -1,12 +1,10 @@
-module.exports = function ($) {
+'use strict';
+
+module.exports = function ($, flags) {
 	const pars = $('p');
-	pars.each((index, par) => {
-		if(index > 1
-			&& par.next
-			&& par.next.name === 'p'
-			&& !par.parent
-			&& par.prev.name !== 'aside') {
-			$(par).after(`<div class="o-ads in-article-advert advert"
+	const midAd = (adIndex) =>
+		adIndex === 0 ?
+			`<div class="o-ads in-article-advert advert"
 				data-o-ads-name="mpu"
 				data-o-ads-center="true"
 				data-o-ads-label="true"
@@ -16,10 +14,45 @@ module.exports = function ($) {
 				data-o-ads-formats-medium="MediumRectangle,Responsive"
 				data-o-ads-formats-large="Responsive"
 				data-o-ads-formats-extra="Responsive"
-				aria-hidden="true"></div>`);
-			return false;
+				aria-hidden="true"></div>` :
+		`<div class="o-ads in-article-advert advert"
+				data-o-ads-name="second-mpu"
+				data-o-ads-center="true"
+				data-o-ads-label="true"
+				data-o-ads-targeting="pos=mid;"
+				data-o-ads-formats-default="MediumRectangle,Responsive"
+				data-o-ads-formats-small="MediumRectangle,Responsive"
+				data-o-ads-formats-medium="false"
+				data-o-ads-formats-large="false"
+				data-o-ads-formats-extra="false"
+				aria-hidden="true"></div>`;
+	;
+
+
+	if(flags.adsMoreArticleMPUs && pars.length <= 3) {
+		//If article shorter than three pars, insert an ad right at the end
+		$('*').last().after(midAd);
+	} else {
+
+		const maxAdsToRender = 2;
+		let nextAvailableIndex = 1;
+		let adsRendered = 0;
+
+		for(let index = 0; index < pars.length; index++) {
+			const par = pars[index];
+			const isBetweenParagraphs = par.next && par.next.name === 'p' && !par.parent && par.prev && par.prev.name !== 'aside';
+
+			if(index > nextAvailableIndex && isBetweenParagraphs && adsRendered < maxAdsToRender) {
+				$(par).after(midAd(adsRendered++));
+
+				if(flags.adsMoreArticleMPUs) {
+					nextAvailableIndex = index + 5; //insert an Ad after another 6 paragraphs
+				} else {
+					break; // no more ads to render
+				}
+			}
 		}
-	});
+	}
 
 	return $;
 };

--- a/server/transforms/inline-ad.js
+++ b/server/transforms/inline-ad.js
@@ -22,7 +22,7 @@ module.exports = function ($, flags) {
 				data-o-ads-targeting="pos=mid;"
 				data-o-ads-formats-default="MediumRectangle,Responsive"
 				data-o-ads-formats-small="MediumRectangle,Responsive"
-				data-o-ads-formats-medium="false"
+				data-o-ads-formats-medium="MediumRectangle,Responsive"
 				data-o-ads-formats-large="false"
 				data-o-ads-formats-extra="false"
 				aria-hidden="true"></div>`;

--- a/test/server/transforms/inline-ad.test.js
+++ b/test/server/transforms/inline-ad.test.js
@@ -9,16 +9,30 @@ describe('Inline ad inside body', function () {
 
 	const adHtml = '<div class="o-ads in-article-advert advert" data-o-ads-name="mpu" data-o-ads-center="true" data-o-ads-label="true" data-o-ads-targeting="pos=mid;" data-o-ads-formats-default="MediumRectangle,Responsive" data-o-ads-formats-small="MediumRectangle,Responsive" data-o-ads-formats-medium="MediumRectangle,Responsive" data-o-ads-formats-large="Responsive" data-o-ads-formats-extra="Responsive" aria-hidden="true"></div>';
 
+	const secondAdHtml = '<div class="o-ads in-article-advert advert" data-o-ads-name="second-mpu" data-o-ads-center="true" data-o-ads-label="true" data-o-ads-targeting="pos=mid;" data-o-ads-formats-default="MediumRectangle,Responsive" data-o-ads-formats-small="MediumRectangle,Responsive" data-o-ads-formats-medium="false" data-o-ads-formats-large="false" data-o-ads-formats-extra="false" aria-hidden="true"></div>';
+
 	it('should insert an ad between the third and fourth paragraphs', function() {
 		const $ = cheerio.load('<p>1</p><p>2</p><p>3</p><p>4</p>', { decodeEntities: false });
 		inlineAdTransform($, {}, {adsLayout: 'default'});
 		expect($.html()).to.equal(`<p>1</p><p>2</p><p>3</p>${adHtml}<p>4</p>`);
 	});
 
-	it('should not insert an ad if there are only three paragraphs', function() {
+	it('should insert an ad at the end of the doc if there are three paragraphs', function() {
 		const $ = cheerio.load('<p>1</p><img><p>2</p><p>3</p><img>', { decodeEntities: false });
-		inlineAdTransform($, {}, {adsLayout: 'default'});
+		inlineAdTransform($, { adsMoreArticleMPUs: true }, {adsLayout: 'default'});
+		expect($.html()).to.equal(`<p>1</p><img><p>2</p><p>3</p><img>${adHtml}`);
+	});
+
+	it('should not insert an ad at the end of the doc if there are three paragraphs and the flag is off', function() {
+		const $ = cheerio.load('<p>1</p><img><p>2</p><p>3</p><img>', { decodeEntities: false });
+		inlineAdTransform($, { adsMoreArticleMPUs: false }, {adsLayout: 'default'});
 		expect($.html()).to.equal(`<p>1</p><img><p>2</p><p>3</p><img>`);
+	});
+
+	it('should insert an ad at the end of the doc if there are less than three paragraphs', function() {
+		const $ = cheerio.load('<p>1</p>', { decodeEntities: false });
+		inlineAdTransform($, { adsMoreArticleMPUs: true }, {adsLayout: 'default'});
+		expect($.html()).to.equal(`<p>1</p>${adHtml}`);
 	});
 
 	it('should move the ad later if there is any other element after the third paragraph', function() {
@@ -37,5 +51,11 @@ describe('Inline ad inside body', function () {
 		var $ = cheerio.load('<p>1</p><aside>2</aside><p>3</p><p>4</p><p>5</p>');
 		$ = inlineAdTransform($, {}, 'responsive');
 		expect($.html()).to.equal(`<p>1</p><aside>2</aside><p>3</p><p>4</p>${adHtml.replace("pos=mpu;", "pos=mid;")}<p>5</p>`);
+	});
+
+	it('should add a second MPU after another 6 pars if flag is on', function() {
+		var $ = cheerio.load(`<p>1</p><p>2</p><p>3</p><p>4</p><p>5</p><p>6</p><p>7</p><p>8</p><p>9</p><p>10</p><p>11</p><p>12</p><p>13</p><p>14</p><p>15</p><p>16</p>`);
+		$ = inlineAdTransform($, { adsMoreArticleMPUs: true}, 'responsive');
+		expect($.html()).to.equal(`<p>1</p><p>2</p><p>3</p>${adHtml}<p>4</p><p>5</p><p>6</p><p>7</p><p>8</p><p>9</p>${secondAdHtml}<p>10</p><p>11</p><p>12</p><p>13</p><p>14</p><p>15</p><p>16</p>`);
 	});
 });

--- a/test/server/transforms/inline-ad.test.js
+++ b/test/server/transforms/inline-ad.test.js
@@ -9,7 +9,7 @@ describe('Inline ad inside body', function () {
 
 	const adHtml = '<div class="o-ads in-article-advert advert" data-o-ads-name="mpu" data-o-ads-center="true" data-o-ads-label="true" data-o-ads-targeting="pos=mid;" data-o-ads-formats-default="MediumRectangle,Responsive" data-o-ads-formats-small="MediumRectangle,Responsive" data-o-ads-formats-medium="MediumRectangle,Responsive" data-o-ads-formats-large="Responsive" data-o-ads-formats-extra="Responsive" aria-hidden="true"></div>';
 
-	const secondAdHtml = '<div class="o-ads in-article-advert advert" data-o-ads-name="second-mpu" data-o-ads-center="true" data-o-ads-label="true" data-o-ads-targeting="pos=mid;" data-o-ads-formats-default="MediumRectangle,Responsive" data-o-ads-formats-small="MediumRectangle,Responsive" data-o-ads-formats-medium="false" data-o-ads-formats-large="false" data-o-ads-formats-extra="false" aria-hidden="true"></div>';
+	const secondAdHtml = '<div class="o-ads in-article-advert advert" data-o-ads-name="second-mpu" data-o-ads-center="true" data-o-ads-label="true" data-o-ads-targeting="pos=mid;" data-o-ads-formats-default="MediumRectangle,Responsive" data-o-ads-formats-small="MediumRectangle,Responsive" data-o-ads-formats-medium="MediumRectangle,Responsive" data-o-ads-formats-large="false" data-o-ads-formats-extra="false" aria-hidden="true"></div>';
 
 	it('should insert an ad between the third and fourth paragraphs', function() {
 		const $ = cheerio.load('<p>1</p><p>2</p><p>3</p><p>4</p>', { decodeEntities: false });

--- a/views/partials/ads/top.html
+++ b/views/partials/ads/top.html
@@ -1,8 +1,8 @@
 <div
 	{{#if @root.flags.adsReserveBillboardHeight}}
-	class="advert above-header-advert o-ads advert--background advert--transition advert--reserve-250"
+	class="advert above-header-advert o-ads o-ads--background o-ads--transition o-ads--reserve-250"
 {{else}}
-	class="o-ads above-header-advert advert advert--background advert--transition advert--reserve-90"
+	class="o-ads above-header-advert advert o-ads--background o-ads--transition o-ads--reserve-90"
 {{/if}}
 	data-o-ads-name="entry"
 	data-o-ads-center="true"


### PR DESCRIPTION
@VladDubrovskis @andrewgeorgiou1981 @andygnewman 
If the adsMoreArticleMPUs flag is on:

* If an article is shorter than 3 paragraphs, stick an ad at the bottom of the article
* On mobiles and tablet portrait - add a second ad slot a further 6 paragraphs after the first one (still abiding to the same rules of having to be between two paragraphs and not an aside, etc).

Also tidy up some old classnames.