### PR TITLE
Read more / Up Next teaser label

### DIFF
--- a/server/controllers/article-helpers/content-package.js
+++ b/server/controllers/article-helpers/content-package.js
@@ -8,9 +8,9 @@ const getSequenceId = (pkg, currentIndex) => {
 };
 
 const addContext = ({ pkg, currentIndex }) => ({
-	prev: pkg.contains[currentIndex - 1],
+	prev: Object.assign({ sequenceId: getSequenceId(pkg, currentIndex - 1) }, pkg.contains[currentIndex - 1]),
 	current: pkg.contains[currentIndex],
-	next: pkg.contains[currentIndex + 1],
+	next: Object.assign({ sequenceId: getSequenceId(pkg, currentIndex + 1) }, pkg.contains[currentIndex + 1]),
 	home: pkg,
 	sequenceId: getSequenceId(pkg, currentIndex)
 });

--- a/test/server/controllers/article-helpers/content-package.test.js
+++ b/test/server/controllers/article-helpers/content-package.test.js
@@ -182,8 +182,8 @@ describe('Content package article helper', () => {
 			}]
 		};
 		expect(subject(packageArticleStub).context).eql({
-			prev: {id: 'def'},
-			next: {id: 'jkl'},
+			prev: {id: 'def', sequenceId: undefined },
+			next: {id: 'jkl', sequenceId: undefined },
 			home: {id: 'ghi', contains: [{id: 'abc'}, {id: 'def'}, {id: '123'}, {id: 'jkl'}], design: { theme: 'special-report' }},
 			current: {id: '123'},
 			sequenceId: undefined

--- a/views/partials/teasers/end-nav.html
+++ b/views/partials/teasers/end-nav.html
@@ -1,8 +1,13 @@
 <div class="package__end-nav-teaser">
-	<div class="o-teaser o-teaser--large-portrait{{#if mainImage}} o-teaser--has-image{{/if}}" data-o-component="o-teaser" data-trackable="teaser">
+	<div class="o-teaser o-teaser--large-portrait {{#if mainImage}}o-teaser--has-image{{/if}}" data-o-component="o-teaser" data-trackable="teaser">
 		<div class="o-teaser__content">
 			<div class="o-teaser__meta">
-				<span class="package__text--highlit package__text--m">UP NEXT</span>
+				{{{json this}}}
+				{{#if sequenceId}}
+					<span class="package__text--highlit package__text--m">UP NEXT</span><span class="package__text--strong package__text--highlit package__text--m">{{sequenceId}}</span>
+				{{else}}
+					<span class="package__text--highlit package__text--m">READ MORE</span>
+				{{/if}}
 			</div>
 			<a href="{{relativeUrl}}" data-trackable="main-link">
 				<h2 class="o-teaser__heading">{{title}}</h2>

--- a/views/partials/teasers/end-nav.html
+++ b/views/partials/teasers/end-nav.html
@@ -2,9 +2,8 @@
 	<div class="o-teaser o-teaser--large-portrait {{#if mainImage}}o-teaser--has-image{{/if}}" data-o-component="o-teaser" data-trackable="teaser">
 		<div class="o-teaser__content">
 			<div class="o-teaser__meta">
-				{{{json this}}}
 				{{#if sequenceId}}
-					<span class="package__text--highlit package__text--m">UP NEXT</span><span class="package__text--strong package__text--highlit package__text--m">{{sequenceId}}</span>
+					<span class="package__text--highlit package__text--m">UP NEXT</span> <span class="package__text--strong package__text--highlit package__text--m">{{sequenceId}}</span>
 				{{else}}
 					<span class="package__text--highlit package__text--m">READ MORE</span>
 				{{/if}}


### PR DESCRIPTION
The content package article helper is getting a bit Gross, but does this: 

ORDERED:
![screen shot 2017-03-29 at 15 23 36](https://cloud.githubusercontent.com/assets/4750238/24459958/c652a1e0-1494-11e7-90fd-a722cfb9ad64.png)

UNORDERED:
![screen shot 2017-03-29 at 15 24 00](https://cloud.githubusercontent.com/assets/4750238/24459959/c657b342-1494-11e7-8ef4-3ec9c1b3eb1d.png)
