### PR TITLE
Amends to inArticlePreview barriers

### DIFF
--- a/client/components/inline-barrier/broadcast-opportunity.js
+++ b/client/components/inline-barrier/broadcast-opportunity.js
@@ -23,4 +23,3 @@ module.exports = (subtype) => {
 		offers: Array.from(offersEls).map(e => e.getAttribute('data-offer-id'))
 	}, context))
 };
-

--- a/client/components/inline-barrier/broadcast-opportunity.js
+++ b/client/components/inline-barrier/broadcast-opportunity.js
@@ -1,0 +1,26 @@
+import { broadcast } from 'n-ui/utils';
+
+module.exports = (subtype) => {
+	const appNameEl = document.querySelector('[data-next-app]');
+	const appVersionEl = document.querySelector('[data-next-version]');
+	const context = {
+		product: 'next',
+		app: appNameEl && appNameEl.getAttribute('data-next-app'),
+		appVersion: appVersionEl && appVersionEl.getAttribute('data-next-version')
+	};
+	const acquisitionContextEls = document.querySelectorAll('[data-acquisition-context]');
+	const offersEls = document.querySelectorAll('[data-offer-id]');
+
+	broadcast('oTracking.event', Object.assign({
+		category: 'barrier',
+		action: 'view',
+		opportunity: {
+			type: 'barrier',
+			subtype
+		},
+		type: 'barrier',
+		acquisitionContext: Array.from(acquisitionContextEls).map(e => e.getAttribute('data-acquisition-context')),
+		offers: Array.from(offersEls).map(e => e.getAttribute('data-offer-id'))
+	}, context))
+};
+

--- a/client/components/inline-barrier/main.js
+++ b/client/components/inline-barrier/main.js
@@ -1,130 +1,26 @@
-/**
-* !WIP Proof of Concept
-*
-* For now we simply render an inline barrier page similar to fastft.
-* In future this could become an n/o-component
-*/
-
-import { broadcast } from 'n-ui/utils';
-
-const broadcastOpportunity = (subtype) => {
-	const appNameEl = document.querySelector('[data-next-app]');
-	const appVersionEl = document.querySelector('[data-next-version]');
-	const context = {
-		product: 'next',
-		app: appNameEl && appNameEl.getAttribute('data-next-app'),
-		appVersion: appVersionEl && appVersionEl.getAttribute('data-next-version')
-	};
-	const acquisitionContextEls = document.querySelectorAll('[data-acquisition-context]');
-	const offersEls = document.querySelectorAll('[data-offer-id]');
-
-	broadcast('oTracking.event', Object.assign({
-		category: 'barrier',
-		action: 'view',
-		opportunity: {
-			type: 'barrier',
-			subtype
-		},
-		type: 'barrier',
-		acquisitionContext: Array.from(acquisitionContextEls).map(e => e.getAttribute('data-acquisition-context')),
-		offers: Array.from(offersEls).map(e => e.getAttribute('data-offer-id'))
-	}, context))
-};
-
-const populateWithPsp = (el) => fetch('/products?fragment=true&inline=true&narrow=true&in-article=true', { credentials: 'same-origin' })
-	.then(response => {
-		if (response.ok) {
-			return response.text().then(html => {
-				const parsedHtml = new DOMParser().parseFromString(html, 'text/html');
-				const coreWrapper = el.querySelector('.inline-barrier__content');
-				const pspEl = parsedHtml.querySelector('.barrier');
-
-				if (!el || !pspEl || !coreWrapper) { return; }
-
-				//Remove duplicate ID so pa11y passes
-				pspEl.removeAttribute('id');
-				const pspTitle = pspEl.querySelector('.barrier-grid__heading-pretext');
-
-				if (pspTitle) {
-					// Horrible hacks to modify the PSP title text, for a slightly dirty MVT
-					const titleContainer = pspTitle.parentElement;
-					const nonH1Title = document.createElement('p');
-					nonH1Title.className = 'barrier-grid__heading barrier-grid__heading-pretext';
-					nonH1Title.innerHTML = 'Want to read more?';
-					const sub = document.createElement('p');
-					sub.innerHTML = '<span class="barrier-grid__article-title">Subscribe by choosing a package below:</span>';
-					titleContainer.insertAdjacentElement('beforeend', nonH1Title);
-					titleContainer.insertAdjacentElement('beforeend', sub);
-					pspTitle.remove();
-				}
-
-				el.classList.remove('inline-barrier--no-prices');
-				el.classList.add('inline-barrier--has-prices');
-				el.replaceChild(pspEl, coreWrapper);
-
-				broadcastOpportunity('inline-psp');
-			});
-		}
-	})
-	.catch(() => {
-		// eslint-disable-next-line no-console
-		console.error('Failed to retrieve/process PSP fragment');
-	})
-	.then(() => {
-		el.classList.add('inline-barrier--done');
-	});
-
-const populateWithTrial = (el) => fetch(`https://next-signup-api.ft.com/offer/41218b9e-c8ae-c934-43ad-71b13fcb4465?countryCode=${el.dataset.countryCode}`, {
-	headers: {
-		'x-api-env': 'prod'
-	}
-})
-	.then(response => {
-		if (response.ok) {
-			return response.json();
-		} else {
-			throw new Error('Network response was not ok.');
-		}
-	})
-	.then(json => json.data)
-	.then(({offer}) => {
-		const coreWrapper = el.querySelector('.inline-barrier__content');
-		const enhancedTrialTemplate = document.querySelector('#js-barrier-trial');
-
-		if (!el || !enhancedTrialTemplate || !coreWrapper) { return; }
-
-		coreWrapper.innerHTML = enhancedTrialTemplate.innerHTML;
-		const trialPriceables = [...coreWrapper.querySelectorAll('.js-barrier-trial-price')];
-		const postTrialPriceables = [...coreWrapper.querySelectorAll('.js-barrier-trial-after-price')];
-
-		const trialOffer = offer.charges.find(charge => charge.billing_period === 'trial');
-		//FIXME: make sure this is the right object: why different amounts from psp page?
-		const postTrialOffer = offer.charges.find(charge => charge.billing_period === 'monthly');
-		//TODO: investigate localization of symbol/value ordering
-
-		trialPriceables.forEach(priceable => priceable.innerHTML = `${trialOffer.amount.symbol}${trialOffer.amount.value.replace('.00', '')}`);
-		postTrialPriceables.forEach(priceable => priceable.innerHTML = `${postTrialOffer.display_amount.weekly.symbol}${postTrialOffer.display_amount.weekly.value}`);
-
-		el.classList.remove('inline-barrier--no-prices');
-		el.classList.add('inline-barrier--has-prices');
-
-		broadcastOpportunity('inline-trial');
-	})
-	.catch(() => {
-		// eslint-disable-next-line no-console
-		console.error('Failed to retrieve/process trial offer data');
-	})
-	.then(() => {
-		el.classList.add('inline-barrier--done');
-	});
+import populateWithPsp from './populate-with-psp';
+import populateWithTrial from './populate-with-trial';
+import broadcastOpportunity from './broadcast-opportunity';
 
 export default (flags) => {
 	const el = document.querySelector('.inline-barrier');
+	const inArticlePreviewVariant = flags.get('inArticlePreview');
 
-	if (el && el.dataset.nType === 'standard' && flags.get('inArticlePreview') === 'psp') {
-		populateWithPsp(el);
-	}
-	else if (el && el.dataset.nType === 'standard' && el.dataset.countryCode && flags.get('inArticlePreview') === 'trial') {
-		populateWithTrial(el);
-	}
+	if (!el || !inArticlePreviewVariant || !el.dataset.countryCode) { return; }
+
+	const populateWithOffer = (inArticlePreviewVariant === 'trial') ? populateWithTrial : populateWithPsp;
+
+	populateWithOffer(el)
+		.then(() => {
+			// Tracking for MVT analysis
+			broadcastOpportunity(`inline-${inArticlePreviewVariant}`);
+		})
+		.catch((err) => {
+			// eslint-disable-next-line no-console
+			console.error('Failed to retrieve/process offer data', err);
+		})
+		.then(() => {
+			// Show either the core or enhanced barrier, depending on success of fetching offer data
+			el.classList.add('inline-barrier--done');
+		});
 }

