### PR TITLE
Replace clipboard data with legal message

### DIFF
--- a/client/components/legal-copy/main.js
+++ b/client/components/legal-copy/main.js
@@ -1,0 +1,8 @@
+module.exports = function () {
+	const articleBody = document.querySelector('[data-legal-copy]');
+
+	articleBody.addEventListener('copy', (e) => {
+		e.clipboardData.setData('text/plain', 'naughty');
+		e.preventDefault();
+	});
+}

--- a/client/components/legal-copy/main.js
+++ b/client/components/legal-copy/main.js
@@ -1,8 +1,30 @@
-module.exports = function () {
+'use strict';
+
+function supportsClipboard (e) { return e.clipboardData || window.clipboardData; }
+function hasEventClipboardSupport (e) { return e.clipboardData && !!e.clipboardData.setData }
+
+module.exports = function (flags) {
 	const articleBody = document.querySelector('[data-legal-copy]');
 
+	if(!articleBody) { return }
+	if (!flags.get('articleCopyLegalNotice')) { return }
+
+	const tsAndCsLink = 'http://help.ft.com/legal/ft-com-terms-and-conditions/';
+	const copyrightLink = 'http://help.ft.com/legal/copyright-policy/';
+	const supportEmail = 'ftsales.support@ft.com';
+
+	const msgText = `High quality global journalism requires investment. Please share this article with others using the link below, do not cut & paste the article. See our Ts&Cs and Copyright Policy for more detail. Email ${supportEmail} to buy additional rights.`;
+	const msgHtml = `High quality global journalism requires investment. Please share this article with others using the link below, do not cut & paste the article. See our <a href="${tsAndCsLink}" target="_blank">Ts&Cs</a> and <a href="${copyrightLink}" target="_blank">Copyright</a> Policy for more detail. Email <a href="mailto:${supportEmail}">${supportEmail}</a> to buy additional rights.`;
+
 	articleBody.addEventListener('copy', (e) => {
-		e.clipboardData.setData('text/plain', 'naughty');
+		if(!supportsClipboard(e)) { return }
+
+		if(hasEventClipboardSupport(e)) {
+			e.clipboardData.setData('text/html', msgHtml);
+		} else {
+			window.clipboardData.setData('Text', msgText);
+		}
+
 		e.preventDefault();
 	});
 }

--- a/client/main.js
+++ b/client/main.js
@@ -19,6 +19,7 @@ bootstrap(nUiConfig, ({flags, mainCss}) => {
 	const share = require('./components/share/main');
 	const promotedContent = require('./components/ads/promoted-content');
 	const ftlabsSpokenLayer = require('./components/ftlabsSpokenLayer/main');
+	const legalCopy = require('./components/legal-copy/main');
 
 	// cacheJourney();
 

--- a/client/main.js
+++ b/client/main.js
@@ -45,6 +45,7 @@ bootstrap(nUiConfig, ({flags, mainCss}) => {
 
 	toc.init(flags);
 	scrollDepth(flags);
+	legalCopy(flags);
 
 	mainCss.then(() => {
 		slideshow(document.querySelectorAll('.article ft-slideshow'));

--- a/views/content.html
+++ b/views/content.html
@@ -54,7 +54,7 @@
 					{{/ifEquals}}
 					{{#ifEquals contentType 'podcast'}}
 						{{#if standfirst}}
-							<div class="article__body n-content-body" data-trackable="article-body">
+							<div class="article__body n-content-body" data-trackable="article-body" data-legal-copy>
 								<p>{{{standfirst}}}</p>
 							</div>
 						{{/if}}

--- a/views/partials/body-article.html
+++ b/views/partials/body-article.html
@@ -1,4 +1,4 @@
-<div class="article__body n-content-body{{#if withGcs}} p402_premium{{/if}}" data-trackable="article-body">
+<div class="article__body n-content-body{{#if withGcs}} p402_premium{{/if}}" data-trackable="article-body" data-legal-copy>
 	{{{bodyHTML}}}
 </div>
 {{#if withGcs}}


### PR DESCRIPTION
This replaces a users clipboard data with a legal copy message to prevent copyright infringements. It uses the `copy` event which is only supported in a sub-set of browsers. But we are OK with this for the initial experiment.