### PR TITLE
Topper flag check

### DIFF
--- a/test/smoke.js
+++ b/test/smoke.js
@@ -23,6 +23,8 @@ module.exports = [
 			'/embedded-components/slideshow/593496fc-a4d5-11e5-97e1-a754d5d9538c': 200,
 			// fragment view
 			'/content/a85bf481-457c-3bd4-bd49-3801d175d583?fragment=true': 200,
+			// article with topper
+			'/content/7b38ad62-d1a5-11e6-b06b-680c49b4b4c0': 200,
 			// related fragments - story package
 			'/article/02cad03a-844f-11e4-bae9-00144feabdc0/story-package?articleIds=b56232bc-adec-11e4-919e-00144feab7de,8a5c2c02-a47e-11e4-b943-00144feab7de,6bfcdc6e-a0b6-11e4-8ad8-00144feab7de,c0dbd6d6-8072-11e4-9907-00144feabdc0': 200,
 			// related fragments - more-ons
@@ -53,6 +55,8 @@ module.exports = [
 			'/content/c382002a-a839-366c-9b5f-c3e51a25e05d': 200,
 			// fragment view
 			'/content/a85bf481-457c-3bd4-bd49-3801d175d583?fragment=true': 200
+			// article with topper
+			'/content/7b38ad62-d1a5-11e6-b06b-680c49b4b4c0': 200
 		}
 	}
 ];

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -54,7 +54,7 @@ module.exports = [
 			// video
 			'/content/c382002a-a839-366c-9b5f-c3e51a25e05d': 200,
 			// fragment view
-			'/content/a85bf481-457c-3bd4-bd49-3801d175d583?fragment=true': 200
+			'/content/a85bf481-457c-3bd4-bd49-3801d175d583?fragment=true': 200,
 			// article with topper
 			'/content/7b38ad62-d1a5-11e6-b06b-680c49b4b4c0': 200
 		}

--- a/views/content.html
+++ b/views/content.html
@@ -26,11 +26,11 @@
 		{{#defineBlock 'above-header'}}{{> ads/top }}{{/defineBlock}}
 	{{/if}}
 
-	{{#if topper}}
+	{{#ifAll @root.flags.articleTopper topper}}
 		{{> topper/main}}
 	{{else}}
 		{{> header/content-header}}
-	{{/if}}
+	{{/ifAll}}
 	{{> body-wrapper}}
 
 {{>propensity-messaging-promo-unit}}


### PR DESCRIPTION
If we add topper to the ElasticSearch model, then currently the feature would have accidentally gone live (as the code currently only checked in the controller before fetching from /internalcontent).

This adds an interim check in the template for the flag, so that we can roll out ElasticSearch before the other article PR.

@kavanagh @TheoLeanse @gvonkoss 