--- a/client/components/inline-barrier/main.js
+++ b/client/components/inline-barrier/main.js
@@ -88,15 +88,23 @@ const populateWithTrial = (el) => fetch(`https://next-signup-api.ft.com/offer/41
 	})
 	.then(json => json.data)
 	.then(({offer}) => {
-		//FIXME: Populate copy with new offer data
-		const trialPriceables = [...document.querySelectorAll('.js-barrier-trial-price')];
-		const postTrialPriceables = [...document.querySelectorAll('.js-barrier-trial-after-price')];
+		const coreWrapper = el.querySelector('.inline-barrier__content');
+		const enhancedTrialTemplate = document.querySelector('#js-barrier-trial');
+
+		if (!el || !enhancedTrialTemplate || !coreWrapper) { return; }
+
+		coreWrapper.innerHTML = enhancedTrialTemplate.innerHTML;
+		const trialPriceables = [...coreWrapper.querySelectorAll('.js-barrier-trial-price')];
+		const postTrialPriceables = [...coreWrapper.querySelectorAll('.js-barrier-trial-after-price')];
+
 		const trialOffer = offer.charges.find(charge => charge.billing_period === 'trial');
 		//FIXME: make sure this is the right object: why different amounts from psp page?
 		const postTrialOffer = offer.charges.find(charge => charge.billing_period === 'monthly');
 		//TODO: investigate localization of symbol/value ordering
+
 		trialPriceables.forEach(priceable => priceable.innerHTML = `${trialOffer.amount.symbol}${trialOffer.amount.value.replace('.00', '')}`);
 		postTrialPriceables.forEach(priceable => priceable.innerHTML = `${postTrialOffer.display_amount.weekly.symbol}${postTrialOffer.display_amount.weekly.value}`);
+
 		el.classList.remove('inline-barrier--no-prices');
 		el.classList.add('inline-barrier--has-prices');
 

--- a/client/components/inline-barrier/main.js
+++ b/client/components/inline-barrier/main.js
@@ -59,6 +59,7 @@ const populateWithPsp = (el) => fetch('/products?fragment=true&inline=true&narro
 				}
 
 				el.classList.remove('inline-barrier--no-prices');
+				el.classList.add('inline-barrier--has-prices');
 				el.replaceChild(pspEl, coreWrapper);
 
 				broadcastOpportunity('inline-psp');
@@ -87,11 +88,17 @@ const populateWithTrial = (el) => fetch(`https://next-signup-api.ft.com/offer/41
 	})
 	.then(json => json.data)
 	.then(({offer}) => {
-		const priceables = [...document.querySelectorAll('.js-barrier-trial-price')];
+		//FIXME: Populate copy with new offer data
+		const trialPriceables = [...document.querySelectorAll('.js-barrier-trial-price')];
+		const postTrialPriceables = [...document.querySelectorAll('.js-barrier-trial-after-price')];
 		const trialOffer = offer.charges.find(charge => charge.billing_period === 'trial');
+		//FIXME: make sure this is the right object: why different amounts from psp page?
+		const postTrialOffer = offer.charges.find(charge => charge.billing_period === 'monthly');
 		//TODO: investigate localization of symbol/value ordering
-		priceables.forEach(priceable => priceable.innerHTML = `${trialOffer.amount.symbol}${trialOffer.amount.value.replace('.00', '')}`);
+		trialPriceables.forEach(priceable => priceable.innerHTML = `${trialOffer.amount.symbol}${trialOffer.amount.value.replace('.00', '')}`);
+		postTrialPriceables.forEach(priceable => priceable.innerHTML = `${postTrialOffer.display_amount.weekly.symbol}${postTrialOffer.display_amount.weekly.value}`);
 		el.classList.remove('inline-barrier--no-prices');
+		el.classList.add('inline-barrier--has-prices');
 
 		broadcastOpportunity('inline-trial');
 	})

