### PR TITLE
Fail getInteractive() gracefully (by ignoring it)

### DIFF
--- a/server/controllers/negotiation.js
+++ b/server/controllers/negotiation.js
@@ -21,9 +21,12 @@ function isArticleVideo ({ webUrl = '' } = {}) {
 }
 
 function getInteractive (contentId) {
-	return interactivePoller.getData().find(
-		mapping => mapping.articleuuid === contentId
-	);
+	try {
+		return interactivePoller.getData().find(
+			mapping => mapping.articleuuid === contentId
+		);
+	}
+	catch (e) {}
 }
 
 function getArticle (contentId) {


### PR DESCRIPTION
Fixes :crossed_fingers: a problem when running locally and npm-linked to @financialtimes/n-ui.

However, I couldn't discern what was making `getInteractive()` — specifically, `interactivePoller.getData()` — fail ... 