### PR TITLE
Hide in-article teaser image URLs for print

### DIFF
--- a/client/main.scss
+++ b/client/main.scss
@@ -141,6 +141,11 @@ $o-video-is-silent: false;
 			padding-left: 0;
 		}
 	}
+
+	// We’re already printing the headline URL, so no point showing it again for the image
+	.o-teaser__image-container a[href^='/']:after {
+		content: '';
+	}
 }
 
 //TODO: Putting all the teaser-related CSS here.

--- a/client/main.scss
+++ b/client/main.scss
@@ -143,9 +143,11 @@ $o-video-is-silent: false;
 	}
 
 	// We’re already printing the headline URL, so no point showing it again for the image
+	// scss-lint:disable QualifyingElement
 	.o-teaser__image-container a[href^='/']:after {
 		content: '';
 	}
+	// scss-lint:enable QualifyingElement
 }
 
 //TODO: Putting all the teaser-related CSS here.


### PR DESCRIPTION
We’re already printing the headline URL, so no point showing it again
for the image (they’re the same URL).

@adgad 