### PR TITLE
Affinity proxy

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,8 @@
     "o-email-only-signup": "^3.2.3",
     "o-gallery": "^1.7.4",
     "o-share": "^2.1.2",
-    "superstore": "^2.1.0"
+    "superstore": "^2.1.0",
+    "next-affinity-client": "^0.1.0"
   },
   "resolutions": {
     "o-typography": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "forever": "^0.15.1",
     "ft-n-article-branding": "^3.0.0",
     "ft-n-content-transform": "^2.0.0",
+    "ft-next-affinity-client": "^0.1.0",
     "ft-next-article-genre": "^1.1.0",
     "ft-next-article-primary-tag": "^1.0.0",
     "ft-poller": "^2.0.3",
@@ -30,10 +31,10 @@
     "n-health": "^1.3.0",
     "n-podcast-mapping": "Financial-Times/n-podcast-mapping",
     "next-ft-api-client": "^3.16.0",
+    "next-json-ld": "https://github.com/Financial-Times/next-json-ld",
     "react": "^15.0.1",
     "react-dom": "^15.0.1",
-    "shellpromise": "^1.3.0",
-    "next-json-ld": "https://github.com/Financial-Times/next-json-ld"
+    "shellpromise": "^1.3.0"
   },
   "devDependencies": {
     "@financial-times/n-heroku-tools": "^6.12.0",

--- a/server/app.js
+++ b/server/app.js
@@ -58,6 +58,13 @@ app.get(`^/content/:id(${uuid})$`, (req, res, next) => {
 	next();
 }, require('./controllers/negotiation'));
 
+// normal caching on popular calls, no caching on other affinity calls
+app.get('^/__affinity/:type(popular)', require('./controllers/affinity-proxy'));
+app.get(`^/__affinity/:type/:id(${uuid})?/:user(user)?/:uid?`, (req, res, next) => {
+	res.set('Surrogate-Control', res.FT_NO_CACHE);
+	next();
+}, require('./controllers/affinity-proxy'));
+
 app.get('/__gtg', (req, res) => {
 	res.status(200).end();
 });

--- a/server/controllers/affinity-proxy.js
+++ b/server/controllers/affinity-proxy.js
@@ -1,0 +1,21 @@
+'use strict';
+const affinityApi = require('ft-next-affinity-client');
+const logger = require('@financial-times/n-logger').default;
+
+/**
+* Public-facing endpoint to proxy client-side requests via the server to the affinity client
+* See affinity-client for params
+**/
+module.exports = (req, res) => {
+	const options = {
+		params: req.params,
+		query: req.query
+	};
+	return affinityApi.buildRequest(options)
+		.then(data => {
+			return res.json(data)
+		})
+		.catch(error => {
+			logger.warn('Error fetching content from affinity proxy to client', { event: 'FETCH_PROXY_ERROR', msg: error });
+		});
+}

--- a/server/controllers/affinity-proxy.js
+++ b/server/controllers/affinity-proxy.js
@@ -1,21 +1,16 @@
 'use strict';
 const affinityApi = require('ft-next-affinity-client');
-const logger = require('@financial-times/n-logger').default;
 
 /**
 * Public-facing endpoint to proxy client-side requests via the server to the affinity client
 * See affinity-client for params
 **/
-module.exports = (req, res) => {
+module.exports = (req, res, next) => {
 	const options = {
 		params: req.params,
 		query: req.query
 	};
 	return affinityApi.buildRequest(options)
-		.then(data => {
-			return res.json(data)
-		})
-		.catch(error => {
-			logger.warn('Error fetching content from affinity proxy to client', { event: 'FETCH_PROXY_ERROR', msg: error });
-		});
+		.then(data => res.json(data))
+		.catch(next);
 }

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -32,9 +32,7 @@ module.exports = [
 			// articles with not tagged with X
 			'/article/02cad03a-844f-11e4-bae9-00144feabdc0/more-on?tagIds=TnN0ZWluX1BOX1BvbGl0aWNpYW5fMTY4OA==-UE4=,NDdiMzAyNzctMTRlMy00Zjk1LWEyZjYtYmYwZWIwYWU2NzAy-VG9waWNz&index=1': {
 				content: ''
-			},
-			// affinity
-			'/__affinity/popular': 200
+			}
 		}
 	}
 ];

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -32,7 +32,9 @@ module.exports = [
 			// articles with not tagged with X
 			'/article/02cad03a-844f-11e4-bae9-00144feabdc0/more-on?tagIds=TnN0ZWluX1BOX1BvbGl0aWNpYW5fMTY4OA==-UE4=,NDdiMzAyNzctMTRlMy00Zjk1LWEyZjYtYmYwZWIwYWU2NzAy-VG9waWNz&index=1': {
 				content: ''
-			}
+			},
+			// affinity
+			'/__affinity/popular': 200
 		}
 	}
 ];


### PR DESCRIPTION
provides public-facing access to the affinity api so that client-side calls don't contain keys in their headers but use a server-side proxy instead