### PR TITLE
Tidy up core version of inArticlePreview trial variant

### DIFF
--- a/views/partials/inline-barrier.html
+++ b/views/partials/inline-barrier.html
@@ -21,7 +21,7 @@
 				</p>
 				<img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fstandard_digital.png?width=160&amp;source=next&amp;fit=scale-down" alt="" role="presentation" aria-hidden="true">
 				<p>
-					<a href="/signup?offerId=41218b9e-c8ae-c934-43ad-71b13fcb4465&in-article=true" class="o-buttons o-buttons--big o-buttons--standout inline-barrier__button" data-trackable="sign-up">
+					<a href="/signup?offerId=41218b9e-c8ae-c934-43ad-71b13fcb4465&amp;in-article=true" class="o-buttons o-buttons--big o-buttons--standout inline-barrier__button" data-trackable="sign-up">
 						Sign up for <span class="js-barrier-trial-price"></span> trial now
 					</a>
 				</p>

--- a/views/partials/inline-barrier.html
+++ b/views/partials/inline-barrier.html
@@ -13,15 +13,30 @@
 		{{else ifEquals @root.flags.inArticlePreview 'trial'}}
 
 			<div class="inline-barrier__content">
-				<p class="inline-barrier__heading inline-barrier__needs-price">Keep reading for just <span class="js-barrier-trial-price"></span></p>
-				<p class="inline-barrier__description inline-barrier__needs-price">Receive 4 weeks of unlimited Premium <span aria-label="F T dot com">FT.com</span> access for just <span class="js-barrier-trial-price"></span>*</p>
+				<p class="inline-barrier__heading inline-barrier__needs-price">
+					Keep reading for just <span class="js-barrier-trial-price"></span>
+				</p>
+				<p class="inline-barrier__description">
+					Receive 4 weeks of unlimited Premium <span aria-label="F T dot com">FT.com</span> access<span class="inline-barrier__needs-price"> for just <span class="js-barrier-trial-price"></span></span>*
+				</p>
 				<img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fstandard_digital.png?width=160&amp;source=next&amp;fit=scale-down" alt="" role="presentation" aria-hidden="true">
-				<p><a href="/signup?offerId=41218b9e-c8ae-c934-43ad-71b13fcb4465&in-article=true" class="o-buttons o-buttons--big o-buttons--standout inline-barrier__button" data-trackable="sign-up">Sign up<span class="inline-barrier__needs-price"> for <span class="js-barrier-trial-price"></span> trial now</a></p>
-				<p class="inline-barrier__more"><a href="/products?in-article=true" data-trackable="view-all">View all subscription options</a></p>
-				<p class="inline-barrier__terms inline-barrier__needs-price"><a href="http://help.ft.com/help/legal-privacy/terms-conditions/" data-trackable="terms-conditions">*Terms &amp; conditions apply.</a></p>
+				<p>
+					<a href="/signup?offerId=41218b9e-c8ae-c934-43ad-71b13fcb4465&in-article=true" class="o-buttons o-buttons--big o-buttons--standout inline-barrier__button" data-trackable="sign-up">
+						Sign up for <span class="js-barrier-trial-price"></span> trial now
+					</a>
+				</p>
+				<p class="inline-barrier__more">
+					<a href="/products?in-article=true" data-trackable="view-all">
+						View all subscription options
+					</a>
+				</p>
+				<p class="inline-barrier__terms">
+					<a href="http://help.ft.com/help/legal-privacy/terms-conditions/" data-trackable="terms-conditions">
+						*Terms &amp; conditions apply.
+					</a>
+				</p>
 			</div>
 
 		{{/ifEquals}}
-
 	</div>
 {{/if}}


### PR DESCRIPTION
Now that we’re forcing all `inArticlePreview` journeys onto the new
form (which has the price of the trial included in it), our core and
enhanced text can be almost the same (apart from the actual currency
text).