### PR TITLE
Align inArticlePreview core designs

### DIFF
--- a/client/components/inline-barrier/main.js
+++ b/client/components/inline-barrier/main.js
@@ -36,10 +36,14 @@ const populateWithPsp = (el) => fetch('/products?fragment=true&inline=true&narro
 		if (response.ok) {
 			return response.text().then(html => {
 				const parsedHtml = new DOMParser().parseFromString(html, 'text/html');
+				const coreWrapper = el.querySelector('.inline-barrier__content');
 				const pspEl = parsedHtml.querySelector('.barrier');
+
+				if (!el || !pspEl || !coreWrapper) { return; }
+
 				//Remove duplicate ID so pa11y passes
-				pspEl && pspEl.removeAttribute('id');
-				const pspTitle = pspEl && pspEl.querySelector('.barrier-grid__heading-pretext');
+				pspEl.removeAttribute('id');
+				const pspTitle = pspEl.querySelector('.barrier-grid__heading-pretext');
 
 				if (pspTitle) {
 					// Horrible hacks to modify the PSP title text, for a slightly dirty MVT
@@ -55,11 +59,12 @@ const populateWithPsp = (el) => fetch('/products?fragment=true&inline=true&narro
 				}
 
 				el.classList.remove('inline-barrier--no-prices');
-				el.insertAdjacentElement('beforeend', pspEl);
+				el.replaceChild(pspEl, coreWrapper);
 
 				broadcastOpportunity('inline-psp');
 			});
 		}
+	})
 	});
 
 const populateWithTrial = (el) => fetch(`https://next-signup-api.ft.com/offer/41218b9e-c8ae-c934-43ad-71b13fcb4465?countryCode=${el.dataset.countryCode}`, {

--- a/client/components/inline-barrier/main.js
+++ b/client/components/inline-barrier/main.js
@@ -65,6 +65,12 @@ const populateWithPsp = (el) => fetch('/products?fragment=true&inline=true&narro
 			});
 		}
 	})
