### PR TITLE
Ads - fix bug with instream

### DIFF
--- a/server/transforms/inline-ad.js
+++ b/server/transforms/inline-ad.js
@@ -31,7 +31,7 @@ module.exports = function ($, flags) {
 
 	if(flags.threeAdProposition && pars.length <= 3) {
 		//If article shorter than three pars, insert an ad right at the end
-		$('*').last().after(midAd);
+		$('p').last().after(midAd);
 	} else {
 
 		const maxAdsToRender = 2;

--- a/server/transforms/inline-ad.js
+++ b/server/transforms/inline-ad.js
@@ -31,8 +31,9 @@ module.exports = function ($, flags) {
 
 	if(flags.threeAdProposition && pars.length <= 3) {
 		//If article shorter than three pars, insert an ad right at the end
-		if ($('*').last()[0].name === 'p'){
-			$('*').last().after(midAd);
+		let lastElement = $('*').last();
+		if (lastElement[0].name === 'p'){
+			lastElement.after(midAd);
 		}
 	} else {
 

--- a/server/transforms/inline-ad.js
+++ b/server/transforms/inline-ad.js
@@ -31,7 +31,9 @@ module.exports = function ($, flags) {
 
 	if(flags.threeAdProposition && pars.length <= 3) {
 		//If article shorter than three pars, insert an ad right at the end
-		$('p').last().after(midAd);
+		if ($('*').last()[0].name === 'p'){
+			$('*').last().after(midAd);
+		}
 	} else {
 
 		const maxAdsToRender = 2;

--- a/test/server/transforms/inline-ad.test.js
+++ b/test/server/transforms/inline-ad.test.js
@@ -17,9 +17,15 @@ describe('Inline ad inside body', function () {
 	});
 
 	it('should insert an ad at the end of the doc if there are three paragraphs', function () {
+		const $ = cheerio.load('<p>1</p><img><p>2</p><p>3</p>', { decodeEntities: false });
+		inlineAdTransform($, { threeAdProposition: true }, {adsLayout: 'default'});
+		expect($.html()).to.equal(`<p>1</p><img><p>2</p><p>3</p>${adHtmlWithoutResponsive}`);
+	});
+
+	it('should not insert an ad at the end of the doc if there are three paragraphs but the last element is not a paragraph', function () {
 		const $ = cheerio.load('<p>1</p><img><p>2</p><p>3</p><img>', { decodeEntities: false });
 		inlineAdTransform($, { threeAdProposition: true }, {adsLayout: 'default'});
-		expect($.html()).to.equal(`<p>1</p><img><p>2</p><p>3</p><img>${adHtmlWithoutResponsive}`);
+		expect($.html()).to.equal('<p>1</p><img><p>2</p><p>3</p><img>');
 	});
 
 	it('should not insert an ad at the end of the doc if there are three paragraphs and the flag is off', function () {


### PR DESCRIPTION
Ads; if the last element in the article body is not a paragraph then we no longer wish to insert an ad. This has been done to prevent layout issues if the last element is an absolute positioned <img>