--- a/client/components/inline-barrier/main.scss
+++ b/client/components/inline-barrier/main.scss
@@ -1,4 +1,5 @@
 .inline-barrier__fader {
+	// scss-lint:disable DuplicateProperty
 	background: getColor('pink');
 	//Super verbose in order to keep Safari happy
 	background: linear-gradient(to bottom, rgba(getColor('pink'), 0), rgba(getColor('pink'), 0.8), rgba(getColor('pink'), 1));

--- a/client/components/inline-barrier/main.scss
+++ b/client/components/inline-barrier/main.scss
@@ -1,5 +1,5 @@
 .inline-barrier__fader {
-	background: oColorsGetPaletteColor('pink');
+	background: getColor('pink');
 	//Super verbose in order to keep Safari happy
 	background: linear-gradient(to bottom, rgba(getColor('pink'), 0), rgba(getColor('pink'), 0.8), rgba(getColor('pink'), 1));
 	height: 160px;
@@ -8,8 +8,8 @@
 }
 
 .inline-barrier__content {
-	background-color: oColorsGetPaletteColor('warm-5');
-	border: 1px solid oColorsGetPaletteColor('warm-3');
+	background-color: getColor('warm-5');
+	border: 1px solid getColor('warm-3');
 	box-sizing: border-box;
 	padding: 15px 15px 0;
 	text-align: center;
@@ -17,7 +17,7 @@
 
 .inline-barrier__heading {
 	@include oTypographySansBold('l', true);
-	color: oColorsGetPaletteColor('cold-1');
+	color: getColor('cold-1');
 	margin: 0 0 5px;
 }
 

--- a/client/components/inline-barrier/main.scss
+++ b/client/components/inline-barrier/main.scss
@@ -15,27 +15,30 @@
 	text-align: center;
 }
 
+.inline-barrier__bridge {
+	@include oTypographySansBold('s');
+	background: getColor('white');
+	color: getColor('cold-1');
+	margin: -15px -15px 15px;
+	padding: 10px;
+}
+
 .inline-barrier__heading {
-	@include oTypographySansBold('l', true);
+	@include oTypographySansBold('m');
 	color: getColor('cold-1');
 	margin: 0 0 5px;
 }
 
-.inline-barrier__description {
+.inline-barrier__body {
 	font-size: 17px;
 	font-weight: 400;
 	line-height: 23px;
 	margin: 0 0 10px;
 }
 
-.inline-barrier__more {
-	@include oTypographySansSize('s', true);
+.inline-barrier__cta-secondary {
+	@include oTypographySansSize('s');
 	margin: 0 0 10px;
-}
-
-.inline-barrier__terms {
-	@include oTypographySansSize('xs', true);
-	margin: 0 0 20px;
 }
 
 @include oGridRespondTo($until: 'M') {
@@ -44,26 +47,43 @@
 	}
 }
 
-// Horrible hack for an MVT, to avoid shaving a humongous yak. Sorry, Internet.
-// scss-lint:disable QualifyingElement
-p.barrier-grid__heading-pretext {
-	margin-top: 15px;
+.core {
+	.inline-barrier__if-has-prices {
+		display: none;
+	}
 }
 
 .enhanced {
 	.inline-barrier {
-		.inline-barrier__content {
+		display: none;
+	}
+	.inline-barrier--done {
+		display: block;
+	}
+}
+
+.inline-barrier--done {
+	&.inline-barrier--no-prices {
+		.inline-barrier__if-no-prices {
+			display: block;
+		}
+		.inline-barrier__if-has-prices {
 			display: none;
 		}
 	}
 
-	.inline-barrier--done {
-		.inline-barrier__content {
+	&.inline-barrier--has-prices {
+		.inline-barrier__if-no-prices {
+			display: none;
+		}
+		.inline-barrier__if-has-prices {
 			display: block;
 		}
 	}
 }
 
-.inline-barrier--no-prices .inline-barrier__needs-price {
-	display: none;
+// Horrible hack for an MVT, to avoid shaving a humongous yak. Sorry, Internet.
+// scss-lint:disable QualifyingElement
+p.barrier-grid__heading-pretext {
+	margin-top: 15px;
 }

--- a/client/components/inline-barrier/main.scss
+++ b/client/components/inline-barrier/main.scss
@@ -47,38 +47,12 @@
 	}
 }
 
-.core {
-	.inline-barrier__if-has-prices {
-		display: none;
-	}
-}
-
 .enhanced {
 	.inline-barrier {
 		display: none;
 	}
 	.inline-barrier--done {
 		display: block;
-	}
-}
-
-.inline-barrier--done {
-	&.inline-barrier--no-prices {
-		.inline-barrier__if-no-prices {
-			display: block;
-		}
-		.inline-barrier__if-has-prices {
-			display: none;
-		}
-	}
-
-	&.inline-barrier--has-prices {
-		.inline-barrier__if-no-prices {
-			display: none;
-		}
-		.inline-barrier__if-has-prices {
-			display: block;
-		}
 	}
 }
 

--- a/client/components/inline-barrier/populate-with-psp.js
+++ b/client/components/inline-barrier/populate-with-psp.js
@@ -1,0 +1,33 @@
+module.exports = (el) => fetch('/products?fragment=true&inline=true&narrow=true&in-article=true', { credentials: 'same-origin' })
+	.then(response => {
+		if (!response.ok) {
+			throw new Error(`Request for PSP fragment returned a bad response. Status: ${response.status}`);
+		}
+		return response.text();
+	})
+	.then(html => {
+		const parsedHtml = new DOMParser().parseFromString(html, 'text/html');
+		const coreWrapper = el.querySelector('.inline-barrier__content');
+		const pspEl = parsedHtml.querySelector('.barrier');
+
+		if (!el || !pspEl || !coreWrapper) { return; }
+
+		//Remove duplicate ID so pa11y passes
+		pspEl.removeAttribute('id');
+		const pspTitle = pspEl.querySelector('.barrier-grid__heading-pretext');
+
+		if (pspTitle) {
+			// Horrible hacks to modify the PSP title text, for a slightly dirty MVT
+			const titleContainer = pspTitle.parentElement;
+			const nonH1Title = document.createElement('p');
+			nonH1Title.className = 'barrier-grid__heading barrier-grid__heading-pretext';
+			nonH1Title.innerHTML = 'Want to read more?';
+			const sub = document.createElement('p');
+			sub.innerHTML = '<span class="barrier-grid__article-title">Subscribe by choosing a package below:</span>';
+			titleContainer.insertAdjacentElement('beforeend', nonH1Title);
+			titleContainer.insertAdjacentElement('beforeend', sub);
+			pspTitle.remove();
+		}
+
+		el.replaceChild(pspEl, coreWrapper);
+	});

--- a/client/components/inline-barrier/populate-with-trial.js
+++ b/client/components/inline-barrier/populate-with-trial.js
@@ -1,0 +1,30 @@
+module.exports = (el) => fetch(`https://next-signup-api.ft.com/offer/41218b9e-c8ae-c934-43ad-71b13fcb4465?countryCode=${el.dataset.countryCode}`, {
+	headers: {
+		'x-api-env': 'prod'
+	}
+})
+	.then(response => {
+		if (!response.ok) {
+			throw new Error(`Request for trial offer data returned a bad response. Status: ${response.status}`);
+		}
+		return response.json();
+	})
+	.then(json => json.data)
+	.then(({offer}) => {
+		const coreWrapper = el.querySelector('.inline-barrier__content');
+		const enhancedTrialTemplate = document.querySelector('#js-barrier-trial');
+
+		if (!el || !enhancedTrialTemplate || !coreWrapper) { return; }
+
+		coreWrapper.innerHTML = enhancedTrialTemplate.innerHTML;
+		const trialPriceables = [...coreWrapper.querySelectorAll('.js-barrier-trial-price')];
+		const postTrialPriceables = [...coreWrapper.querySelectorAll('.js-barrier-trial-after-price')];
+
+		const trialOffer = offer.charges.find(charge => charge.billing_period === 'trial');
+		//FIXME: make sure this is the right object: why different amounts from psp page?
+		const postTrialOffer = offer.charges.find(charge => charge.billing_period === 'monthly');
+		//TODO: investigate localization of symbol/value ordering
+
+		trialPriceables.forEach(priceable => priceable.innerHTML = `${trialOffer.amount.symbol}${trialOffer.amount.value.replace('.00', '')}`);
+		postTrialPriceables.forEach(priceable => priceable.innerHTML = `${postTrialOffer.display_amount.weekly.symbol}${postTrialOffer.display_amount.weekly.value}`);
+	});

--- a/server/controllers/article.js
+++ b/server/controllers/article.js
@@ -78,6 +78,7 @@ const showGcs = (req, res, isFreeArticle) => {
 };
 
 module.exports = function articleV3Controller (req, res, next, content) {
+	const userIsAnonymous = res.locals.anon && res.locals.anon.userIsAnonymous;
 	let asyncWorkToDo = [];
 
 	res.vary('ft-is-aud-dev');
@@ -117,8 +118,9 @@ module.exports = function articleV3Controller (req, res, next, content) {
 	}
 
 	// Inline barrier page & data
+	const shouldShow = userIsAnonymous && req.get('ft-access-preview') && !req.query.fragment && res.locals.flags.inArticlePreview;
 	content.inlineBarrier = {
-		show: (res.locals.anon && res.locals.anon.userIsAnonymous) && req.get('ft-access-preview') && !req.query.fragment && res.locals.flags.inArticlePreview,
+		shouldShow,
 		countryCode: req.get('country-code'),
 		type: 'standard' // TODO - set inline barrier type via preflight decision
 	};
@@ -127,7 +129,7 @@ module.exports = function articleV3Controller (req, res, next, content) {
 	Object.assign(content, transformArticleBody(content.bodyHTML, res.locals.flags, {
 			fragment: req.query.fragment,
 			adsLayout: content.adsLayout,
-			userIsAnonymous: res.locals.anon && res.locals.anon.userIsAnonymous,
+			userIsAnonymous,
 			previewArticle: req.get('ft-access-preview') // TODO: match on res.get() ?
 		}
 	));

--- a/test/server/controllers/article.test.js
+++ b/test/server/controllers/article.test.js
@@ -182,7 +182,7 @@ describe('Article Controller', () => {
 		});
 
 		it('renders with an inline barrier', () => {
-			expect(result.inlineBarrier.show).to.equal(true);
+			expect(result.inlineBarrier.shouldShow).to.equal(true);
 		});
 
 		it('will not render lightSignup if inArticlePreview flag is on', () => {

--- a/views/partials/body-wrapper.html
+++ b/views/partials/body-wrapper.html
@@ -27,7 +27,7 @@
 						{{> light-signup tag=primaryTag articleUuid=id isInferred=lightSignup.isInferred}}
 					{{/if}}
 					{{#if inlineBarrier.shouldShow}}
-						{{> inline-barrier inlineBarrier}}
+						{{> inline-barrier/template inlineBarrier}}
 					{{/if}}
 				{{/ifEquals}}
 				{{#ifEquals contentType 'podcast'}}

--- a/views/partials/body-wrapper.html
+++ b/views/partials/body-wrapper.html
@@ -26,7 +26,7 @@
 					{{#if lightSignup.show}}
 						{{> light-signup tag=primaryTag articleUuid=id isInferred=lightSignup.isInferred}}
 					{{/if}}
-					{{#if inlineBarrier.show}}
+					{{#if inlineBarrier.shouldShow}}
 						{{> inline-barrier inlineBarrier}}
 					{{/if}}
 				{{/ifEquals}}

--- a/views/partials/inline-barrier.html
+++ b/views/partials/inline-barrier.html
@@ -1,5 +1,7 @@
 {{#if @root.flags.inArticlePreview}}
 
+	{{!-- TODO: change image to premium image --}}
+	{{!-- Inline partial so both variants can share the same image --}}
 	{{#*inline "image"}}
 		<img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fstandard_digital.png?width=160&amp;source=next&amp;fit=scale-down" alt="" role="presentation" aria-hidden="true">
 	{{/inline}}
@@ -8,7 +10,7 @@
 		<div class="inline-barrier__fader">
 			<p class="n-util-visually-hidden">This is the end of your free article preview.</p>
 		</div>
-		<div class="inline-barrier__content">
+		<div class="inline-barrier__content" data-trackable="{{@root.flags.inArticlePreview}}">
 
 			{{#ifEquals @root.flags.inArticlePreview 'psp'}}
 
@@ -22,28 +24,62 @@
 
 			{{else ifEquals @root.flags.inArticlePreview 'trial'}}
 
-				<p class="inline-barrier__heading inline-barrier__needs-price">
-					Keep reading for just <span class="js-barrier-trial-price"></span>
-				</p>
-				<p class="inline-barrier__description">
-					Receive 4 weeks of unlimited Premium <span aria-label="F T dot com">FT.com</span> access<span class="inline-barrier__needs-price"> for just <span class="js-barrier-trial-price"></span></span>*
-				</p>
-				{{> image }}
-				<p>
-					<a href="/signup?offerId=41218b9e-c8ae-c934-43ad-71b13fcb4465&amp;in-article=true" class="o-buttons o-buttons--big o-buttons--standout inline-barrier__button" data-trackable="sign-up">
-						Sign up for <span class="js-barrier-trial-price"></span> trial now
-					</a>
-				</p>
-				<p class="inline-barrier__more">
-					<a href="/products?in-article=true" data-trackable="view-all">
-						View all subscription options
-					</a>
-				</p>
-				<p class="inline-barrier__terms">
-					<a href="http://help.ft.com/help/legal-privacy/terms-conditions/" data-trackable="terms-conditions">
-						*Terms &amp; conditions apply.
-					</a>
-				</p>
+				{{!--
+				Note:	This no-prices version is for non-CTM journeys but *also* a fallback for if/when we
+						fail to retrieve (client side) offer data.
+						Check with the Conversion team to find out why the copy and links are different.
+				--}}
+				<div class="inline-barrier__if-no-prices" data-trackable="no-prices">
+					<p class="inline-barrier__bridge">
+						You must have a subscription to read this article.
+					</p>
+					<p class="inline-barrier__heading">
+						Today’s global financial landscape.<br>
+						Deciphered.
+					</p>
+					<p class="inline-barrier__body">
+						When it comes to news, comment and analysis, the <span aria-label="Financial Times">FT</span> offers something different.
+					</p>
+					{{> image }}
+					<p class="inline-barrier__cta-primary">
+						<a href="/products?in-article=true" class="o-buttons o-buttons--big o-buttons--standout inline-barrier__button" data-trackable="cta-primary">
+							View all subscription options
+						</a>
+					</p>
+					<p class="inline-barrier__cta-secondary">
+						<a href="http://help.ft.com/help/legal-privacy/terms-conditions/" data-trackable="cta-secondary">
+							*Terms &amp; conditions apply.
+						</a>
+					</p>
+				</div>
+
+				{{!-- TODO: Make this a script template --}}
+				<div class="inline-barrier__if-has-prices" data-trackable="has-prices">
+
+					<p class="inline-barrier__bridge">
+						Want to continue reading?
+					</p>
+					<p class="inline-barrier__heading">
+						4 weeks of unlimited Premium <span aria-label="F T dot com">FT.com</span> access for just
+						<span class="js-barrier-trial-price"></span>*
+					</p>
+					<p class="inline-barrier__body">
+					*<span class="js-barrier-trial-price"></span> for 4 weeks, then <span class="js-barrier-trial-after-price"></span> per week thereafter.
+						<a href="http://help.ft.com/help/legal-privacy/terms-conditions/" data-trackable="terms-conditions">Terms &amp; conditions</a> apply.
+					</p>
+					{{> image }}
+					<p class="inline-barrier__cta-primary">
+						<a href="/signup?offerId=41218b9e-c8ae-c934-43ad-71b13fcb4465&amp;in-article=true" class="o-buttons o-buttons--big o-buttons--standout inline-barrier__button" data-trackable="cta-primary">
+							Sign up for <span class="js-barrier-trial-price"></span> trial
+						</a>
+					</p>
+					<p class="inline-barrier__cta-secondary">
+						<a href="/products?in-article=true" data-trackable="cta-secondary">
+							View all subscription options
+						</a>
+					</p>
+
+				</div>
 
 			{{/ifEquals}}
 

--- a/views/partials/inline-barrier/core.html
+++ b/views/partials/inline-barrier/core.html
@@ -3,26 +3,24 @@ Note:	This no-prices version is for core/non-CTM journeys but *also* a fallback 
 		fail to retrieve (client side) offer data.
 		Check with the Conversion team to find out why the copy and links are different.
 --}}
-<div class="inline-barrier__if-no-prices" data-trackable="no-prices">
-	<p class="inline-barrier__bridge">
-		You must have a subscription to read this article.
-	</p>
-	<p class="inline-barrier__heading">
-		Today’s global financial landscape.<br>
-		Deciphered.
-	</p>
-	<p class="inline-barrier__body">
-		When it comes to news, comment and analysis, the <span aria-label="Financial Times">FT</span> offers something different.
-	</p>
-	{{> image }}
-	<p class="inline-barrier__cta-primary">
-		<a href="/products?in-article=true" class="o-buttons o-buttons--big o-buttons--standout inline-barrier__button" data-trackable="cta-primary">
-			View all subscription options
-		</a>
-	</p>
-	<p class="inline-barrier__cta-secondary">
-		<a href="http://help.ft.com/help/legal-privacy/terms-conditions/" data-trackable="cta-secondary">
-			*Terms &amp; conditions apply.
-		</a>
-	</p>
-</div>
+<p class="inline-barrier__bridge">
+	You must have a subscription to read this article.
+</p>
+<p class="inline-barrier__heading">
+	Today’s global financial landscape.<br>
+	Deciphered.
+</p>
+<p class="inline-barrier__body">
+	When it comes to news, comment and analysis, the <span aria-label="Financial Times">FT</span> offers something different.
+</p>
+{{> image }}
+<p class="inline-barrier__cta-primary">
+	<a href="/products?in-article=true" class="o-buttons o-buttons--big o-buttons--standout inline-barrier__button" data-trackable="cta-primary">
+		View all subscription options
+	</a>
+</p>
+<p class="inline-barrier__cta-secondary">
+	<a href="http://help.ft.com/help/legal-privacy/terms-conditions/" data-trackable="cta-secondary">
+		*Terms &amp; conditions apply.
+	</a>
+</p>

--- a/views/partials/inline-barrier/core.html
+++ b/views/partials/inline-barrier/core.html
@@ -1,0 +1,28 @@
+{{!--
+Note:	This no-prices version is for core/non-CTM journeys but *also* a fallback for if/when we
+		fail to retrieve (client side) offer data.
+		Check with the Conversion team to find out why the copy and links are different.
+--}}
+<div class="inline-barrier__if-no-prices" data-trackable="no-prices">
+	<p class="inline-barrier__bridge">
+		You must have a subscription to read this article.
+	</p>
+	<p class="inline-barrier__heading">
+		Today’s global financial landscape.<br>
+		Deciphered.
+	</p>
+	<p class="inline-barrier__body">
+		When it comes to news, comment and analysis, the <span aria-label="Financial Times">FT</span> offers something different.
+	</p>
+	{{> image }}
+	<p class="inline-barrier__cta-primary">
+		<a href="/products?in-article=true" class="o-buttons o-buttons--big o-buttons--standout inline-barrier__button" data-trackable="cta-primary">
+			View all subscription options
+		</a>
+	</p>
+	<p class="inline-barrier__cta-secondary">
+		<a href="http://help.ft.com/help/legal-privacy/terms-conditions/" data-trackable="cta-secondary">
+			*Terms &amp; conditions apply.
+		</a>
+	</p>
+</div>

--- a/views/partials/inline-barrier/enhanced-trial.html
+++ b/views/partials/inline-barrier/enhanced-trial.html
@@ -1,0 +1,24 @@
+<script type="text/template" id="js-barrier-trial">
+	<p class="inline-barrier__bridge">
+		Want to continue reading?
+	</p>
+	<p class="inline-barrier__heading">
+		4 weeks of unlimited Premium <span aria-label="F T dot com">FT.com</span> access for just
+		<span class="js-barrier-trial-price"></span>*
+	</p>
+	<p class="inline-barrier__body">
+	*<span class="js-barrier-trial-price"></span> for 4 weeks, then <span class="js-barrier-trial-after-price"></span> per week thereafter.
+		<a href="http://help.ft.com/help/legal-privacy/terms-conditions/" data-trackable="terms-conditions">Terms &amp; conditions</a> apply.
+	</p>
+	{{> image }}
+	<p class="inline-barrier__cta-primary">
+		<a href="/signup?offerId=41218b9e-c8ae-c934-43ad-71b13fcb4465&amp;in-article=true" class="o-buttons o-buttons--big o-buttons--standout inline-barrier__button" data-trackable="cta-primary">
+			Sign up for <span class="js-barrier-trial-price"></span> trial
+		</a>
+	</p>
+	<p class="inline-barrier__cta-secondary">
+		<a href="/products?in-article=true" data-trackable="cta-secondary">
+			View all subscription options
+		</a>
+	</p>
+</script>

--- a/views/partials/inline-barrier/template.html
+++ b/views/partials/inline-barrier/template.html
@@ -6,7 +6,7 @@
 		<img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fstandard_digital.png?width=160&amp;source=next&amp;fit=scale-down" alt="" role="presentation" aria-hidden="true">
 	{{/inline}}
 
-	<div class="inline-barrier inline-barrier--{{@root.flags.inArticlePreview}} inline-barrier--no-prices" data-n-component="inline-barrier" data-n-type="{{type}}" data-country-code="{{countryCode}}" data-trackable="inline-barrier">
+	<div class="inline-barrier inline-barrier--{{@root.flags.inArticlePreview}}" data-n-component="inline-barrier" data-n-type="{{type}}" data-country-code="{{countryCode}}" data-trackable="inline-barrier">
 		<div class="inline-barrier__fader">
 			<p class="n-util-visually-hidden">This is the end of your free article preview.</p>
 		</div>

--- a/views/partials/inline-barrier/template.html
+++ b/views/partials/inline-barrier/template.html
@@ -1,6 +1,6 @@
 {{#if @root.flags.inArticlePreview}}
 
-	{{!-- TODO: change image to premium image --}}
+	{{!-- TODO: change image requested premium packshot from sub.ft.com --}}
 	{{!-- Inline partial so both variants can share the same image --}}
 	{{#*inline "image"}}
 		<img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fstandard_digital.png?width=160&amp;source=next&amp;fit=scale-down" alt="" role="presentation" aria-hidden="true">
@@ -12,46 +12,9 @@
 		</div>
 		<div class="inline-barrier__content" data-trackable="{{@root.flags.inArticlePreview}}">
 
-			{{#ifEquals @root.flags.inArticlePreview 'psp'}}
+			{{> inline-barrier/core  }}
 
-				<p class="inline-barrier__description">
-					Want to read more?
-				</p>
-				{{> image }}
-				<p>
-					<a href="/products?in-article=true" class="o-buttons o-buttons--big o-buttons--standout inline-barrier__button" aria-label="Subscribe to the Financial Times" data-trackable="sign-up-psp">Subscribe to the FT</a>
-				</p>
-
-			{{else ifEquals @root.flags.inArticlePreview 'trial'}}
-
-				{{!--
-				Note:	This no-prices version is for non-CTM journeys but *also* a fallback for if/when we
-						fail to retrieve (client side) offer data.
-						Check with the Conversion team to find out why the copy and links are different.
-				--}}
-				<div class="inline-barrier__if-no-prices" data-trackable="no-prices">
-					<p class="inline-barrier__bridge">
-						You must have a subscription to read this article.
-					</p>
-					<p class="inline-barrier__heading">
-						Today’s global financial landscape.<br>
-						Deciphered.
-					</p>
-					<p class="inline-barrier__body">
-						When it comes to news, comment and analysis, the <span aria-label="Financial Times">FT</span> offers something different.
-					</p>
-					{{> image }}
-					<p class="inline-barrier__cta-primary">
-						<a href="/products?in-article=true" class="o-buttons o-buttons--big o-buttons--standout inline-barrier__button" data-trackable="cta-primary">
-							View all subscription options
-						</a>
-					</p>
-					<p class="inline-barrier__cta-secondary">
-						<a href="http://help.ft.com/help/legal-privacy/terms-conditions/" data-trackable="cta-secondary">
-							*Terms &amp; conditions apply.
-						</a>
-					</p>
-				</div>
+			{{#ifEquals @root.flags.inArticlePreview 'trial'}}
 
 				{{!-- TODO: Make this a script template --}}
 				<div class="inline-barrier__if-has-prices" data-trackable="has-prices">

--- a/views/partials/inline-barrier/template.html
+++ b/views/partials/inline-barrier/template.html
@@ -1,7 +1,7 @@
 {{#if @root.flags.inArticlePreview}}
 
 	{{!-- TODO: change image requested premium packshot from sub.ft.com --}}
-	{{!-- Inline partial so both variants can share the same image --}}
+	{{!-- Inline partial so core/enhanced can share the same image --}}
 	{{#*inline "image"}}
 		<img src="https://www.ft.com/__origami/service/image/v2/images/raw/https%3A%2F%2Fwww.ft.com%2F__assets%2Fcreatives%2Fstandard_digital.png?width=160&amp;source=next&amp;fit=scale-down" alt="" role="presentation" aria-hidden="true">
 	{{/inline}}
@@ -11,41 +11,12 @@
 			<p class="n-util-visually-hidden">This is the end of your free article preview.</p>
 		</div>
 		<div class="inline-barrier__content" data-trackable="{{@root.flags.inArticlePreview}}">
-
 			{{> inline-barrier/core  }}
-
-			{{#ifEquals @root.flags.inArticlePreview 'trial'}}
-
-				{{!-- TODO: Make this a script template --}}
-				<div class="inline-barrier__if-has-prices" data-trackable="has-prices">
-
-					<p class="inline-barrier__bridge">
-						Want to continue reading?
-					</p>
-					<p class="inline-barrier__heading">
-						4 weeks of unlimited Premium <span aria-label="F T dot com">FT.com</span> access for just
-						<span class="js-barrier-trial-price"></span>*
-					</p>
-					<p class="inline-barrier__body">
-					*<span class="js-barrier-trial-price"></span> for 4 weeks, then <span class="js-barrier-trial-after-price"></span> per week thereafter.
-						<a href="http://help.ft.com/help/legal-privacy/terms-conditions/" data-trackable="terms-conditions">Terms &amp; conditions</a> apply.
-					</p>
-					{{> image }}
-					<p class="inline-barrier__cta-primary">
-						<a href="/signup?offerId=41218b9e-c8ae-c934-43ad-71b13fcb4465&amp;in-article=true" class="o-buttons o-buttons--big o-buttons--standout inline-barrier__button" data-trackable="cta-primary">
-							Sign up for <span class="js-barrier-trial-price"></span> trial
-						</a>
-					</p>
-					<p class="inline-barrier__cta-secondary">
-						<a href="/products?in-article=true" data-trackable="cta-secondary">
-							View all subscription options
-						</a>
-					</p>
-
-				</div>
-
-			{{/ifEquals}}
-
 		</div>
 	</div>
+
+	{{#ifEquals @root.flags.inArticlePreview 'trial'}}
+		{{> inline-barrier/enhanced-trial }}
+	{{/ifEquals}}
+
 {{/if}}


### PR DESCRIPTION
- moves core and enhanced versions of the inline barrier into separate journeys, as requested by UX
- amends copy as requested by UX
- splits core and enhanced code into template partials
- splits client-side JS into modules
- not my best PR, sorry Internet