+	.catch(() => {
+		// eslint-disable-next-line no-console
+		console.error('Failed to retrieve/process PSP fragment');
+	})
+	.then(() => {
+		el.classList.add('inline-barrier--done');
 	});
 
 const populateWithTrial = (el) => fetch(`https://next-signup-api.ft.com/offer/41218b9e-c8ae-c934-43ad-71b13fcb4465?countryCode=${el.dataset.countryCode}`, {

--- a/client/components/inline-barrier/main.scss
+++ b/client/components/inline-barrier/main.scss
@@ -51,13 +51,13 @@ p.barrier-grid__heading-pretext {
 }
 
 .enhanced {
-	.inline-barrier--trial {
+	.inline-barrier {
 		.inline-barrier__content {
 			display: none;
 		}
 	}
 
-	.inline-barrier--trial.inline-barrier--done {
+	.inline-barrier--done {
 		.inline-barrier__content {
 			display: block;
 		}

--- a/views/partials/inline-barrier.html
+++ b/views/partials/inline-barrier.html
@@ -4,14 +4,15 @@
 			<p class="n-util-visually-hidden">This is the end of your free article preview.</p>
 		</div>
 		<div class="inline-barrier__content">
-		{{#ifEquals @root.flags.inArticlePreview 'psp'}}
 
-			<div class="n-util-hide-enhanced">
-				<p class="inline-barrier__heading">Want to read more?</p>
-				<a href="/products?in-article=true" class="o-buttons o-buttons--standout o-buttons--big" aria-label="Subscribe to the Financial Times">Subscribe to the FT</a>
-			</div>
+			{{#ifEquals @root.flags.inArticlePreview 'psp'}}
 
-		{{else ifEquals @root.flags.inArticlePreview 'trial'}}
+				<div class="n-util-hide-enhanced">
+					<p class="inline-barrier__heading">Want to read more?</p>
+					<a href="/products?in-article=true" class="o-buttons o-buttons--standout o-buttons--big" aria-label="Subscribe to the Financial Times">Subscribe to the FT</a>
+				</div>
+
+			{{else ifEquals @root.flags.inArticlePreview 'trial'}}
 
 				<p class="inline-barrier__heading inline-barrier__needs-price">
 					Keep reading for just <span class="js-barrier-trial-price"></span>
@@ -36,7 +37,7 @@
 					</a>
 				</p>
 
-		{{/ifEquals}}
+			{{/ifEquals}}
 
 		</div>
 	</div>

--- a/views/partials/inline-barrier.html
+++ b/views/partials/inline-barrier.html
@@ -1,4 +1,9 @@
 {{#if @root.flags.inArticlePreview}}
+
+	{{#*inline "image"}}
+		<img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fstandard_digital.png?width=160&amp;source=next&amp;fit=scale-down" alt="" role="presentation" aria-hidden="true">
+	{{/inline}}
+
 	<div class="inline-barrier inline-barrier--{{@root.flags.inArticlePreview}} inline-barrier--no-prices" data-n-component="inline-barrier" data-n-type="{{type}}" data-country-code="{{countryCode}}" data-trackable="inline-barrier">
 		<div class="inline-barrier__fader">
 			<p class="n-util-visually-hidden">This is the end of your free article preview.</p>
@@ -7,10 +12,13 @@
 
 			{{#ifEquals @root.flags.inArticlePreview 'psp'}}
 
-				<div class="n-util-hide-enhanced">
-					<p class="inline-barrier__heading">Want to read more?</p>
-					<a href="/products?in-article=true" class="o-buttons o-buttons--standout o-buttons--big" aria-label="Subscribe to the Financial Times">Subscribe to the FT</a>
-				</div>
+				<p class="inline-barrier__description">
+					Want to read more?
+				</p>
+				{{> image }}
+				<p>
+					<a href="/products?in-article=true" class="o-buttons o-buttons--big o-buttons--standout inline-barrier__button" aria-label="Subscribe to the Financial Times" data-trackable="sign-up-psp">Subscribe to the FT</a>
+				</p>
 
 			{{else ifEquals @root.flags.inArticlePreview 'trial'}}
 
@@ -20,7 +28,7 @@
 				<p class="inline-barrier__description">
 					Receive 4 weeks of unlimited Premium <span aria-label="F T dot com">FT.com</span> access<span class="inline-barrier__needs-price"> for just <span class="js-barrier-trial-price"></span></span>*
 				</p>
-				<img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fstandard_digital.png?width=160&amp;source=next&amp;fit=scale-down" alt="" role="presentation" aria-hidden="true">
+				{{> image }}
 				<p>
 					<a href="/signup?offerId=41218b9e-c8ae-c934-43ad-71b13fcb4465&amp;in-article=true" class="o-buttons o-buttons--big o-buttons--standout inline-barrier__button" data-trackable="sign-up">
 						Sign up for <span class="js-barrier-trial-price"></span> trial now

--- a/views/partials/inline-barrier.html
+++ b/views/partials/inline-barrier.html
@@ -3,6 +3,7 @@
 		<div class="inline-barrier__fader">
 			<p class="n-util-visually-hidden">This is the end of your free article preview.</p>
 		</div>
+		<div class="inline-barrier__content">
 		{{#ifEquals @root.flags.inArticlePreview 'psp'}}
 
 			<div class="n-util-hide-enhanced">
@@ -12,7 +13,6 @@
 
 		{{else ifEquals @root.flags.inArticlePreview 'trial'}}
 
-			<div class="inline-barrier__content">
 				<p class="inline-barrier__heading inline-barrier__needs-price">
 					Keep reading for just <span class="js-barrier-trial-price"></span>
 				</p>
@@ -35,8 +35,9 @@
 						*Terms &amp; conditions apply.
 					</a>
 				</p>
-			</div>
 
 		{{/ifEquals}}
+
+		</div>
 	</div>
 {{/if}}


### PR DESCRIPTION
Core `psp` variant before | Core `psp` variant after
---|---
![psp-core-before](https://cloud.githubusercontent.com/assets/150157/23219723/bf617d5e-f917-11e6-8d8f-42a28b74ab94.png) | ![psp](https://cloud.githubusercontent.com/assets/150157/23219600/6c810afa-f917-11e6-97eb-a9d6ae14d030.png)

Core `trial` variant for comparison:
<img src="https://cloud.githubusercontent.com/assets/150157/23219589/69da7fca-f917-11e6-979b-0e6d5aee043d.png" width="50%">

See commit messages for more context.